### PR TITLE
Improve error message when decoding CSV

### DIFF
--- a/src/main/java/org/culturegraph/mf/stream/converter/CsvDecoder.java
+++ b/src/main/java/org/culturegraph/mf/stream/converter/CsvDecoder.java
@@ -69,7 +69,10 @@ public final class CsvDecoder extends DefaultObjectPipe<String, StreamReceiver> 
 				}
 				getReceiver().endRecord();
 			}else{
-				throw new IllegalArgumentException("wrong number of columns in input line: " + string);
+				throw new IllegalArgumentException(
+						String.format(
+								"wrong number of columns (expected %s, was %s) in input line: %s",
+								header.length, parts.length, string));
 			}
 		}else{
 			getReceiver().startRecord(String.valueOf(++count));


### PR DESCRIPTION
Include expected and actual number of columns if they don't match
