### PR TITLE
Fixed issue #77.

### DIFF
--- a/src/main/java/org/culturegraph/mf/stream/converter/xml/GenericXmlHandler.java
+++ b/src/main/java/org/culturegraph/mf/stream/converter/xml/GenericXmlHandler.java
@@ -31,13 +31,13 @@ import org.xml.sax.SAXException;
 /**
  * A generic xml reader.
  * @author Markus Michael Geipel
- * 
+ *
  */
 @Description("A generic xml reader")
 @In(XmlReceiver.class)
 @Out(StreamReceiver.class)
 public final class GenericXmlHandler extends DefaultXmlPipe<StreamReceiver> {
-	
+
 	private static final Pattern TABS = Pattern.compile("\t+");
 	private final String recordTagName;
 	private boolean inRecord;
@@ -55,7 +55,7 @@ public final class GenericXmlHandler extends DefaultXmlPipe<StreamReceiver> {
 		super();
 		this.recordTagName = recordTagName;
 	}
-	
+
 	@Override
 	public void startElement(final String uri, final String localName, final String qName, final Attributes attributes)
 			throws SAXException {
@@ -66,7 +66,11 @@ public final class GenericXmlHandler extends DefaultXmlPipe<StreamReceiver> {
 			writeAttributes(attributes);
 		} else if (localName.equals(recordTagName)) {
 			final String identifier = attributes.getValue("id");
-			getReceiver().startRecord(identifier);
+			if (identifier == null) {
+				getReceiver().startRecord("");
+			} else {
+				getReceiver().startRecord(identifier);
+			}
 			writeAttributes(attributes);
 			inRecord = true;
 		}

--- a/src/test/java/org/culturegraph/mf/stream/converter/xml/GenericXMLHandlerTest.java
+++ b/src/test/java/org/culturegraph/mf/stream/converter/xml/GenericXMLHandlerTest.java
@@ -36,10 +36,10 @@ public final class GenericXMLHandlerTest {
 	private ResourceOpener opener;
 	private XmlDecoder xmlDecoder;
 	private GenericXmlHandler genericXmlHandler;
-	
+
 	@Mock
 	private StreamReceiver receiver;
-	
+
 	@Before
 	public void setup() {
 		MockitoAnnotations.initMocks(this);
@@ -50,17 +50,17 @@ public final class GenericXMLHandlerTest {
 				.setReceiver(genericXmlHandler)
 				.setReceiver(receiver);
 	}
-	
+
 	@After
 	public void cleanup() {
 		opener.closeStream();
 	}
-	
+
 	@Test
 	public void testShouldIgnoreCharDataNotInARecord() {
-		
+
 		opener.process(DataFilePath.GENERIC_XML);
-		
+
 		final InOrder ordered = inOrder(receiver);
 		ordered.verify(receiver).startRecord("1");
 		ordered.verify(receiver).literal("id", "1");
@@ -83,7 +83,27 @@ public final class GenericXMLHandlerTest {
 		ordered.verify(receiver).literal("lang", "de");
 		ordered.verify(receiver).literal("value", "Zweiter Datensatz");
 		ordered.verify(receiver).endEntity();
-		ordered.verify(receiver).endRecord();	
+		ordered.verify(receiver).endRecord();
 	}
-	
+
+	@Test
+	public void testShouldEmitEmptyStringIfRecordTagHasNoIdAttribute() {
+
+		opener.process(DataFilePath.DATA_PREFIX + "shouldEmitEmptyStringIfRecordTagHasNoIdAttribute.xml");
+
+		final InOrder ordered = inOrder(receiver);
+		ordered.verify(receiver).startRecord("");
+		ordered.verify(receiver).endRecord();
+	}
+
+	@Test
+	public void testShouldEmitValueOfIdAttribute() {
+
+		opener.process(DataFilePath.DATA_PREFIX + "shouldEmitValueOfIdAttribute.xml");
+
+		final InOrder ordered = inOrder(receiver);
+		ordered.verify(receiver).startRecord("theRecordID");
+		ordered.verify(receiver).endRecord();
+	}
+
 }

--- a/src/test/resources/data/shouldEmitEmptyStringIfRecordTagHasNoIdAttribute.xml
+++ b/src/test/resources/data/shouldEmitEmptyStringIfRecordTagHasNoIdAttribute.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testdata>
+	<record />
+</testdata>

--- a/src/test/resources/data/shouldEmitValueOfIdAttribute.xml
+++ b/src/test/resources/data/shouldEmitValueOfIdAttribute.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testdata>
+	<record id="theRecordID" />
+</testdata>


### PR DESCRIPTION
GenericXmlHandler now outputs empty strings instead of null if no id
attribute is found on record elements
