### PR TITLE
JsonEncoder should not prefix pretty-printed output with spaces.

### DIFF
--- a/metafacture-json/src/main/java/org/metafacture/json/JsonEncoder.java
+++ b/metafacture-json/src/main/java/org/metafacture/json/JsonEncoder.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.core.JsonStreamContext;
 import com.fasterxml.jackson.core.SerializableString;
 import com.fasterxml.jackson.core.io.CharacterEscapes;
 import com.fasterxml.jackson.core.io.SerializedString;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 
 /**
  * Serialises an object as JSON. Records and entities are represented
@@ -66,11 +67,7 @@ public final class JsonEncoder extends
 	}
 
 	public void setPrettyPrinting(final boolean prettyPrinting) {
-		if (prettyPrinting) {
-			jsonGenerator.useDefaultPrettyPrinter();
-		} else {
-			jsonGenerator.setPrettyPrinter(null);
-		}
+		jsonGenerator.setPrettyPrinter(prettyPrinting ? new DefaultPrettyPrinter((SerializableString) null) : null);
 	}
 
 	public boolean getPrettyPrinting() {

--- a/metafacture-json/src/test/java/org/metafacture/json/JsonEncoderTest.java
+++ b/metafacture-json/src/test/java/org/metafacture/json/JsonEncoderTest.java
@@ -181,6 +181,22 @@ public final class JsonEncoderTest {
 		ordered.verify(receiver).process(fixQuotes("{'L2':'V2'}"));
 	}
 
+	@Test
+	public void testShouldNotPrefixPrettyPrintedOutputWithSpaces() {
+		encoder.setPrettyPrinting(true);
+
+		encoder.startRecord("");
+		encoder.literal(LITERAL1, VALUE1);
+		encoder.endRecord();
+		encoder.startRecord("");
+		encoder.literal(LITERAL2, VALUE2);
+		encoder.endRecord();
+
+		final InOrder ordered = inOrder(receiver);
+		ordered.verify(receiver).process(fixQuotes("{\n  'L1' : 'V1'\n}"));
+		ordered.verify(receiver).process(fixQuotes("{\n  'L2' : 'V2'\n}"));
+	}
+
 	/*
 	 * Utility method which replaces all single quotes in a string with double quotes.
 	 * This allows to specify the JSON output in the test cases without having to wrap


### PR DESCRIPTION
Jackson's JsonGenerator [doesn't apply](/FasterXML/jackson-core/blob/8ee7d0f6c06b72417ecc1a911e933bda79535f36/src/main/java/com/fasterxml/jackson/core/base/GeneratorBase.java#L395) configured root value separator to pretty-printer.

Ref.: #153 (d84456a)