### PR TITLE
Add `@Out(Void.class)` annotations to writer implementations

### DIFF
--- a/src/main/java/org/culturegraph/mf/stream/sink/ObjectWriter.java
+++ b/src/main/java/org/culturegraph/mf/stream/sink/ObjectWriter.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.culturegraph.mf.framework.ObjectReceiver;
 import org.culturegraph.mf.framework.annotations.Description;
 import org.culturegraph.mf.framework.annotations.In;
+import org.culturegraph.mf.framework.annotations.Out;
 import org.culturegraph.mf.framework.annotations.ReturnsAvailableArguments;
 
 
@@ -36,6 +37,7 @@ import org.culturegraph.mf.framework.annotations.ReturnsAvailableArguments;
 
 @Description("Writes objects to stdout or a file")
 @In(Object.class)
+@Out(Void.class)
 public final class ObjectWriter<T> implements ObjectReceiver<T> {
 
 	private static final String STDOUT = "stdout";

--- a/src/main/java/org/culturegraph/mf/stream/sink/TripleObjectWriter.java
+++ b/src/main/java/org/culturegraph/mf/stream/sink/TripleObjectWriter.java
@@ -27,6 +27,7 @@ import org.culturegraph.mf.exceptions.MetafactureException;
 import org.culturegraph.mf.framework.DefaultObjectReceiver;
 import org.culturegraph.mf.framework.annotations.Description;
 import org.culturegraph.mf.framework.annotations.In;
+import org.culturegraph.mf.framework.annotations.Out;
 import org.culturegraph.mf.types.Triple;
 
 /**
@@ -46,6 +47,7 @@ import org.culturegraph.mf.types.Triple;
 		+ "within `baseDir`. THIS MODULE SHOULD NOT BE USED IN ENVIRONMENTS IN WHICH "
 		+ "THE VALUES OF SUBJECT AND PREDICATE A PROVIDED BY AN UNTRUSTED SOURCE!")
 @In(Triple.class)
+@Out(Void.class)
 public final class TripleObjectWriter extends DefaultObjectReceiver<Triple> {
 
 	private final String baseDir;

--- a/src/main/java/org/culturegraph/mf/stream/sink/TripleWriter.java
+++ b/src/main/java/org/culturegraph/mf/stream/sink/TripleWriter.java
@@ -22,12 +22,18 @@ import java.io.ObjectOutputStream;
 
 import org.culturegraph.mf.exceptions.MetafactureException;
 import org.culturegraph.mf.framework.DefaultObjectReceiver;
+import org.culturegraph.mf.framework.annotations.Description;
+import org.culturegraph.mf.framework.annotations.In;
+import org.culturegraph.mf.framework.annotations.Out;
 import org.culturegraph.mf.types.Triple;
 
 /**
  * @author Christoph Böhme
  *
  */
+@Description("Writes triples into a file.")
+@In(Triple.class)
+@Out(Void.class)
 public final class TripleWriter extends DefaultObjectReceiver<Triple> {
 
 	public static final int BUFFERSIZE = 2048;


### PR DESCRIPTION
The IDE uses the `@In` and `@Out` annotations to validate workflows. It issues warnings when no annotation is found. Since the writers don't actually output anything as part of the workflow, `Void.class` might make sense as their output type.
