### PR TITLE
Added new attributes era and removeLeadingZeros to DateFormat

### DIFF
--- a/src/main/java/org/culturegraph/mf/morph/functions/DateFormat.java
+++ b/src/main/java/org/culturegraph/mf/morph/functions/DateFormat.java
@@ -15,10 +15,10 @@
  */
 package org.culturegraph.mf.morph.functions;
 
-import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.Collections;
-import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
@@ -27,13 +27,25 @@ import org.culturegraph.mf.exceptions.MorphDefException;
 
 /**
  * Format date/time strings in Metamorph. By default the input format is
- * dd.MM.yyyy and the output format is dd. MMMM yyyy.
- *
+ * dd.MM.yyyy and the output format is {@link java.text.DateFormat.Field#LONG}.
+ * <br/>
+ * The Attribute removeLeadingZeros will remove all leading zeros from all
+ * numbers in the output date.
+ * <br/>
+ * The attribute era is used to specify if the date is BC or AD. Default
+ * value is AUTO. To understand that, three short examples:
+ * <ul><li>Input: 20.07.356 (era=BC)</li>
+ * <li>Output (German location): 20. Juli 0356 v. Chr.</li>
+ * <ul><li>Input: 20.07.356 (era=AD,removeLeadingZeros=true)</li>
+ * <li>Output (German location): 20. Juli 356</li>
+ * <li>Input: 20.07.-356 (era=AUTO)</li>
+ * <li>Output (German location): 20. Juli 0357 v. Chr. (there is NO year 0;
+ * see ISO 8601, Proleptic Gregorian Calendar)</li></ul>
+ * <p/>
  * Examples of using this function in Metamorph:
- * <ul>
- *     <li>Default date format: <code>&lt;dateformat /&gt;</code></li>
- *     <li>Read ISO-dates and generate German style dates:
- *     <code>&lt;dateformat inputformat="yyyy-MM-dd" outputformat="dd.MM.yyyy" /&gt;</code></li>
+ * <ul><li>Default date format: <code>&lt;dateformat /&gt;</code></li>
+ * <li>Read ISO-dates and generate German style dates:
+ * <code>&lt;dateformat inputformat="yyyy-MM-dd" outputformat="dd.MM.yyyy" /&gt;</code></li>
  * </ul>
  *
  * @author Michael Büchner
@@ -42,11 +54,15 @@ public class DateFormat extends AbstractSimpleStatelessFunction {
 
 	public static final String DEFAULT_INPUT_FORMAT = "dd.MM.yyyy";
 	public static final DateFormats DEFAULT_OUTPUT_FORMAT = DateFormats.LONG;
+	public static final boolean DEFAULT_REMOVE_LEADING_ZEROS = false;
+	public static final Era DEFAULT_ERA = Era.AUTO;
 
 	private static final Set<String> SUPPORTED_LANGUAGES;
 
 	private String inputFormat = DEFAULT_INPUT_FORMAT;
 	private DateFormats outputFormat = DEFAULT_OUTPUT_FORMAT;
+	private Era era = DEFAULT_ERA;
+	private boolean removeLeadingZeros = DEFAULT_REMOVE_LEADING_ZEROS;
 	private Locale outputLocale = Locale.getDefault();
 
 	/**
@@ -73,6 +89,29 @@ public class DateFormat extends AbstractSimpleStatelessFunction {
 
 	}
 
+	/**
+	 * Supported eras (basically AUTO, AD and BC). Maps to
+	 * {@link java.util.GregorianCalendar}.
+	 *
+	 * @author Michael Büchner
+	 */
+	public enum Era {
+		AD(GregorianCalendar.AD),
+		BC(GregorianCalendar.BC),
+		AUTO(-1);
+
+		private final int eraId;
+
+		Era(final int eraId) {
+			this.eraId = eraId;
+		}
+
+		int getEraId() {
+			return eraId;
+		}
+
+	}
+
 	static {
 		final Set<String> set = new HashSet<String>();
 		Collections.addAll(set, Locale.getISOLanguages());
@@ -81,15 +120,34 @@ public class DateFormat extends AbstractSimpleStatelessFunction {
 
 	@Override
 	public final String process(final String value) {
-		String result = value;
+		String result;
 		try {
-			final java.text.DateFormat inputDateFormat = new SimpleDateFormat(inputFormat);
-			final Date date = inputDateFormat.parse(value);
-			result = java.text.DateFormat.getDateInstance(outputFormat.getFormatId(), outputLocale).format(date);
+			final Calendar c = Calendar.getInstance();
+			final SimpleDateFormat sdf = new SimpleDateFormat(inputFormat);
+			c.setTime(sdf.parse(value));
+			if (era == Era.BC) {
+				c.set(Calendar.ERA, GregorianCalendar.BC);
+			} else if (era == Era.AD) {
+				c.set(Calendar.ERA, GregorianCalendar.AD);
+			}
+
+			final SimpleDateFormat sdfp = (SimpleDateFormat) java.text.DateFormat.getDateInstance(outputFormat.getFormatId(), outputLocale);
+			String p = sdfp.toPattern();
+			if (c.get(Calendar.ERA) == GregorianCalendar.BC) {
+				p = p.replace("yyyy", "yyyy G");
+			}
+
+			final SimpleDateFormat sdfo = new SimpleDateFormat(p, outputLocale);
+			result = sdfo.format(c.getTime());
+
+			if (removeLeadingZeros) {
+				result = result.replaceAll("([0]{1,})([0-9]{1,})", "$2");
+			}
+
 		} catch (final IllegalArgumentException e) {
 			throw new MorphDefException("The date/time format is not supported.", e);
-		} catch (final ParseException e) {
-			// Nothing to do
+		} catch (final Exception e) {
+			result = value;
 		}
 		return result;
 	}
@@ -102,11 +160,18 @@ public class DateFormat extends AbstractSimpleStatelessFunction {
 		this.outputFormat = outputFormat;
 	}
 
+	public final void setEra(final Era era) {
+		this.era = era;
+	}
+
+	public final void setRemoveLeadingZeros(final boolean removeLeadingZeros) {
+		this.removeLeadingZeros = removeLeadingZeros;
+	}
+
 	public final void setLanguage(final String language) {
 		if (!SUPPORTED_LANGUAGES.contains(language)) {
 			throw new MorphDefException("Language '" + language + "' not supported.");
 		}
 		this.outputLocale = new Locale(language);
 	}
-
 }

--- a/src/main/resources/schemata/metamorph.xsd
+++ b/src/main/resources/schemata/metamorph.xsd
@@ -908,8 +908,8 @@
 				</annotation>
 				<simpleType>
 					<restriction base="string">
-						<enumeration value="record"></enumeration>
-						<enumeration value="entity"></enumeration>
+						<enumeration value="record" />
+						<enumeration value="entity" />
 					</restriction>
 				</simpleType>
 			</attribute>
@@ -920,9 +920,9 @@
 				</annotation>
 				<simpleType>
 					<restriction base="string">
-						<enumeration value="name"></enumeration>
-						<enumeration value="value"></enumeration>
-						<enumeration value="name-value"></enumeration>
+						<enumeration value="name" />
+						<enumeration value="value" />
+						<enumeration value="name-value" />
 					</restriction>
 				</simpleType>
 			</attribute>
@@ -994,6 +994,16 @@
 					</restriction>
 				</simpleType>
 			</attribute>
+            <attribute name="era" use="optional" default="AUTO">
+                <simpleType>
+                    <restriction base="string">
+                        <enumeration value="AUTO" />
+                        <enumeration value="AD" />
+                        <enumeration value="BC" />
+                    </restriction>
+                </simpleType>
+            </attribute>
+            <attribute name="removeLeadingZeros" type="boolean" use="optional" default="false" />
 			<attribute name="language" type="string" use="optional" />
 		</complexType>
 	</element>


### PR DESCRIPTION
This is needed for Entity Facts to parse BC dates. It also enables the possibility to remove leading zeros of date numbers (in java.text.DateFormat the year always has 4 digits, filled with zeros).
