### PR TITLE
fix #160

### DIFF
--- a/src/main/java/org/culturegraph/mf/stream/pipe/sort/AbstractTripleSort.java
+++ b/src/main/java/org/culturegraph/mf/stream/pipe/sort/AbstractTripleSort.java
@@ -34,7 +34,7 @@ import org.culturegraph.mf.util.MemoryWarningSystem.Listener;
 
 /**
  * @author markus geipel
- * 
+ *
  */
 public abstract class AbstractTripleSort extends DefaultObjectPipe<Triple, ObjectReceiver<Triple>> implements Listener {
 	/**
@@ -46,7 +46,7 @@ public abstract class AbstractTripleSort extends DefaultObjectPipe<Triple, Objec
 
 	/**
 	 * sort order
-	 * 
+	 *
 	 */
 	public enum Order {
 		INCREASING {
@@ -98,8 +98,10 @@ public abstract class AbstractTripleSort extends DefaultObjectPipe<Triple, Objec
 	public final void process(final Triple namedValue) {
 		if (memoryLow) {
 			try {
-				nextBatch();
-			} catch (IOException e) {
+				if (!buffer.isEmpty()) {
+					nextBatch();
+				}
+			} catch (final IOException e) {
 				throw new MetafactureException("Error writing to temp file after sorting", e);
 			} finally {
 				memoryLow = false;
@@ -115,7 +117,7 @@ public abstract class AbstractTripleSort extends DefaultObjectPipe<Triple, Objec
 		final ObjectOutputStream out = new ObjectOutputStream(new FileOutputStream(tempFile));
 
 		try {
-			for (Triple triple : buffer) {
+			for (final Triple triple : buffer) {
 				triple.write(out);
 			}
 		} finally {
@@ -130,7 +132,7 @@ public abstract class AbstractTripleSort extends DefaultObjectPipe<Triple, Objec
 
 		if (tempFiles.isEmpty()) {
 			Collections.sort(buffer, createComparator(compare, order));
-			for (Triple triple : buffer) {
+			for (final Triple triple : buffer) {
 				sortedTriple(triple);
 			}
 			onFinished();
@@ -148,7 +150,7 @@ public abstract class AbstractTripleSort extends DefaultObjectPipe<Triple, Objec
 					});
 			try {
 				nextBatch();
-				for (File file : tempFiles) {
+				for (final File file : tempFiles) {
 					queue.add(new SortedTripleFileFacade(file));
 				}
 
@@ -163,10 +165,10 @@ public abstract class AbstractTripleSort extends DefaultObjectPipe<Triple, Objec
 					}
 				}
 				onFinished();
-			} catch (IOException e) {
+			} catch (final IOException e) {
 				throw new MetafactureException("Error merging temp files", e);
 			} finally {
-				for (SortedTripleFileFacade sortedFileFacade : queue) {
+				for (final SortedTripleFileFacade sortedFileFacade : queue) {
 					sortedFileFacade.close();
 				}
 			}
@@ -228,7 +230,7 @@ public abstract class AbstractTripleSort extends DefaultObjectPipe<Triple, Objec
 	@Override
 	public final void onResetStream() {
 		buffer.clear();
-		for (File file : tempFiles) {
+		for (final File file : tempFiles) {
 			if (file.exists()) {
 				file.delete();
 			}

--- a/src/test/java/org/culturegraph/mf/stream/pipe/sort/AbstractTripleSortTest.java
+++ b/src/test/java/org/culturegraph/mf/stream/pipe/sort/AbstractTripleSortTest.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright 2013 Deutsche Nationalbibliothek
+ *
+ *  Licensed under the Apache License, Version 2.0 the "License";
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.culturegraph.mf.stream.pipe.sort;
+
+import org.culturegraph.mf.types.Triple;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for class {@link AbstractTripleSort}.
+ *
+ * @author Christoph Böhme
+ *
+ */
+ public final class AbstractTripleSortTest {
+
+	private static final Triple T1 = new Triple("s", "p", "o");
+
+	// NO CHECKSTYLE IllegalType FOR 3 LINES:
+	// AbstractFormatter is the system under test. To keep the test
+	// case concise no named mock implementation is created.
+	private AbstractTripleSort tripleSort;
+
+	@Before
+	public void setup() {
+		tripleSort = new AbstractTripleSort() {
+			@Override
+			protected void sortedTriple(final Triple namedValue) {}
+		};
+	}
+
+	@Test
+	public void shouldNotFailIfFlushingBeforeFirstRecord() {
+		tripleSort.memoryLow(0, 0);
+		tripleSort.process(T1);
+		tripleSort.closeStream();
+	}
+
+}


### PR DESCRIPTION
AbstractTripleSort threw NullPointerExceptions if it received a
"memoryLow" message before the first record was processed.
