### PR TITLE
Allow PICA+ parser to end with two parser states

### DIFF
--- a/src/main/java/org/culturegraph/mf/stream/converter/bib/PicaDecoder.java
+++ b/src/main/java/org/culturegraph/mf/stream/converter/bib/PicaDecoder.java
@@ -119,7 +119,10 @@ public final class PicaDecoder
 		for (int i = 0; i < recordLen; ++i) {
 			state = state.parseChar(buffer[i], parserContext);
 		}
-		if (state != PicaParserState.FIELD_START) {
+		if (state == PicaParserState.SUBFIELD_VALUE) {
+			parserContext.emitLiteral();
+			parserContext.emitEndEntity();
+		} else if (state != PicaParserState.FIELD_START) {
 			if (fixUnexpectedEOR) {
 				state = state.parseChar(PicaConstants.FIELD_DELIMITER, parserContext);
 				assert state == PicaParserState.FIELD_START;

--- a/src/test/java/org/culturegraph/mf/stream/converter/bib/PicaDecoderTest.java
+++ b/src/test/java/org/culturegraph/mf/stream/converter/bib/PicaDecoderTest.java
@@ -276,7 +276,7 @@ public final class PicaDecoderTest {
 				FIELD_003AT +
 				FIELD_028A_START +
 				SUBFIELD_A +
-				SUBFIELD_D);
+				SUBFIELD);
 	}
 	
 	@Test


### PR DESCRIPTION
Fix #137

In some PICA+ serializations the field separator (ASCII 0x1E) precedes
the field, in some it succeeds the field.
