### PR TITLE
Fixes #125: Set correct file modes in distribution on Linux

### DIFF
--- a/src/main/assembly/assembly.xml
+++ b/src/main/assembly/assembly.xml
@@ -1,55 +1,81 @@
-<assembly>
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" 
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+		
 	<id>bin</id>
+	
 	<formats>
+		<format>tar.gz</format>
 		<format>zip</format>
 	</formats>
 
-	<!-- Adds dependencies to zip package under lib directory -->
+	<!-- Adds dependencies to distribution package under lib directory -->
 	<dependencySets>
 		<dependencySet>
 			<useProjectArtifact>false</useProjectArtifact>
 			<outputDirectory>lib</outputDirectory>
 			<unpack>false</unpack>
+			<directoryMode>0755</directoryMode>
+			<fileMode>0644</fileMode>
 		</dependencySet>
 	</dependencySets>
 
 	<fileSets>
-		<fileSet>
-			<directory>${project.build.scriptSourceDirectory}</directory>
-			<outputDirectory></outputDirectory>
-			<includes>
-				<include>*.bat</include>
-				<include>*.sh</include>
-			</includes>
-			<filtered>true</filtered>
-		</fileSet>
-		<!-- adds jar package to the root directory of zip package -->
+		<!-- adds jar package to the root directory of distribution package -->
 		<fileSet>
 			<directory>${project.build.directory}</directory>
 			<outputDirectory></outputDirectory>
 			<includes>
 				<include>*.jar</include>
 			</includes>
+			<directoryMode>0755</directoryMode>
+			<fileMode>0644</fileMode>
 		</fileSet>
-
+		<fileSet>
+			<directory>${project.build.scriptSourceDirectory}</directory>
+			<outputDirectory></outputDirectory>
+			<includes>
+				<include>*.bat</include>
+			</includes>
+			<filtered>true</filtered>
+			<directoryMode>0755</directoryMode>
+			<fileMode>0755</fileMode>
+			<lineEnding>crlf</lineEnding>
+		</fileSet>
+		<fileSet>
+			<directory>${project.build.scriptSourceDirectory}</directory>
+			<outputDirectory></outputDirectory>
+			<includes>
+				<include>*.sh</include>
+			</includes>
+			<filtered>true</filtered>
+			<directoryMode>0755</directoryMode>
+			<fileMode>0755</fileMode>
+			<lineEnding>lf</lineEnding>
+		</fileSet>
 		<fileSet>
 			<directory>examples/</directory>
 			<outputDirectory>examples/</outputDirectory>
 			<includes>
 				<include>**/*</include>
 			</includes>
+			<directoryMode>0755</directoryMode>
+			<fileMode>0644</fileMode>
 		</fileSet>
 		<fileSet>
-			<directory>${project.basedir}/src/main/resources/schemata/
-			</directory>
+			<directory>${project.basedir}/src/main/resources/schemata/</directory>
 			<outputDirectory>schemata/</outputDirectory>
 			<includes>
 				<include>*.xsd</include>
 			</includes>
+			<directoryMode>0755</directoryMode>
+			<fileMode>0644</fileMode>
 		</fileSet>
 		<fileSet>
 			<directory>modules/</directory>
 			<outputDirectory>modules/</outputDirectory>
+			<directoryMode>0755</directoryMode>
+			<fileMode>0644</fileMode>
 		</fileSet>
 		<fileSet>
 			<directory></directory>
@@ -57,6 +83,8 @@
 			<includes>
 				<include>*.md</include>
 			</includes>
+			<directoryMode>0755</directoryMode>
+			<fileMode>0644</fileMode>
 		</fileSet>
 	</fileSets>
 </assembly>


### PR DESCRIPTION
Ensures that directory and file permissions are set correctly in the
distribution package. Additionally, the line endings of the shell and
batch scripts are converted to the one of the target platform. 

This commit adds tar.gz as an additional distribution file format since
directory modes do not work correctly in zip-files created by the
assembly plugin (see http://jira.codehaus.org/browse/MASSEMBLY-494 for
an explanation and a workaround if desired). However, tar.gz files can
be cumbersome to work with on Windows. Consequently, both archive
formats should be offered.
