### PR TITLE
Add ObjectThreader for multithreading using pipelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ build
 .classpath
 .project
 .settings/
+bin/
 
 # Ignore IntelliJ project files:
 *.ipr

--- a/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/ObjectPipeDecoupler.java
+++ b/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/ObjectPipeDecoupler.java
@@ -97,13 +97,17 @@ public final class ObjectPipeDecoupler<T> implements ObjectPipe<T, ObjectReceive
 
     @Override
     public void resetStream() {
-        queue.add(Feeder.BLUE_PILL);
+        try {
+            queue.put(Feeder.BLUE_PILL);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
     }
 
     @Override
     public void closeStream() {
-        queue.add(Feeder.RED_PILL);
         try {
+            queue.put(Feeder.RED_PILL);
             thread.join();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -147,6 +151,7 @@ public final class ObjectPipeDecoupler<T> implements ObjectPipe<T, ObjectReceive
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
+                return;
             }
         }
     }

--- a/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/ObjectPipeDecoupler.java
+++ b/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/ObjectPipeDecoupler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013, 2014 Deutsche Nationalbibliothek
+ * Copyright 2013-2019 Deutsche Nationalbibliothek and others
  *
  * Licensed under the Apache License, Version 2.0 the "License";
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
  * @param <T> Object type
  *
  * @author Markus Micheal Geipel
+ * @author Pascal Christoph (dr0i)
  */
 @In(Object.class)
 @Out(Object.class)

--- a/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/ObjectPipeDecoupler.java
+++ b/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/ObjectPipeDecoupler.java
@@ -49,15 +49,15 @@ public final class ObjectPipeDecoupler<T> implements ObjectPipe<T, ObjectReceive
     private boolean debug;
 
     public ObjectPipeDecoupler() {
-        queue = new LinkedBlockingQueue<Object>(DEFAULT_CAPACITY);
+        queue = new LinkedBlockingQueue<>(DEFAULT_CAPACITY);
     }
 
     public ObjectPipeDecoupler(final int capacity) {
-        queue = new LinkedBlockingQueue<Object>(capacity);
+        queue = new LinkedBlockingQueue<>(capacity);
     }
 
     public ObjectPipeDecoupler(final String capacity) {
-        queue = new LinkedBlockingQueue<Object>(Integer.parseInt(capacity));
+        queue = new LinkedBlockingQueue<>(Integer.parseInt(capacity));
     }
 
     public void setDebug(final boolean debug) {
@@ -73,7 +73,7 @@ public final class ObjectPipeDecoupler<T> implements ObjectPipe<T, ObjectReceive
         try {
             queue.put(obj);
             if (debug) {
-                LOG.info("Current buffer size: " + queue.size());
+                LOG.info("Current buffer size: {}", queue.size());
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();

--- a/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/ObjectThreader.java
+++ b/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/ObjectThreader.java
@@ -1,0 +1,70 @@
+/* Copyright 2019 hbz, Pascal Christoph. 
+ * 
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.metafacture.flowcontrol;
+
+import org.metafacture.framework.FluxCommand;
+import org.metafacture.framework.ObjectPipe;
+import org.metafacture.framework.ObjectReceiver;
+import org.metafacture.framework.Tee;
+import org.metafacture.framework.annotations.Description;
+import org.metafacture.framework.annotations.In;
+import org.metafacture.framework.annotations.Out;
+import org.metafacture.framework.helpers.DefaultTee;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Divides incoming objects and distributes them to added receivers. These
+ * receivers are coupled with an
+ * {@link org.metafacture.flowcontrol.ObjectPipeDecoupler}, so each added
+ * receiver runs in its own thread.
+ * 
+ * @param <T> Object type
+ *
+ * @author Pascal Christoph(dr0i)
+ * 
+ */
+@In(Object.class)
+@Out(Object.class)
+@Description("incoming objects are distributed to the added receivers, running in their own threads")
+@FluxCommand("threader")
+public class ObjectThreader<T> extends DefaultTee<ObjectReceiver<T>> implements ObjectPipe<T, ObjectReceiver<T>> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ObjectThreader.class);
+    private int objectNumber = 0;
+
+    @Override
+    public void process(final T obj) {
+        getReceivers().get(objectNumber).process(obj);
+        if (objectNumber == getReceivers().size() - 1)
+            objectNumber = 0;
+        else
+            objectNumber++;
+    }
+
+    @Override
+    public <R extends ObjectReceiver<T>> R setReceiver(final R receiver) {
+        return super.setReceiver(new ObjectPipeDecoupler<T>().setReceiver(receiver));
+    }
+
+    @Override
+    public Tee<ObjectReceiver<T>> addReceiver(final ObjectReceiver<T> receiver) {
+        LOG.info("Adding thread " + (getReceivers().size() + 1));
+        ObjectPipeDecoupler<T> opd = new ObjectPipeDecoupler<>();
+        opd.setReceiver(receiver);
+        return super.addReceiver(opd);
+    }
+}

--- a/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/ObjectThreader.java
+++ b/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/ObjectThreader.java
@@ -1,4 +1,4 @@
-/* Copyright 2019 hbz, Pascal Christoph. 
+/* Copyright 2019 Pascal Christoph, hbz.
  * 
  * Licensed under the Apache License, Version 2.0 the "License";
  * you may not use this file except in compliance with the License.
@@ -34,12 +34,12 @@ import org.slf4j.LoggerFactory;
  * 
  * @param <T> Object type
  *
- * @author Pascal Christoph(dr0i)
+ * @author Pascal Christoph (dr0i)
  * 
  */
 @In(Object.class)
 @Out(Object.class)
-@Description("incoming objects are distributed to the added receivers, running in their own threads")
+@Description("Incoming objects are distributed to the added receivers, running in their own threads.")
 @FluxCommand("thread-object-tee")
 public class ObjectThreader<T> extends DefaultTee<ObjectReceiver<T>> implements ObjectPipe<T, ObjectReceiver<T>> {
 
@@ -49,10 +49,11 @@ public class ObjectThreader<T> extends DefaultTee<ObjectReceiver<T>> implements 
     @Override
     public void process(final T obj) {
         getReceivers().get(objectNumber).process(obj);
-        if (objectNumber == getReceivers().size() - 1)
+        if (objectNumber == getReceivers().size() - 1) {
             objectNumber = 0;
-        else
+        } else {
             objectNumber++;
+        }
     }
 
     @Override

--- a/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/ObjectThreader.java
+++ b/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/ObjectThreader.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
 @In(Object.class)
 @Out(Object.class)
 @Description("incoming objects are distributed to the added receivers, running in their own threads")
-@FluxCommand("threader")
+@FluxCommand("object-threader-tee")
 public class ObjectThreader<T> extends DefaultTee<ObjectReceiver<T>> implements ObjectPipe<T, ObjectReceiver<T>> {
 
     private static final Logger LOG = LoggerFactory.getLogger(ObjectThreader.class);

--- a/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/ObjectThreader.java
+++ b/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/ObjectThreader.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
 @In(Object.class)
 @Out(Object.class)
 @Description("incoming objects are distributed to the added receivers, running in their own threads")
-@FluxCommand("object-threader-tee")
+@FluxCommand("thread-object-tee")
 public class ObjectThreader<T> extends DefaultTee<ObjectReceiver<T>> implements ObjectPipe<T, ObjectReceiver<T>> {
 
     private static final Logger LOG = LoggerFactory.getLogger(ObjectThreader.class);

--- a/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/ObjectThreader.java
+++ b/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/ObjectThreader.java
@@ -62,7 +62,7 @@ public class ObjectThreader<T> extends DefaultTee<ObjectReceiver<T>> implements 
 
     @Override
     public Tee<ObjectReceiver<T>> addReceiver(final ObjectReceiver<T> receiver) {
-        LOG.info("Adding thread " + (getReceivers().size() + 1));
+        LOG.info("Adding thread {}", (getReceivers().size() + 1));
         ObjectPipeDecoupler<T> opd = new ObjectPipeDecoupler<>();
         opd.setReceiver(receiver);
         return super.addReceiver(opd);

--- a/metafacture-flowcontrol/src/main/resources/flux-commands.properties
+++ b/metafacture-flowcontrol/src/main/resources/flux-commands.properties
@@ -20,3 +20,4 @@ batch-reset org.metafacture.flowcontrol.StreamBatchResetter
 reset-object-batch org.metafacture.flowcontrol.ObjectBatchResetter
 defer-stream org.metafacture.flowcontrol.StreamDeferrer
 catch-stream-exception org.metafacture.flowcontrol.StreamExceptionCatcher
+object-threader-tee org.metafacture.flowcontrol.ObjectThreader

--- a/metafacture-flowcontrol/src/main/resources/flux-commands.properties
+++ b/metafacture-flowcontrol/src/main/resources/flux-commands.properties
@@ -20,4 +20,4 @@ batch-reset org.metafacture.flowcontrol.StreamBatchResetter
 reset-object-batch org.metafacture.flowcontrol.ObjectBatchResetter
 defer-stream org.metafacture.flowcontrol.StreamDeferrer
 catch-stream-exception org.metafacture.flowcontrol.StreamExceptionCatcher
-object-threader-tee org.metafacture.flowcontrol.ObjectThreader
+thread-object-tee org.metafacture.flowcontrol.ObjectThreader

--- a/metafacture-flowcontrol/src/test/java/org/metafacture/flowcontrol/ObjectThreaderTest.java
+++ b/metafacture-flowcontrol/src/test/java/org/metafacture/flowcontrol/ObjectThreaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 hbz
+ * Copyright 2019 Pascal Christoph, hbz.
  *
  * Licensed under the Apache License, Version 2.0 the "License";
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 package org.metafacture.flowcontrol;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.atMost;
@@ -31,7 +33,7 @@ import org.mockito.MockitoAnnotations;
  * Tests for class {@link ObjectThreader} (which itself uses
  * {@link org.metafacture.flowcontrol.ObjectPipeDecoupler} to thread receivers).
  *
- * @author Pascal Christoph(dr0i)
+ * @author Pascal Christoph (dr0i)
  *
  */
 public final class ObjectThreaderTest {
@@ -59,7 +61,7 @@ public final class ObjectThreaderTest {
 		objectThreader.process("a");
 		objectThreader.process("c");
 		// check if two more threads were indeed created
-		assert (Thread.getAllStackTraces().keySet().size() - ACTIVE_THREADS_AT_BEGINNING == 2);
+		assertThat(Thread.getAllStackTraces().keySet().size() - ACTIVE_THREADS_AT_BEGINNING).isEqualTo(2);
 		objectThreader.closeStream();
 		// verify thread 1
 		verify(receiverThread1, atLeast(2)).process("a");

--- a/metafacture-flowcontrol/src/test/java/org/metafacture/flowcontrol/ObjectThreaderTest.java
+++ b/metafacture-flowcontrol/src/test/java/org/metafacture/flowcontrol/ObjectThreaderTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 hbz
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.metafacture.flowcontrol;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.atMost;
+import static org.mockito.Mockito.atLeast;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.metafacture.flowcontrol.ObjectThreader;
+import org.metafacture.framework.ObjectReceiver;
+
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Tests for class {@link ObjectThreader} (which itself uses
+ * {@link org.metafacture.flowcontrol.ObjectPipeDecoupler} to thread receivers).
+ *
+ * @author Pascal Christoph(dr0i)
+ *
+ */
+public final class ObjectThreaderTest {
+
+	@Mock
+	private ObjectReceiver<String> receiverThread1;
+	@Mock
+	private ObjectReceiver<String> receiverThread2;
+
+	private final ObjectThreader<String> objectThreader = new ObjectThreader<>();
+	private static final int ACTIVE_THREADS_AT_BEGINNING = Thread.getAllStackTraces().keySet().size();
+
+	@Before
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+		objectThreader//
+				.addReceiver(receiverThread1)//
+				.addReceiver(receiverThread2);
+	}
+
+	@Test
+	public void shouldSplitAllObjectsToAllThreadedDownStreamReceivers() throws InterruptedException {
+		objectThreader.process("a");
+		objectThreader.process("b");
+		objectThreader.process("a");
+		objectThreader.process("c");
+		// check if two more threads were indeed created
+		assert (Thread.getAllStackTraces().keySet().size() - ACTIVE_THREADS_AT_BEGINNING == 2);
+		objectThreader.closeStream();
+		// verify thread 1
+		verify(receiverThread1, atLeast(2)).process("a");
+		verify(receiverThread1, atMost(0)).process("b");
+		verify(receiverThread1, atMost(0)).process("c");
+		// verify thread 2
+		verify(receiverThread2, atMost(0)).process("a");
+		verify(receiverThread2, atLeast(1)).process("b");
+		verify(receiverThread2, atLeast(1)).process("c");
+	}
+
+}

--- a/metafacture-framework/src/main/java/org/metafacture/framework/helpers/DefaultTee.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/helpers/DefaultTee.java
@@ -35,7 +35,7 @@ public class DefaultTee<T extends Receiver> implements Tee<T> {
     private final List<T> receivers = new ArrayList<T>();
 
     @Override
-    public final <R extends T> R setReceiver(final R receiver) {
+    public <R extends T> R setReceiver(final R receiver) {
         receivers.clear();
         receivers.add(receiver);
         onChangeReceivers();
@@ -52,7 +52,7 @@ public class DefaultTee<T extends Receiver> implements Tee<T> {
     }
 
     @Override
-    public final Tee<T> addReceiver(final T receiver) {
+    public Tee<T> addReceiver(final T receiver) {
         receivers.add(receiver);
         onChangeReceivers();
         return this;

--- a/metafacture-framework/src/main/java/org/metafacture/framework/helpers/DefaultTee.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/helpers/DefaultTee.java
@@ -35,7 +35,7 @@ public class DefaultTee<T extends Receiver> implements Tee<T> {
     private final List<T> receivers = new ArrayList<T>();
 
     @Override
-    public <R extends T> R setReceiver(final R receiver) {
+    public final <R extends T> R setReceiver(final R receiver) {
         receivers.clear();
         receivers.add(receiver);
         onChangeReceivers();
@@ -52,7 +52,7 @@ public class DefaultTee<T extends Receiver> implements Tee<T> {
     }
 
     @Override
-    public Tee<T> addReceiver(final T receiver) {
+    public final Tee<T> addReceiver(final T receiver) {
         receivers.add(receiver);
         onChangeReceivers();
         return this;


### PR DESCRIPTION
Add ObjectThreader for multithreading using pipelines
    
The ObjectThreader divides incoming objects and passes them to receivers, each internally plumbed with an ObjectPipeDecoupler. Thus, a multithreaded object pipeline is created.
The receivers are to be added like every Tee receiver.

See hbz/lobid-resources#967.

This also fixes a bug in ObjectPipeDecoupler concerning threading:
While Queue.add() throws an IllegalStateException if the Queue is full, a Queue. put() just waits until there is space left in Queue (see hbz/lobid-resources#980).


