### PR TITLE
Renamed SimpleXmlWriter to SimpleXmlEncoder

### DIFF
--- a/src/main/java/org/culturegraph/mf/stream/converter/StreamToJDomDocument.java
+++ b/src/main/java/org/culturegraph/mf/stream/converter/StreamToJDomDocument.java
@@ -27,7 +27,7 @@ import org.culturegraph.mf.framework.StreamReceiver;
 import org.culturegraph.mf.framework.annotations.Description;
 import org.culturegraph.mf.framework.annotations.In;
 import org.culturegraph.mf.framework.annotations.Out;
-import org.culturegraph.mf.stream.sink.SimpleXmlWriter;
+import org.culturegraph.mf.stream.converter.xml.SimpleXmlEncoder;
 import org.culturegraph.mf.util.ResourceUtil;
 import org.jdom.Document;
 import org.jdom.Element;
@@ -109,7 +109,7 @@ public final class StreamToJDomDocument extends DefaultSender<ObjectReceiver<Doc
 		assert !isClosed();
 		if (name.isEmpty()) {
 			currentElement.addContent(value);
-		} else if (name.startsWith(SimpleXmlWriter.ATTRIBUTE_MARKER)) {
+		} else if (name.startsWith(SimpleXmlEncoder.ATTRIBUTE_MARKER)) {
 			final String[] parts = NAMESPACE_DELIMITER.split(name);
 			if (parts.length == 2) {
 				currentElement.setAttribute(parts[1], value, getNamespace(parts[0].substring(1)));

--- a/src/main/java/org/culturegraph/mf/stream/converter/xml/SimpleXmlEncoder.java
+++ b/src/main/java/org/culturegraph/mf/stream/converter/xml/SimpleXmlEncoder.java
@@ -13,7 +13,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.culturegraph.mf.stream.sink;
+package org.culturegraph.mf.stream.converter.xml;
 
 import java.net.URL;
 import java.util.ArrayList;
@@ -35,15 +35,16 @@ import org.culturegraph.mf.util.ResourceUtil;
 
 /**
  *
- * writes a stream to XML
+ * Encodes a stream as XML
  *
- * @author Markus Michael Geipel, Christoph Böhme
+ * @author Markus Michael Geipel
+ * @author Christoph Böhme
  *
  */
-@Description("writes a stream to xml")
+@Description("Encodes a stream as xml")
 @In(StreamReceiver.class)
 @Out(String.class)
-public final class SimpleXmlWriter extends DefaultStreamPipe<ObjectReceiver<String>> {
+public final class SimpleXmlEncoder extends DefaultStreamPipe<ObjectReceiver<String>> {
 
 	public static final String ATTRIBUTE_MARKER = "~";
 	public static final String NAMESPACES = "namespaces";
@@ -90,7 +91,7 @@ public final class SimpleXmlWriter extends DefaultStreamPipe<ObjectReceiver<Stri
 			namespaces.put(entry.getKey().toString(), entry.getValue().toString());
 		}
 	}
-	
+
 	public void setNamespaceFile(final URL url) {
 		final Properties properties = ResourceUtil.loadProperties(url);
 		for (final Entry<Object, Object> entry : properties.entrySet()) {
@@ -274,7 +275,7 @@ public final class SimpleXmlWriter extends DefaultStreamPipe<ObjectReceiver<Stri
 		public Element createChild(final String name) {
 			final Element child = new Element(name, this);
 			if (children == NO_CHILDREN) {
-				children = new ArrayList<SimpleXmlWriter.Element>();
+				children = new ArrayList<SimpleXmlEncoder.Element>();
 			}
 			children.add(child);
 			return child;

--- a/src/main/resources/flux-commands.properties
+++ b/src/main/resources/flux-commands.properties
@@ -71,7 +71,7 @@ object-tee org.culturegraph.mf.stream.pipe.ObjectTee
 stream-tee org.culturegraph.mf.stream.pipe.StreamTee
 wait-for-inputs	org.culturegraph.mf.stream.pipe.CloseSupressor
 
-stream-to-xml	org.culturegraph.mf.stream.sink.SimpleXmlWriter
+stream-to-xml	org.culturegraph.mf.stream.converter.xml.SimpleXmlEncoder
 rdf-macros	org.culturegraph.mf.stream.pipe.RdfMacroPipe
 
 batch-log	org.culturegraph.mf.stream.pipe.BatchLogger

--- a/src/test/java/org/culturegraph/mf/stream/converter/xml/SimpleXmlEncoderTest.java
+++ b/src/test/java/org/culturegraph/mf/stream/converter/xml/SimpleXmlEncoderTest.java
@@ -13,22 +13,23 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.culturegraph.mf.stream.sink;
+package org.culturegraph.mf.stream.converter.xml;
 
 
 
 import org.culturegraph.mf.framework.DefaultObjectReceiver;
 import org.culturegraph.mf.framework.StreamReceiver;
+import org.culturegraph.mf.stream.converter.xml.SimpleXmlEncoder;
 import org.junit.Assert;
 import org.junit.Test;
 
 /**
- * Tests {@link SimpleXmlWriter}.
+ * Tests {@link SimpleXmlEncoder}.
  *
  * @author Markus Geipel
  *
  */
-public final class SimpleXmlWriterTest {
+public final class SimpleXmlEncoderTest {
 
 
 	private static final String TAG = "tag";
@@ -41,14 +42,14 @@ public final class SimpleXmlWriterTest {
 	public void testShouldOnlyEscapeFiveChars() {
 		final StringBuilder builder = new StringBuilder();
 
-		SimpleXmlWriter.writeEscaped(builder , "&<>'\" üäö");
+		SimpleXmlEncoder.writeEscaped(builder , "&<>'\" üäö");
 
 		Assert.assertEquals("&amp;&lt;&gt;&apos;&quot; üäö", builder.toString());
 	}
 
 	@Test
 	public void testShouldHandleSeparateRoots(){
-		final SimpleXmlWriter writer = new SimpleXmlWriter();
+		final SimpleXmlEncoder writer = new SimpleXmlEncoder();
 		writer.setRootTag("root");
 		writer.setRecordTag("record");
 		writer.setWriteXmlHeader(false);


### PR DESCRIPTION
The SimpleXmlWriter/Encoder does not write xml but just encodes it. Hence, the
class was renamed and moved from org.culturegraph.mf.stream.sink to
org.culturegraph.mf.stream.converter.xml.
