### PR TITLE
Improved specification of modules directory.

### DIFF
--- a/src/main/java/org/culturegraph/mf/Flux.java
+++ b/src/main/java/org/culturegraph/mf/Flux.java
@@ -18,6 +18,8 @@ package org.culturegraph.mf;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.HashMap;
@@ -34,12 +36,18 @@ import org.culturegraph.mf.util.ResourceUtil;
 
 /**
  * @author Markus Michael Geipel
- * 
+ *
  */
 public final class Flux {
 	public static final String MODULES_DIR = "modules";
+
+	private static final String JAR_FILE_EXTENSION = ".jar";
+	private static final String CLASS_FILE_EXTENSION = ".class";
+
 	private static final Pattern VAR_PATTERN = Pattern.compile("([^=]*)=(.*)");
 	private static final String SCRIPT_HOME = "FLUX_DIR";
+
+	private static final String MODULES_DIR_ARG = "-modules=";
 
 	private Flux() {
 		// no instances
@@ -49,34 +57,27 @@ public final class Flux {
 	 * @param args
 	 * @throws IOException
 	 * @throws RecognitionException
+	 * @throws URISyntaxException
 	 */
 	public static void main(final String[] args) throws IOException, RecognitionException {
 
-		final File modulesDir = new File(MODULES_DIR);
-		if (modulesDir.exists()) {
-			final FilenameFilter filter = new FilenameFilter() {
-				@Override
-				public boolean accept(final File dir, final String name) {
-					return name.endsWith(".jar") || name.endsWith(".class");
-				}
-			};
-			final List<URL> moduleURLs = new LinkedList<URL>();
-			for (File file : modulesDir.listFiles(filter)) {
-				moduleURLs.add(file.getAbsoluteFile().toURI().toURL());
-			}
-			final URLClassLoader moduleLoader = new URLClassLoader(moduleURLs.toArray(new URL[0]), Thread
-					.currentThread().getContextClassLoader());
-			Thread.currentThread().setContextClassLoader(moduleLoader);
+		loadModules(getModulesDir(args));
+
+		final int fileArg;
+		if (args.length > 0 && args[0].startsWith(MODULES_DIR_ARG)) {
+			fileArg = 1;
+		} else {
+			fileArg = 0;
 		}
 
-		if (args.length < 1) {
+		if (args.length < (fileArg + 1)) {
 			Flow.printHelp(System.out);
 			System.exit(2);
 		} else {
 
-			final File fluxFile = new File(args[0]);
+			final File fluxFile = new File(args[fileArg]);
 			if (!fluxFile.exists()) {
-				System.err.println("File not found: " + args[0]);
+				System.err.println("File not found: " + args[fileArg]);
 				System.exit(1);
 				return;
 			}
@@ -85,7 +86,10 @@ public final class Flux {
 			final Map<String, String> vars = new HashMap<String, String>();
 			vars.put(SCRIPT_HOME, fluxFile.getAbsoluteFile().getParent() + System.getProperty("file.separator"));
 
-			for (int i = 1; i < args.length; ++i) {
+			for (int i = fileArg + 1; i < args.length; ++i) {
+				if (args[i].startsWith(MODULES_DIR_ARG)) {
+					continue;
+				}
 				final Matcher matcher = VAR_PATTERN.matcher(args[i]);
 				if (!matcher.find()) {
 					Flow.printHelp(System.err);
@@ -96,11 +100,51 @@ public final class Flux {
 
 			// run parser and builder
 			final List<Flow> flows = FluxCompiler.compile(ResourceUtil.getStream(fluxFile), vars);
-			for (Flow flow : flows) {
+			for (final Flow flow : flows) {
 				flow.start();
 			}
 		}
 	}
 
+	private static File getModulesDir(final String[] args) {
+		File modulesDir = new File(MODULES_DIR);
+
+		File programDir = null;
+		try {
+			programDir = new File(Flux.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+		} catch (final URISyntaxException e) {
+			// Ignore the programDir, if it is not available
+		}
+		if (programDir != null) {
+			if (programDir.getName().endsWith(JAR_FILE_EXTENSION)) {
+				programDir = programDir.getParentFile();
+			}
+			modulesDir = new File(programDir, MODULES_DIR);
+		}
+
+		if (args.length > 0 && args[0].startsWith(MODULES_DIR_ARG)) {
+			modulesDir = new File(args[0].substring(MODULES_DIR_ARG.length()));
+		}
+
+		return modulesDir;
+	}
+
+	private static void loadModules(final File modulesDir) throws MalformedURLException {
+		if (modulesDir.exists()) {
+			final FilenameFilter filter = new FilenameFilter() {
+				@Override
+				public boolean accept(final File dir, final String name) {
+					return name.endsWith(JAR_FILE_EXTENSION) || name.endsWith(CLASS_FILE_EXTENSION);
+				}
+			};
+			final List<URL> moduleURLs = new LinkedList<URL>();
+			for (final File file : modulesDir.listFiles(filter)) {
+				moduleURLs.add(file.getAbsoluteFile().toURI().toURL());
+			}
+			final URLClassLoader moduleLoader = new URLClassLoader(moduleURLs.toArray(new URL[0]), Thread
+					.currentThread().getContextClassLoader());
+			Thread.currentThread().setContextClassLoader(moduleLoader);
+		}
+	}
 
 }


### PR DESCRIPTION
Flux now looks for a modules directory in the following locations:
1. A modules directory in the current working directory
2. A modules directory in the same directory as the metafacture-core jar
   file
3. If the first commandline argument is -modules=PATH, this is used as
   the modules directory
