### PR TITLE
Fix examples and annotations on Flux command implementations

### DIFF
--- a/examples/morph/morph-marc21.flux
+++ b/examples/morph/morph-marc21.flux
@@ -5,5 +5,5 @@ open-file|
 as-lines|
 decode-marc21|
 morph(FLUX_DIR + "morph-marc21.xml")|
-encode("literals")|
+encode-literals|
 write("stdout");

--- a/src/main/java/org/culturegraph/mf/stream/converter/bib/MabDecoder.java
+++ b/src/main/java/org/culturegraph/mf/stream/converter/bib/MabDecoder.java
@@ -20,6 +20,9 @@ import java.util.regex.Pattern;
 import org.culturegraph.mf.exceptions.FormatException;
 import org.culturegraph.mf.framework.DefaultObjectPipe;
 import org.culturegraph.mf.framework.StreamReceiver;
+import org.culturegraph.mf.framework.annotations.Description;
+import org.culturegraph.mf.framework.annotations.In;
+import org.culturegraph.mf.framework.annotations.Out;
 
 
 /**
@@ -31,6 +34,9 @@ import org.culturegraph.mf.framework.StreamReceiver;
  * @author Markus Michael Geipel, Christoph Böhme
  *
  */
+@Description("Parses a raw Mab2 stream (UTF-8 encoding expected).")
+@In(String.class)
+@Out(StreamReceiver.class)
 public final class MabDecoder 
 		extends DefaultObjectPipe<String, StreamReceiver> {
 	

--- a/src/main/java/org/culturegraph/mf/stream/converter/bib/MarcDecoder.java
+++ b/src/main/java/org/culturegraph/mf/stream/converter/bib/MarcDecoder.java
@@ -20,6 +20,9 @@ import java.util.regex.Pattern;
 import org.culturegraph.mf.exceptions.FormatException;
 import org.culturegraph.mf.framework.DefaultObjectPipe;
 import org.culturegraph.mf.framework.StreamReceiver;
+import org.culturegraph.mf.framework.annotations.Description;
+import org.culturegraph.mf.framework.annotations.In;
+import org.culturegraph.mf.framework.annotations.Out;
 import org.culturegraph.mf.stream.converter.IllegalEncodingException;
 
 
@@ -31,6 +34,9 @@ import org.culturegraph.mf.stream.converter.IllegalEncodingException;
  * 
  * @author Markus Michael Geipel, Christoph Böhme
  */
+@Description("Parses a raw Marc string (UTF-8 encoding expected).")
+@In(String.class)
+@Out(StreamReceiver.class)
 public final class MarcDecoder 
 		extends DefaultObjectPipe<String, StreamReceiver> {
 

--- a/src/main/java/org/culturegraph/mf/stream/pipe/ObjectTee.java
+++ b/src/main/java/org/culturegraph/mf/stream/pipe/ObjectTee.java
@@ -18,6 +18,9 @@ package org.culturegraph.mf.stream.pipe;
 import org.culturegraph.mf.framework.DefaultTee;
 import org.culturegraph.mf.framework.ObjectPipe;
 import org.culturegraph.mf.framework.ObjectReceiver;
+import org.culturegraph.mf.framework.annotations.Description;
+import org.culturegraph.mf.framework.annotations.In;
+import org.culturegraph.mf.framework.annotations.Out;
 
 /**
  * Sends an object to more than one receiver.
@@ -27,6 +30,9 @@ import org.culturegraph.mf.framework.ObjectReceiver;
  * @author Christoph Böhme
  *
  */
+@Description("Sends an object to more than one receiver.")
+@In(Object.class)
+@Out(Object.class)
 public final class ObjectTee<T> extends DefaultTee<ObjectReceiver<T>>
 		implements ObjectPipe<T, ObjectReceiver<T>> {
 

--- a/src/main/java/org/culturegraph/mf/stream/pipe/StreamTee.java
+++ b/src/main/java/org/culturegraph/mf/stream/pipe/StreamTee.java
@@ -18,6 +18,9 @@ package org.culturegraph.mf.stream.pipe;
 import org.culturegraph.mf.framework.DefaultTee;
 import org.culturegraph.mf.framework.StreamPipe;
 import org.culturegraph.mf.framework.StreamReceiver;
+import org.culturegraph.mf.framework.annotations.Description;
+import org.culturegraph.mf.framework.annotations.In;
+import org.culturegraph.mf.framework.annotations.Out;
 
 /**
  * Replicates an event stream to an arbitrary number of {@link StreamReceiver}s. 
@@ -25,6 +28,9 @@ import org.culturegraph.mf.framework.StreamReceiver;
  * @author Christoph Böhme, Markus Michael Geipel
  *
  */
+@Description("Replicates an event stream to an arbitrary number of stream receivers.")
+@In(StreamReceiver.class)
+@Out(StreamReceiver.class)
 public final class StreamTee extends DefaultTee<StreamReceiver>
 		implements StreamPipe<StreamReceiver> {
 

--- a/src/main/java/org/culturegraph/mf/stream/pipe/sort/TripleCount.java
+++ b/src/main/java/org/culturegraph/mf/stream/pipe/sort/TripleCount.java
@@ -28,8 +28,8 @@ import org.culturegraph.mf.types.Triple;
  *
  */
 @Description("Counts triples")
-@In(NamedValue.class)
-@Out(NamedValue.class)
+@In(Triple.class)
+@Out(Triple.class)
 public final class TripleCount extends AbstractTripleSort {
 	
 	public static final String DEFAULT_COUNTP_REDICATE = "count";


### PR DESCRIPTION
With the Flux validator in the Metafacture IDE, the `@In` and `@Out`
annotations on the Flux command implementation classes are processed
to check the workflows (see [1]). With the current Flux examples in
metafacture-core, the IDE reports some errors and warnings which
this commit fixes:
- Update morph-marc21.flux to use the new `encode-literals` command
- Fix `@In` and `@Out` annotations of `TripleCount`
- Add some missing `@In`, `@Out`, and `@Description` annotations

[1] https://github.com/culturegraph/metafacture-ide/pull/23
