### PR TITLE
Implement non-normalized PICA+ serialization

### DIFF
--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/pica/PicaConstants.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/pica/PicaConstants.java
@@ -1,5 +1,4 @@
-/*
- * Copyright 2016 Christoph Böhme
+/* Copyright 2016,2019 Christoph Böhme and hbz
  *
  * Licensed under the Apache License, Version 2.0 the "License";
  * you may not use this file except in compliance with the License.
@@ -13,20 +12,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.biblio.pica;
 
 /**
- * Useful constants for PICA+
+ * Useful constants for PICA+.
+ * PICA+ comes with two possible serializations:
+ * a normalized one and a non-normalized.
  *
  * @author Christoph Böhme
+ * @author Pascal Christoph (dr0i)
  *
  */
-final class PicaConstants {
 
-    public static final char RECORD_MARKER = '\u001d';
-    public static final char FIELD_MARKER = '\u001e';
-    public static final char SUBFIELD_MARKER = '\u001f';
-    public static final char FIELD_END_MARKER = '\n';
+package org.metafacture.biblio.pica;
+
+final class PicaConstants{
+    public static char RECORD_MARKER = '\u001d';
+    public static char FIELD_MARKER = '\u001e';
+    public static char SUBFIELD_MARKER = '\u001f';
+    public static char FIELD_END_MARKER = '\n';
+
+    public static void setNormalizedSerialization() {
+        RECORD_MARKER = '\u001d';
+        FIELD_MARKER = '\u001e';
+        SUBFIELD_MARKER = '\u001f';
+        FIELD_END_MARKER = '\n';
+    }
+
+    public static void setNonNormalizedSerialization() {
+        RECORD_MARKER = '\n';
+        FIELD_MARKER = '\n'; //this is a dummy
+        SUBFIELD_MARKER = '$';
+        FIELD_END_MARKER = '\n';
+    }
 
     private PicaConstants() {
         // No instances allowed

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/pica/PicaParserState.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/pica/PicaParserState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Christoph Böhme
+ * Copyright 2016,2019 Christoph Böhme and hbz
  *
  * Licensed under the Apache License, Version 2.0 the "License";
  * you may not use this file except in compliance with the License.
@@ -25,12 +25,13 @@ package org.metafacture.biblio.pica;
  * The parser ignores spaces in field names. They are not included in the
  * field name.
  *
- * Empty subfields are skipped. For instance, parsing the following input
- * would NOT produce an empty literal: 003@ \u001f\u001e. The parser also
+ * Empty subfields are skipped. For instance, parsing the following normalized 
+ * pica+ would NOT produce an empty literal: 003@ \u001f\u001e. The parser also
  * skips unnamed fields without any subfields.
  *
  * @author Christoph Böhme
- *
+ * @author Pascal Christoph (dr0i)
+ * 
  */
 enum PicaParserState {
 
@@ -38,19 +39,16 @@ enum PicaParserState {
         @Override
         protected PicaParserState parseChar(final char ch, final PicaParserContext ctx) {
             final PicaParserState next;
-            switch (ch) {
-            case PicaConstants.RECORD_MARKER:
-            case PicaConstants.FIELD_MARKER:
-            case PicaConstants.FIELD_END_MARKER:
+            if(ch==PicaConstants.RECORD_MARKER ||
+               ch==PicaConstants.FIELD_MARKER ||
+               ch==PicaConstants.FIELD_END_MARKER){
                 ctx.emitStartEntity();
                 ctx.emitEndEntity();
                 next = FIELD_NAME;
-                break;
-            case PicaConstants.SUBFIELD_MARKER:
+            }else if(ch==PicaConstants.SUBFIELD_MARKER){
                 ctx.emitStartEntity();
                 next = SUBFIELD_NAME;
-                break;
-            default:
+            }else{
                 ctx.appendText(ch);
                 next = this;
             }
@@ -67,17 +65,14 @@ enum PicaParserState {
         @Override
         protected PicaParserState parseChar(final char ch, final PicaParserContext ctx) {
             final PicaParserState next;
-            switch (ch) {
-            case PicaConstants.RECORD_MARKER:
-            case PicaConstants.FIELD_MARKER:
-            case PicaConstants.FIELD_END_MARKER:
+            if(ch==PicaConstants.RECORD_MARKER ||
+               ch==PicaConstants.FIELD_MARKER ||
+               ch==PicaConstants.FIELD_END_MARKER){
                 ctx.emitEndEntity();
                 next = FIELD_NAME;
-                break;
-            case PicaConstants.SUBFIELD_MARKER:
+            }else if(ch==PicaConstants.SUBFIELD_MARKER)
                 next = this;
-                break;
-            default:
+            else{
                 ctx.setSubfieldName(ch);
                 next = SUBFIELD_VALUE;
             }
@@ -93,19 +88,16 @@ enum PicaParserState {
         @Override
         protected PicaParserState parseChar(final char ch, final PicaParserContext ctx) {
             final PicaParserState next;
-            switch (ch) {
-            case PicaConstants.RECORD_MARKER:
-            case PicaConstants.FIELD_MARKER:
-            case PicaConstants.FIELD_END_MARKER:
+            if(ch==PicaConstants.RECORD_MARKER ||
+               ch==PicaConstants.FIELD_MARKER ||
+               ch==PicaConstants.FIELD_END_MARKER){
                 ctx.emitLiteral();
                 ctx.emitEndEntity();
                 next = FIELD_NAME;
-                break;
-            case PicaConstants.SUBFIELD_MARKER:
+            }else if(ch==PicaConstants.SUBFIELD_MARKER){
                 ctx.emitLiteral();
                 next = SUBFIELD_NAME;
-                break;
-            default:
+            }else{
                 ctx.appendText(ch);
                 next = this;
             }
@@ -122,5 +114,4 @@ enum PicaParserState {
     protected abstract PicaParserState parseChar(final char ch, final PicaParserContext ctx);
 
     protected abstract void endOfInput(final PicaParserContext ctx);
-
 }

--- a/metafacture-runner/src/main/dist/examples/read/pica/nonNormalized.pica
+++ b/metafacture-runner/src/main/dist/examples/read/pica/nonNormalized.pica
@@ -1,0 +1,948 @@
+047I $uhttp://deposit.d-nb.de/cgi-bin/dokserv?id=4537631&prov=M&dok_var=1&dok_ext=htm$bHTML$c01$dMVB$e1
+
+001@ $01-2$a5
+001A $01200:10-07-89
+001B $01240:16-01-13$t10:59:20.000
+001D $01240:23-04-12
+001U $0utf8
+001X $00
+002@ $0Af
+003@ $0891142495
+006U $012,A44
+007G $aDNB$0891142495
+007I $So$0721469406
+007I $So$062014388
+010@ $ager
+011@ $a2011$n1989 - 2011
+017A $ara$asf
+021A $xaa$91029784019$YSüdwestdeutscher Sprachatlas$hhrsg. von Volker Schupp. Aufnahmeleitung: Eugen Gabriel. EDV-Bearb.: Rudolf Bühler ; Bernhard Kelle$pMarburg$JElwert$RXA-DE$S430$gAc
+021B $l[Hauptbd.].
+028C $9120827425$7Tp1$Vpiz$Agnd$0120827425$E1934$dVolker$aSchupp$BHrsg.
+028C/01 $9142841315$7Tp1$Vpiz$Agnd$0142841315$E1929$G2011$dHugo$aSteger$BHrsg.
+034D $a[483] Bl. in getr. Zählung
+034I $a34 x 49 cm
+034M $aKt.
+037A $aAbschlussaufnahme
+041A $9040780538$7Tg1$Vgin$Agnd$04078053-3$aSüdwestdeutschland
+041A/01 $904040725X$7Ts1$Vsaz$Agnd$04040725-1$aMundart
+041A/02 $af Sprachatlas
+041A/09 $eDE-101$rDE-101
+045E $e430
+045F $eDDC22ger$a437.40223
+045F/01 $a437
+045F/03 $f0223
+045F/03 $g434
+047A $SFE$apö/rei$ckeine ISBN eingedr., kein Einband vom Verl. vorgesehen
+047A $SERW$aDBF;wl
+
+001@ $01-2$a5
+001A $01140:11-04-95
+001B $09999:07-07-09$t23:51:04.000
+001D $01140:02-06-09
+001U $0utf8
+001X $00
+002@ $0Aa
+003@ $0944133754
+004A $0978-0-8204-2818-5$fPp. : EUR 53.10, sfr 77.00
+006T $096,N04,0757
+006U $009,A29,1760
+007I $So$0423842698
+010@ $aeng
+011@ $a2009
+017A $ara$asf$ali
+019@ $aXD-US$aXA-CH$aXA-DE
+021A $aMothers and masters in twentieth century utopian and dystopian literature$hMary E. Theis
+028A $9115129286$7Tp1$Vpiz$Agnd$0115129286$E1950$dMary Elizabeth$aTheis
+033A $pNew York, NY$pWashington, DC$pBaltimore, Md.$pBern$pFrankfurt, M.$pBerlin$pBrussels$pVienna$pOxford$nLang
+034D $a178 S.
+034I $a23 cm
+034M $aIll.
+036F $x233$9019212607$gAdvz$i1426940-5$YCurrents in comparative Romance languages and literatures$pNew York, NY$pWashington, DC$pBern$pFrankfurt am Main$pBerlin$pBrussels$pVienna$pOxford$JLang$lVol. 33
+037A $aLiteraturverz. S. 169 - 174
+041A $9041207785$7Ts1$Vszz$Agnd$04120778-6$aMutter$gMotiv
+041A/01 $9040412512$7Ts1$Vsaz$Agnd$04041251-9$aUtopie
+041A/02 $9040359646$7Ts1$Vsaz$Agnd$04035964-5$aLiteratur
+041A/08 $f123$f231
+041A/09 $eDE-101$rDE-101
+041A/10 $9041207785$7Ts1$Vszz$Agnd$04120778-6$aMutter$gMotiv
+041A/11 $9042022622$7Ts1$Vsaz$Agnd$04202262-9$aAnti-Utopie
+041A/18 $f12$f21
+041A/19 $eDE-101$rDE-101
+045E $e800
+045F $eDDC22ger$a809.3935252
+045F/01 $a809
+045F/02 $a808.839
+045F/03 $j352
+045F/03 $f0852
+047A $SFE$aS/Ste
+047A $SERW$aFra
+047I $u$$c04$dDNB$e1
+
+001@ $01-2$a5
+001A $01140:18-07-96
+001B $09999:01-09-10$t01:03:03.000
+001D $01140:18-05-10
+001U $0utf8
+001X $00
+002@ $0Aa
+003@ $0948108924
+004A $0978-0-8204-3467-4$fPp. : EUR 49.60, sfr 72.00
+006T $097,N38,0680
+006U $010,A31
+007G $aDNB$0948108924
+007I $So$0705478371
+010@ $aspa
+011@ $a2010
+017A $ara$asf
+019@ $aXD-US$aXA-CH$aXA-DE
+021A $aBorges y la revista multicolor de los sábados$dconfabulados en una escritura de la infamia$hRaquel Atena Green
+028A $9141500964$7Tp3$Vpiz$Agnd$0141500964$E1951$dRaquel Atena$aGreen
+033A $pNew York, NY$pWashington, DC$pBaltimore, Md.$pBern$pFrankfurt, [Main]$pBerlin$pBrussels$pVienna$pOxford$nLang
+034D $a181 S.
+034I $a24 cm
+036F $x232$9977036588$gAdvz$i2209628-0$YWor(l)ds of change$pNew York, NY [u.a.]$JLang$lVol. 32
+037A $aLiteraturangaben
+041A $91004455674$7Tp1$Vpiz$Agnd$0118513532$E1899$G1986$dJorge Luis$aBorges$7Tu1$Vwit$Agnd$07709246-6$tHistoria universal de la infamia
+041A/01 $91004866291$7Tu1$Vwit$Agnd$07710007-4$tRevista multicolor de los sábados
+041A/09 $eDE-101$rDE-101
+045E $e860
+045F $eDDC22ger$a868.6209
+045F/01 $a868
+047A $SFE$aSte/Sch$cKorr. 4000, HST und Zusatz, lt. VM vom 16.8.96, P
+047A $SERW$aFra
+047I $u$$c04$dDNB$e1
+
+001@ $01-2$a5
+001A $01140:18-03-97
+001B $09999:30-09-08$t23:50:15.000
+001D $01140:26-08-08
+001U $0utf8
+001X $00
+002@ $0Aa
+003@ $0950025186
+004A $0978-0-8204-3359-2$fPp. : EUR 40.70, sfr 59.00
+006T $097,N47,0465
+006U $008,A41,2433
+007I $So$0260038860
+010@ $aspa
+011@ $a2008
+017A $ara$asf$ali
+019@ $aXD-US$aXA-DE$aXA-AT$aXA-CH
+021A $aRecontextualización de la poética del siglo XVII en la obra de Jorge Luis Borges$hCristina Ortiz Ceberio
+028A $9115273093$7Tp3$Vpiz$Agnd$0115273093$E1963$dCristina$aOrtiz
+033A $pNew York$pWashington, DC$pBaltimore, Md.$pBern$pFrankfurt, M.$pBerlin$pBrussels$pVienna$pOxford$nLang
+034D $a125 S.
+034I $a24 cm
+036F $x228$9977036588$gAdvz$i2209628-0$YWor(l)ds of change$pNew York, NY [u.a.]$JLang$lVol. 28
+037A $aLiteraturverz. S. 111 - 117
+041A $9040045412$7Ts1$Vsaz$Agnd$04004541-9$aBarock
+041A/01 $9040464490$7Ts1$Vsaz$Agnd$04046449-0$aPoetik
+041A/02 $9118513532$7Tp1$Vpiz$Agnd$0118513532$E1899$G1986$dJorge Luis$aBorges
+041A/08 $f123$f213$f312
+041A/09 $eDE-101$rDE-101
+041A/10 $9040464490$7Ts1$Vsaz$Agnd$04046449-0$aPoetik
+041A/11 $az Geschichte 1600-1700 #
+041A/12 $9118513532$7Tp1$Vpiz$Agnd$0118513532$E1899$G1986$dJorge Luis$aBorges
+041A/18 $f123$f312
+041A/19 $eDE-101$rDE-101
+045E $e860
+045F $eDDC22ger$a868.6209
+045F/01 $a868
+047A $SFE$aSch/Ste
+047A $SERW$aFra
+047I $u$$c04$dDNB$e1
+
+001@ $01-2$a5
+001A $01240:26-03-97
+001B $09999:20-05-08$t23:50:13.000
+001D $01240:07-05-08
+001U $0utf8
+001X $00
+002@ $0Aa
+003@ $0950098078
+004A $0978-3-487-08388-9$fPp. : EUR 48.00
+006T $097,N18,0525
+006U $008,A22,1208
+007I $So$0229442065
+010@ $ager$afre
+011@ $a2008
+017A $ara$asf
+019@ $aXA-DE$aXA-CH
+021A $aVorstellung und Beschreibung derer Schul- und Campagne-Pferden nach ihren Lektionen$din was vor Gelegenheiten solche können gebraucht werden$fRepresentation et description de toutes les lecons des chevaux de manege et de la campagne
+021M $aAnmerkungen von dem Carousel$fRemarques du carousel
+021N $aJohann Elias Ridinger
+028A $9118600621$7Tp1$Vpiz$Agnd$0118600621$E1698$G1767$dJohann Elias$aRidinger
+032B $gndr$aNachdr. der Ausg. Augsburg 1760, 1761$cmit einem Nachw. von Karin Thieme
+033A $pHildesheim$pZürich$pNew York$nOlms-Presse
+034D $a[104] Bl. in getr. Zählung
+034I $a27 cm
+034M $aüberw. Ill.
+036G $aDocumenta hippologica
+037A $aTeilw. in Fraktur. Text dt. und franz.
+041A $9118600621$7Tp1$Vpiz$Agnd$0118600621$E1698$G1767$dJohann Elias$aRidinger
+041A/01 $904033760X$7Ts1$Agnd$04033760-1$aKupferstich
+041A/02 $9988680726$7Ts1$Vszz$Agnd$07611438-7$aDressurreiten$gMotiv
+041A/03 $af Bildband
+041A/08 $f1234$f2314$f3214
+041A/09 $eDE-101$rDE-101
+045E $e760$f796
+045F $eDDC22ger$a769.92
+045F/01 $a769.92
+047A $SFE$agb/may
+047A $SERW$aher
+
+001@ $01-2$a5
+001A $01240:04-04-97
+001B $09999:11-07-12$t22:32:35.000
+001D $09999:99-99-99
+001U $0utf8
+001X $00
+002@ $0Aa
+003@ $0950136069
+004A $fin 2 Ordnern (einzeln berechnet)
+006D $0950136034
+006T $012,N23
+006U $012,A29
+006V $04044121
+007G $aDNB$0950136069
+007I $So$0722352410
+007I $So$0312906333
+010@ $ager
+011@ $a2011$n1997 - 2011
+017A $ara$asf
+019@ $aXA-DE-HE
+021A $aKommentare zum Südwestdeutschen Sprachatlas$hhrsg. von Volker Schupp. Bearb. von Rudolf Bühler ...
+028C $9120827425$7Tp1$Vpiz$Agnd$0120827425$E1934$dVolker$aSchupp$BHrsg.
+028C/01 $9105032638$7Tn3$Agnd$0105032638$dRudolf$aBühler
+028C/02 $9142841315$7Tp1$Vpiz$Agnd$0142841315$E1929$G2011$dHugo$aSteger$BHrsg.
+033A $pMarburg$nElwert
+034D $a[ca. 2000 S. in getr. Zählung]
+034I $a27 cm
+037A $aTeilw. hrsg. von Hugo Steger und Volker Schupp. - Abschlussaufnahme
+041A $9940106388$7Tu1$Vwit$Agnd$04329638-5$tSüdwestdeutscher Sprachatlas
+041A/01 $af Kommentar
+041A/09 $eDE-101$rDE-101
+045E $e430
+045F $eDDC22ger$a437.4
+045F/01 $a437
+045F/03 $g434
+047A $SFE$akrg/rei$ckeine ISBN eingedr.
+047A $SERW$awl
+070A $ane+
+070K $aSüdwestdeutscher Sprachatlas
+
+001@ $01-2$a5
+001A $01140:25-01-00
+001B $09999:04-01-10$t14:03:09.000
+001D $01140:01-12-09
+001U $0utf8
+001X $00
+002@ $0Aa
+003@ $0958345953
+004A $0978-0-8204-4932-6$fPp. : EUR 54.80, sfr 80.00
+004A $00-8204-4932-6
+006T $000,N42,0588
+006U $010,A02
+007G $aDNB$0958345953
+007I $So$0499065315
+010@ $aeng
+011@ $a2009
+017A $ara$asf$ali
+019@ $aXD-US$aXA-CH$aXA-DE$aXA-AT
+021A $aDisguise in George Sand's novels$hFrançoise Ghillebaert
+028A $9121751201$7Tn3$Agnd$0121751201$dFrançoise$aGhillebaert
+033A $pNew York, NY$pWashington, DC$pBaltimore, Md.$pBern$pBoston$pFrankfurt, M.$pBerlin$pBrussels$pVienna$pOxford$nLang
+034D $aXII, 281 S.
+034I $a24 cm
+034M $aIll.
+036F $x294$9019212607$gAdvz$i1426940-5$YCurrents in comparative Romance languages and literatures$pNew York, NY$pWashington, DC$pBern$pFrankfurt am Main$pBerlin$pBrussels$pVienna$pOxford$JLang$lVol. 94
+037A $aLiteraturverz. S. 263 - 276
+041A $9118605348$7Tp1$Vpiz$Agnd$0118605348$E1804$G1876$dGeorge$aSand
+041A/01 $9041136179$7Ts1$Vszz$Agnd$04113617-2$aFrau$gMotiv
+041A/02 $9041878558$7Ts1$Vszz$Agnd$04187855-3$aVerkleidung$gMotiv
+041A/03 $9950412619$7Ts1$Vszz$Agnd$04453362-7$aGeschlechtsidentität$gMotiv
+041A/08 $f1234$f2134$f3412$f4312
+041A/09 $eDE-101$rDE-101
+045E $e840
+045F $eDDC22ger$a843.8
+045F/01 $a843
+047A $SFE$aSte/Sch
+047A $SERW$aFra
+047I $u$$c04$dDNB$e1
+
+001@ $01-2$a5
+001A $01240:12-10-00
+001B $09999:03-02-09$t23:50:38.000
+001D $01240:22-01-09
+001U $0utf8
+001X $00
+002@ $0Aa
+003@ $0959981004
+004A $0978-3-930831-42-5$fkart. : EUR 44.90
+006T $001,N14,0496
+006U $009,A07,1114
+007I $So$0264792119
+010@ $ager
+011@ $a2008$nc 2008
+017A $ara$asi$ali
+019@ $aXA-DE
+021A $aWilde Schweine und Flusspferde$hvon Alastair A. Macdonald und Udo Gansloßer (Hrsg.)
+028C $9136891535$7Tp1$Vpiz$Agnd$0136891535$E1946$dAlastair A.$aMacdonald$BHrsg.
+033A $p[Fürth]$nFilander-Verl.$565760
+034D $a393 S.
+034I $a24 cm
+034M $aIll., graph. Darst., Kt.
+037A $aLiteraturangaben
+041A $9973653809$7Ts1$Vsnz$Agnd$04814734-5$aSchweineartige
+041A/08 $f1
+041A/09 $eDE-101$rDE-101$lFlusspferde sehr wenig
+045E $e590
+045F $eDDC22ger$a599.633
+045F/01 $a599.633
+047A $SFE$aKer
+047A $SERW$ako
+047I $u$$c04$dDNB$e1
+
+001@ $01-2$a5
+001A $01140:23-08-01
+001B $09999:10-03-09$t23:50:12.000
+001D $01140:03-03-09
+001U $0utf8
+001X $00
+002@ $0Aa
+003@ $0962306525
+004A $0978-3-87892-024-3$fkart. : EUR 12.80
+004A $03-87892-024-5$fkart. : EUR 12.80
+006T $001,N39,0731
+006U $009,A12,1547
+007I $So$0634710904
+010@ $ager$crus
+011@ $a2008
+017A $ara$asi
+019@ $aXA-DE
+021A $aSambo$d... der kraftvolle, russische Kampfsport$hvon W. M. Andrejew und E. M. Tschumakow. Aus dem Russ. übers. von C. Menzinger
+022A/01 $aBorʹba sambo$rdt.
+028A $9108407071$7Tn3$Agnd$0108407071$dVladlen M.$aAndreev
+028B/01 $910840708X$7Tn3$Agnd$010840708X$dEvgenij M.$aČumakov
+032@ $g18$a8. Aufl.
+033A $pBerlin$nWeinmann$55109329
+034D $a159 S.
+034I $a21 cm
+034M $aIll.
+041A $9041790197$7Ts1$Agnd$04179019-4$aSambo
+041A/08 $f1
+041A/09 $eDE-101$rDE-101
+045E $e796
+045F $eDDC22ger$a796.81
+045F/01 $a796.81
+047A $SFE$aSte
+047A $SERW$astn$c6.Aufl. vergr., schicken neueste Ausgabe/Ke
+047I $u$$c04$dDNB$e1
+
+001@ $01-2$a5
+001A $01140:03-01-02
+001B $01162:14-03-12$t14:47:42.000
+001D $01140:13-09-11
+001U $0utf8
+001X $00
+002@ $0Aa
+003@ $0963504169
+004A $0978-3-928243-07-0$fkart. : EUR 44.90
+004A $03-928243-07-1
+006T $002,N05,0873
+006U $011,A39
+007G $aDNB$0963504169
+007I $So$0755086561
+011@ $a2011
+017A $ara$asf
+021A $aMaurice Duruflé$dAspekte zu Leben und Werk$hJörg Abbing
+028A $9123454786$7Tp3$Vpiz$Agnd$0123454786$E1969$dJörg$aAbbing
+032@ $g13$a3. Aufl.
+033A $pPaderborn$nEwers
+034D $a550 S.
+034I $a21 cm
+034M $aIll., Noten
+037A $aLiteraturangaben
+041A $9119386968$7Tp1$Vpiz$Agnd$0119386968$E1902$G1986$dMaurice$aDuruflé
+041A/09 $eDE-101$rDE-101
+045E $e780
+045F $eDDC22ger$a780.92
+045F/01 $a780.92
+045V $9090043340
+047A $SND$aP
+047A $SERW$arm
+047A $SFE$aHN
+047I $u$$c04$dDNB$e1
+
+001@ $01-2$a5
+001A $01240:14-03-02
+001B $01250:21-12-10$t12:42:45.000
+001D $01240:09-09-08
+001U $0utf8
+001X $00
+002@ $0Aa
+003@ $0964050250
+004A $0978-3-934376-35-9$fkart. : EUR 22.00 (freier Pr.)
+006T $002,N16,0629
+006U $008,A41,2446
+007G $aDNB$0964050250
+007I $So$0248909250
+010@ $ager
+011@ $a2008
+017A $ara$ali$asi
+019@ $aXA-DE
+021A $aDas @malaio-indonesische Pantun$deinschließlich des Pantuns der Sakai$hMohamad Agar Kalipke
+028A $9123290953$7Tp3$Vpiz$Agnd$0123290953$E1961$dMohamad$aAgar Kalipke
+033A $p[Hamburg]$nAbera$598744
+034D $a111 S.
+034I $a23 cm
+036F $x14$9019013779$gAdvz$i1406563-0$YAustronesia$pHamburg$JAbera-Verl.$lBd. 4
+037A $aLiteraturverz. S. 99 - 102
+041A $9040371948$7Ts1$Vsis$Agnd$04037194-3$aMalaiisch
+041A/01 $9042550823$7Ts1$Agnd$04255082-8$aPantun
+041A/08 $f12$f21
+041A/09 $eDE-101$rDE-101
+041A/10 $995153047X$7Ts1$Vsis$Agnd$04470686-8$aSakai-Sprache
+041A/11 $9042550823$7Ts1$Agnd$04255082-8$aPantun
+041A/18 $f12$f21
+041A/19 $eDE-101$rDE-101
+045E $e890
+045F $eDDC22ger$a899.281009
+045F/01 $a899
+045F/03 $i1
+045F/03 $m9928
+045G $eDDC22ger$a899.22
+045G/01 $a899
+045G/03 $m9922
+047A $SFE$agö
+047A $SERW$aher
+047I $u$$c04$dDNB$e1
+
+001@ $01-2$a5
+001A $01240:25-04-02
+001B $09999:02-03-17$t22:32:35.000
+001D $01240:25-04-02
+001U $0utf8
+001X $00
+002@ $0AF
+002C $aText$btxt
+002D $aohne Hilfsmittel zu benutzen$bn
+002E $aBand$bnc
+002N $a2$bi
+003@ $096430306X
+004A $0978-3-17-013514-7$fGewebe : EUR 576.00 (AT), sfr 644.00 (freier Pr.), EUR 560.00 (DE)
+004A $03-17-013514-7
+004A $0978-3-17-015616-6$cLieferung 1
+004K $09783170135147
+006T $015,N48
+006U $017,A10
+006V $0ba4bc0adae764f6392be4741aad35f57
+007G $aDNB$096430306X
+007I $So$0248303053
+007I $So$0930639414
+007I $So$0723120303
+010@ $ager
+010E $erda
+011@ $a2016
+013D $9040667243$7Ts1$Vsaz$Agnd$04066724-8$aWörterbuch
+017A $ara$asf
+019@ $aXA-DE-BW
+021A $aAramäisches Wörterbuch$hherausgegeben von Holger Gzella ; (Lieferung 1 wurde herausgegeben von Ingo Kottsieper)
+028C $9123649536$7Tp3$Vpiz$Agnd$0123649536$E1974$dHolger$aGzella$BHerausgeber$4edt
+028C $9123855594$7Tp3$Vpiz$Agnd$0123855594$E1959$dIngo$aKottsieper$BHerausgeber$4edt
+029V $9000837563$7Tb1$Vkiz$Agnd$083756-8$aW. Kohlhammer GmbH
+032@ $g11$a1. Auflage
+033A $pStuttgart$nVerlag W. Kohlhammer$55108101
+034D $aXXIV Seiten, 896 Spalten
+034I $a26 cm
+036D $x19$9550668837$gAc$YTheologisches Wörterbuch zum Alten Testament$hherausgegeben von G. Johannes Botterweck und Helmer Ringgren$6Stuttgart ; Berlin ; Köln ; Mainz : Verlag W. Kohlhammer$H1973-2016$lBand 9
+037A $aEnthält Lieferung 1 (2001)-7 (2016)
+041A $9040858804$7Ts1$Vsis$Agnd$04085880-7$aAramäisch
+041A/09 $eDE-101$rDE-101
+044N $bProduktform$aHardback
+044N $bZielgruppe$aTheologInnen (Exegese des Alten und Neuen Testaments), ReligionswissenschaftlerInnen, SemitistInnen.
+044N $bProduktform (spezifisch)$aPaper over boards
+044N $bVLB-WN$a1541: Hardcover, Softcover / Religion, Theologie/Allgemeines, Lexika
+045E $e490$f220
+045F $eDDC22ger$a492.29
+045F/01 $a492.29
+047A $SFE-F$agb/nd
+047A $SERW-F$awl
+
+001@ $01-2$a5
+001A $01140:28-05-02
+001B $09999:12-05-09$t23:50:34.000
+001D $01140:04-05-09
+001U $0utf8
+001X $00
+002@ $0AF
+003@ $0964505959
+004A $0978-3-935581-14-1$fkart. : EUR 19.95, sfr 35.90
+006T $002,N36,0071
+006U $009,A21,0649
+007I $So$0321081197
+010@ $ager
+011@ $a2009
+017A $ara$asi
+019@ $aXA-DE
+021A $aDein Name sei ...$dRituale und Zeremonien zu Geburt und Namensgebung$hRomana & Björn Ulbrich
+028C $9138075476$7Tn3$Agnd$0138075476$dRomana$aUlbrich
+028C/01 $911203313X$7Tn3$Agnd$011203313X$dBjörn$aUlbrich
+033A $pUhlstädt-Kirchhasel$nArun$598183
+034D $a127 S.
+034I $a21 cm
+034M $azahlr. Ill.
+036D $x18$998480000X$gAc$YEdition Björn Ulbrich$6Engerda : Arun$l[8]
+037A $aFälschl. als Bd. 4 des Gesamtwerks bezeichnet
+041A $9042450985$7Ts1$Agnd$04245098-6$aGeburtsritus
+041A/01 $904008017X$7Ts1$Vsaz$Agnd$04008017-1$aBrauchtum
+041A/08 $f12$f21
+041A/09 $eDE-101$rDE-101
+041A/10 $9042265002$7Ts1$Agnd$04226500-9$aNamengebung
+041A/11 $904008017X$7Ts1$Vsaz$Agnd$04008017-1$aBrauchtum
+041A/18 $f12$f21
+041A/19 $eDE-101$rDE-101
+045E $e390$f200
+045F $eDDC22ger$a392.12
+045F/01 $a392.12
+047A $SFE$ahk/sr
+047A $SERW$afs
+047I $u$$c04$dDNB$e1
+
+001@ $01-2$a5
+001A $01140:28-05-02
+001B $01250:03-08-10$t14:23:50.000
+001D $01140:04-05-09
+001U $0utf8
+001X $00
+002@ $0AF
+003@ $0964506084
+004A $0978-3-935581-13-4$fkart. : EUR 19.95, sfr 35.90
+006T $002,N44,0026
+006U $009,A21,0658
+007G $aDNB$0964506084
+007I $So$0321080911
+010@ $ager
+011@ $a2009
+017A $ara$asi
+019@ $aXA-DE
+021A $aOstara$dZeremonien und Brauchtum zu Fasnacht, Ostern und Hohe Maien$hRomana & Björn Ulbrich
+028C $9138075476$7Tn3$Agnd$0138075476$dRomana$aUlbrich
+028C/01 $911203313X$7Tn3$Agnd$011203313X$dBjörn$aUlbrich
+033A $pUhlstädt-Kirchhasel$nArun$598183
+034D $a127 S.
+034I $a30 cm
+034M $azahlr. Ill.
+036D $x19$998480000X$gAc$YEdition Björn Ulbrich$6Engerda : Arun$l[9]
+037A $aFälschl. als Bd. 6 des Gesamtwerks bezeichnet
+041A $9040165183$7Ts1$Vsaz$Agnd$04016518-8$aFastnacht
+041A/01 $9041338669$7Ts1$Agnd$04133866-2$aOsterzeit
+041A/02 $904008017X$7Ts1$Vsaz$Agnd$04008017-1$aBrauchtum
+041A/03 $9040279960$7Ts1$Vsaz$Agnd$04027996-0$aJahreslauf
+041A/08 $f12$f21
+041A/09 $eDE-101$rDE-101
+045E $e390
+045F $eDDC22ger$a394.2
+045F/01 $a394.2
+047A $SFE$ahk/sr
+047A $SERW$afs
+047I $u$$c04$dDNB$e1
+
+001@ $01-2$a5
+001A $01240:11-06-02
+001B $09999:14-07-09$t23:50:23.000
+001D $01240:30-06-09
+001U $0utf8
+001X $00
+002@ $0Aa
+003@ $096459420X
+004A $0978-3-460-32275-2$fkart. Dünndr. : EUR 29.75
+006T $002,N39,0093
+006U $009,A30,0226
+007I $So$0426142764
+010@ $ager
+011@ $a2009
+017A $ara$asi
+019@ $aXA-DE
+021A $aDie @Stuttgarter Konkordanz zur Einheitsübersetzung$hhrsg. von Michael Hartmann
+028A $9138545170$7Tp3$Vpiz$Agnd$0138545170$E1960$dMichael$aHartmann
+033A $pStuttgart$nkbw, Bibelwerk$55107964
+034D $a768 S.
+034I $a20 cm
+041A $9041268644$7Tu1$Vwie$Agnd$04126864-7$tBibel$gEinheitsübersetzung
+041A/01 $af Konkordanz
+041A/08 $f12
+041A/09 $eDE-101$rDE-101
+045E $e220
+045F $eDDC22ger$a220.5317
+045F/01 $a220.5317
+047A $SFE$ahe
+047A $SERW$ads
+
+001@ $01-2$a5
+001A $01140:12-06-02
+001B $01150:23-02-12$t19:05:57.000
+001D $01140:23-02-09
+001U $0utf8
+001X $00
+002@ $0Aa
+003@ $0964607808
+004A $0978-3-89861-127-5$fPp. : EUR 34.95, sfr 36.50
+006T $002,N42,0478
+006U $009,A11,2414
+007G $aDNB$0964607808
+007I $So$0312686770
+011@ $a2009
+017A $ara$asi
+021A $aSuche nach Sicherheit in stürmischer Zeit$dTschechen, Slowaken und Deutsche im System der internationalen Beziehungen der ersten Hälte des 20. Jahrhunderts$hHans Lemberg ...
+028C $9118077198$7Tp1$Vpiz$Agnd$0118077198$E1933$G2009$dHans$aLemberg
+032@ $g11$a1. Aufl.
+033A $pEssen$nKlartext-Verl.
+034D $a449 S.
+034I $a23 cm
+036F $x215$9023223391$gAdvz$i2072082-8$7Tb1$Vkiz$Agnd$02140738-1$aDeutsch-Tschechische und Deutsch-Slowakische Historikerkommission$YVeröffentlichungen der Deutsch-Tschechischen und Deutsch-Slowakischen Historikerkommission$pEssen$JKlartext-Verl.$lBd. 15
+036F/01 $x231$9023223189$gAdvz$i2072072-5$YVeröffentlichungen zur Kultur und Geschichte im östlichen Europa$pEssen$JKlartext-Verl.$lBd. 31
+041A $9040118827$7Tg1$Vgik$Agnd$04011882-4$Vgil$aDeutschland
+041A/01 $9040038467$7Ts1$Vsaz$Agnd$04003846-4$aAußenpolitik
+041A/02 $9040784355$7Tg1$Vgik$Agnd$04078435-6$Vgil$aTschechoslowakei
+041A/03 $az Geschichte 1918-1948
+041A/04 $af Kongress
+041A/05 $ag Hamburg <1999>
+041A/08 $f123456$f213456$f321456
+041A/09 $eDE-101$rDE-101
+041A/10 $9040157016$7Tg1$Vgin$Agnd$04015701-5$aEuropa
+041A/11 $9040038467$7Ts1$Vsaz$Agnd$04003846-4$aAußenpolitik
+041A/12 $9040784355$7Tg1$Vgik$Agnd$04078435-6$Vgil$aTschechoslowakei
+041A/13 $az Geschichte 1938-1948
+041A/14 $af Kongress
+041A/15 $ag Hamburg <1999>
+041A/18 $f123456$f213456$f321456
+041A/19 $eDE-101$rDE-101
+045E $e940
+045F $eDDC22ger$a943.703
+045F/01 $a943.703
+047A $SFE$aSt
+047A $SERW$astn/Pabhr
+047I $u$$c04$dDNB$e1
+
+001@ $01-2$a5
+001A $01140:22-07-02
+001B $09999:18-11-10$t21:42:01.000
+001D $01140:12-02-08
+001U $0utf8
+001X $00
+002@ $0Aa
+003@ $0964891123
+004A $0978-0-8204-5134-3$fPp. : EUR 59.80 (freier Pr.), sfr 99.00 (freier Pr.)
+004A $00-8204-5134-7$fPp. : EUR 59.80 (freier Pr.), sfr 99.00 (freier Pr.)
+006T $002,N33,0733
+006U $008,A10,1645
+007I $So$0237187729
+010@ $aeng
+011@ $a2008
+017A $ara$asf
+019@ $aXD-US$aXA-DE$aXA-CH$aXA-AT
+021A $aForces in modern & postmodern poetry$hAlbert Cook. Ed. by Peter Baker
+028A $9118992147$7Tp1$Vpiz$Agnd$0118992147$E1925$G1998$dAlbert Spaulding$aCook
+033A $pNew York, NY$pWashington, DC$pBaltimore, Md.$pBern$pFrankfurt, M.$pBerlin$pBrussels$pVienna$pOxford$nLang
+034D $a240 S.
+034I $a24 cm
+036F $x212$9552059366$gAdvz$i2291289-7$YStudies in modern poetry$pNew York, NY$pBern$pBerlin$pFrankfurt, M.$pParis$pWien$JLang$lVol. 12
+041A $9040367746$7Ts1$Vsaz$Agnd$04036774-5$aLyrik
+041A/01 $az Geschichte 1900-2000
+041A/02 $af Aufsatzsammlung
+041A/08 $f123
+041A/09 $eDE-101$rDE-101
+045E $e800
+045F $eDDC22ger$a809.104
+045F/01 $a809
+045F/02 $a808.81
+045F/03 $f0904
+047A $SFE$apr/Pt
+047A $SERW$aPsch
+047I $u$$c04$dBVB$e1
+
+001@ $01-2$a5
+001A $01240:28-11-02
+001B $09999:17-02-09$t23:50:23.000
+001D $01240:12-03-08
+001U $0utf8
+001X $00
+002@ $0Aa
+003@ $0965736016
+004A $0978-3-930826-80-3$fkart. : EUR 23.00, sfr 29.10
+004A $03-930826-80-1$fkart. : EUR 23.00, sfr 29.10
+004K $09783930826803
+006T $003,N02,2421
+006U $009,A09,2132
+006V $097a1be01453248ef9408b995a7af2915
+007I $So$0249644603
+010@ $ager$cara
+011@ $a2008
+017A $ara$asi
+019@ $aXA-DE-SH
+021A $aBriefe aus der Wüste$ddie private Korrespondenz der in Ġadāmis ansässigen Yūšaʿ-Familie$hUlrich Haarmann. Aus dem Nachlaß hrsg. und eingeleitet von Stephan Conermann. [Hrsg. von Horst Brinkhaus ...]
+028C $9124679803$7Tp1$Vpiz$Agnd$0124679803$E1942$G1999$dUlrich$aHaarmann$BHrsg.
+033A $pHamburg-Schenefeld$nEB-Verl.$55107345
+034D $a201 S.
+034I $a21 cm
+036F $x15$9023144092$gAdvz$i2069221-3$YAsien und Afrika$pBerlin$JEB-Verl.$lBd. 5
+041A $9042412234$7Ts1$Vsis$Agnd$04241223-7$aArabisch
+041A/01 $az Geschichte 1813-1917
+041A/02 $af Briefsammlung
+041A/08 $f123
+041A/09 $eDE-101$rDE-101
+044N $bVLB-PF$aBC: Paperback
+044N $bVLB-WI$a1: Hardcover, Softcover, Karte
+044N $bVLB-WG$a753: Völkerkunde, Volkskunde / Völkerkunde
+045E $e890
+045F $eDDC22ger$a892.76509
+045F/01 $a892.7
+047A $SFE$arö
+047A $SERW$abu
+047I $u$$c04$dDNB$e1
+
+001@ $01-2$a5
+001A $01240:05-12-02
+001B $09999:04-03-11$t22:34:08.000
+001D $01240:24-02-11
+001U $0utf8
+001X $00
+002@ $0Aa
+003@ $0965803953
+004A $0978-3-460-32058-1$fPp. : EUR 16.90
+004K $09783460320581
+006T $003,N03,0412
+006U $011,A10
+006V $0b296fa9a8dbe4b66817042289c1ccf4b
+007D $0Best.-Nr. 32058
+007G $aDNB$0965803953
+007I $So$0722691858
+010@ $ager$cheb
+011@ $a2011
+017A $ara$asf
+019@ $aXA-DE-BW
+021A $aDas @Buch Ijob$hFridolin Stier. Hrsg. von Eleonore Beck und Martha Sonntag
+022A/01 $aJob$rdt.
+028C $9123569001$7Tp1$Vpiz$Agnd$0123569001$E1926$G2014$dEleonore$aBeck$BHrsg.
+028C/01 $9120476398$7Tp1$Vpiz$Agnd$0120476398$E1902$G1981$dFridolin$aStier$BÜbers.
+033A $pStuttgart$nkbw, Bibelwerk$55107964
+034D $a144 S.
+034I $a19 cm
+034M $aIll.
+041A $9040727254$7Tu1$Vwit$Agnd$04072725-7$tBibel$pIjob
+041A/09 $eDE-101$rDE-101
+044N $bVLB-FS$aHiob
+044N $bVLB-PF$aBB: Gebunden
+044N $bVLB-PG$aRT600: Bibeln (AT)
+044N $bVLB-WI$a1: Hardcover, Softcover, Karte
+044N $bVLB-WG$a548: Religion, Theologie / Bibelausgaben, Gesangbücher
+045E $e220$f230
+045F $eDDC22ger$a223.1
+045F/01 $a223.1
+047A $SFE$amar
+047A $SERW$abö
+047I $u$$c04$dDNB$e1
+
+001@ $01-2$a5
+001A $01240:11-12-02
+001B $09999:31-03-09$t23:51:03.000
+001D $01240:20-03-09
+001U $0utf8
+001X $00
+002@ $0Aa
+003@ $0965850757
+004A $0978-3-8262-1315-1$fPp. : EUR 12.95, sfr 23.30
+004A $03-8262-1315-7$fPp. : EUR 12.95, sfr 23.30
+004K $09783826213151
+006T $003,N04,2003
+006U $009,A15,2713
+006V $02304402
+007I $So$0317697750
+010@ $ager
+011@ $a2009$n[2009?]
+017A $ara$asi
+019@ $aXA-DE-NI
+021A $aChristoph Kolumbus$ddie Entdeckung der Neuen Welt$hJohannes März
+028A $9101615930$7Tn3$Agnd$0101615930$dJohannes$aMärz
+032B $gndr$aNeuausg. der Orig.-Ausg. [Leipzig, Spamer], 1906
+033A $pHolzminden$nReprint-Verl. Leipzig$55107200
+034D $a162 S.
+034I $a22 cm
+034M $aIll.
+041A $9118564994$7Tp1$Vpiz$Agnd$0118564994$E1451$G1506$dCristoforo$aColombo
+041A/01 $af Biographie
+041A/08 $f12
+041A/09 $eDE-101$rDE-101
+044N $bVLB-FS$aChristoph Columbus
+044N $bVLB-FS$aSeefahrer
+044N $bVLB-FS$aEntdecker
+044N $bVLB-FS$aHistorische Seefahrt
+044N $bVLB-FS$aGeographie
+044N $bVLB-PF$a00: (unbekannt)
+044N $bVLB-WI$a1: Hardcover, Softcover, Karte
+044N $bVLB-WG$a552: Geschichte / Allgemeines, Lexika
+045E $e970
+045F $eDDC22ger$a970.015092
+045F/01 $a970.015
+045F/03 $f092
+047A $SFE$aurm
+047A $SERW$asum
+047I $u$$c04$dDNB$e1
+
+001@ $01-2$a5
+001A $01240:13-12-02
+001B $09999:05-04-17$t22:43:04.000
+001D $01240:22-12-16
+001U $0utf8
+001X $00
+002@ $0AF
+002C $aText$btxt
+002D $aohne Hilfsmittel zu benutzen$bn
+002E $aBand$bnc
+002N $a2$bi
+003@ $0965883760
+004A $0978-3-89669-741-7$fFesteinband
+004A $03-89669-741-2
+004K $09783896697417
+006T $003,N04,0346
+006U $017,A15
+006V $029ae1f502c674f10b2f06f09ecf2479e
+007G $aDNB$0965883760
+007I $So$0959276787
+010@ $ager
+010E $erda
+011@ $a2016$n[2016]
+013D $9041434137$7Ts1$Vsaz$Agnd$04143413-4$aAufsatzsammlung
+017A $ara$asf
+019@ $aXA-DE-BW
+021A $aSchriften zur Musik$hAlfred Schütz ; herausgegeben von Gerd Sebald und Andreas Georg Stascheit
+028A $9118611135$7Tp1$Vpiz$Agnd$0118611135$E1899$G1959$dAlfred$aSchutz$BVerfasser$4aut
+028C $9157296059$7Tn3$Agnd$0157296059$dGerd$aSebald$BHerausgeber$4edt
+028C $dAndreas$aStascheit$BHrsg.
+033A $pKonstanz$pMünchen$nUVK Verlagsgesellschaft$55107550
+034D $a264 Seiten
+034I $a22 cm
+034M $aNotenbeispiele
+036D $x17$9966648358$gAc$7Tp1$Vpiz$Agnd$0118611135$E1899$G1959$dAlfred$aSchutz$FVerfasser$4aut$YWerkausgabe$hAlfred Schütz. Hrsg. von Richard Grathoff ...$6Konstanz ; München : UVK Verlagsgesellschaft$H2003$lBand 7
+041A $9040408027$7Ts1$Vsaz$Agnd$04040802-4$aMusik
+041A/09 $eDE-101$rDE-101
+044N $bVLB-PF$a00: (unbekannt)
+045E $e780$f100
+045F $eDDC22ger$a780.1
+045F/01 $a780.1
+047A $SERW-F$aRi
+047A $SFE$avol
+047I $u$$c04$dDNB$e1
+
+001@ $01-2$a5
+001A $01240:15-01-03
+001B $09999:17-02-09$t23:50:23.000
+001D $01240:25-11-08
+001U $0utf8
+001X $00
+002@ $0Aa
+003@ $0966127919
+004A $0978-3-525-36704-9$fPp. : EUR 59.90
+004K $09783525367049
+006T $003,N08,1899
+006U $009,A09,2145
+006V $0f90c3e7737e646298480c5c23de56cbc
+007I $So$0310126765
+010@ $ager
+011@ $a2009
+017A $ara$ali$asf
+019@ $aXA-DE-NI
+021A $aMenschentier und Tiermensch$dDiskurse der Grenzziehung und Grenzüberschreitung im Mittelalter$hUdo Friedrich
+028A $9114026920$7Tp1$Vpiz$Agnd$0114026920$E1956$dUdo$aFriedrich
+033A $pGöttingen$nVandenhoeck & Ruprecht$55109160
+034D $a437 S.
+034I $a24 cm
+036F $x15$902482710X$gAdvz$i2112738-4$YHistorische Semantik$pGöttingen$JVandenhoeck & Ruprecht$lBd. 5
+037A $aLiteraturverz. S. 395 - 432
+041A $904059758X$7Ts1$Vsaz$Agnd$04059758-1$aTheologie
+041A/01 $9040386392$7Ts1$Vsaz$Agnd$04038639-9$aMensch
+041A/02 $9040600874$7Ts1$Vsaz$Agnd$04060087-7$aTiere
+041A/03 $9040465144$7Ts1$Vsaz$Agnd$04046514-7$aPolitik
+041A/04 $9040359646$7Ts1$Vsaz$Agnd$04035964-5$aLiteratur
+041A/05 $9043169899$7Ts1$Vsaz$Agnd$04316989-2$aDiskurstheorie
+041A/08 $f123456$f231456$f321456$f423156$f523416$f612345
+041A/09 $eDE-101$rDE-101
+044N $bVLB-PF$a00: (unbekannt)
+045E $e900$f830
+045F $eDDC22ger$a901
+045F/01 $a901
+047A $SFE$aman
+047A $SERW$akr
+047I $u$$c04$dDNB$e1
+
+001@ $01-2$a5
+001A $01240:21-01-03
+001B $09999:03-03-09$t23:50:26.000
+001D $01240:10-02-09
+001U $0utf8
+001X $00
+002@ $0Aa
+003@ $0966183525
+004D $0978-3-8169-2242-1$fkart. : EUR 29.95
+004K $09783816922421
+006T $003,N09,0236
+006U $009,A11,0158
+006V $02320856
+007I $So$0312686787
+010@ $ager
+011@ $a2009
+017A $ara$asi$ali
+019@ $aXA-DE-BW
+021A $aAktive Entspannung und Stressbewältigung$dwirksame Methoden für Vielbeschäftigte$hAngelika Wagner-Link
+028A $9115619526$7Tp3$Vpiz$Agnd$0115619526$E1950$dAngelika$aWagner-Link
+032@ $g16$a6., völlig neu bearb. Aufl.
+033A $pRenningen$nexpert-Verl.  $55107077
+034D $a193 S.
+034I $a21 cm
+034M $agraph. Darst.
+037A $aLiteraturverz. S. 188 - 190
+041A $9042026466$7Ts1$Vsaz$Agnd$04202646-5$aStressbewältigung
+041A/01 $9041524187$7Ts1$Vsaz$Agnd$04152418-4$aEntspannungsübung
+041A/08 $f12$f21
+041A/09 $eDE-101$rDE-101
+044N $bVLB-FS$aEntspannung
+044N $bVLB-PF$aBC: Paperback
+044N $bVLB-WI$a1: Hardcover, Softcover, Karte
+044N $bVLB-WG$a531: Psychologie / Psychologische Ratgeber
+045E $e150
+045F $eDDC22ger$a155.9042
+045F/01 $a155.9042
+047A $SFE$aHen
+047A $SERW$amh
+047I $u$$c04$dDNB$e1
+
+001@ $01-2$a5
+001A $01240:21-01-03
+001B $01240:04-11-09$t16:31:21.000
+001D $01240:25-11-08
+001U $0utf8
+001X $00
+002@ $0Aa
+003@ $096618629X
+004A $0978-3-7720-2992-9$cFrancke$f kart. : EUR 16.90, ca. sfr 30.50
+004A $0978-3-8252-2397-7$cUTB$f kart. : EUR 16.90, ca. sfr 30.50
+004K $09783825223977
+006T $003,N09,1502
+006U $008,A51,0975
+006V $03607160343d54d85909739b366cd6300
+007I $So$0722917027
+010@ $ager
+011@ $a2008
+017A $ara$ali$asf
+019@ $aXA-DE-BW$aXA-CH
+021A $aJugendsprache$deine Einführung$hEva Neuland
+028A $9124405983$7Tp3$Vpiz$Agnd$0124405983$E1947$dEva$aNeuland
+033A $pTübingen$pBasel$nFrancke
+034D $aXII, 210 S.
+034I $a22 cm
+034M $aIll., graph. Darst.
+036F $x42397$901513430X$gAdvz$i972280-4$YUTB$p[Wechselnde Verlagsorte und Verleger]$l2397
+037A $aLiteraturverz. S. 181 - 197
+041A $9041132920$7Ts1$Vsis$Agnd$04113292-0$aDeutsch
+041A/01 $9040289370$7Ts1$Vsaz$Agnd$04028937-0$aJugendsprache

--- a/metafacture-runner/src/main/dist/examples/read/pica/read-non-normalized-pica.flux
+++ b/metafacture-runner/src/main/dist/examples/read/pica/read-non-normalized-pica.flux
@@ -1,0 +1,12 @@
+// opens file 'fileName', interprets the content as non normalized serialized
+// pica+ and writes to stdout
+
+default fileName = FLUX_DIR + "nonNormalized.pica";
+
+fileName|
+open-file|
+as-lines|
+lines-to-records|
+decode-pica(normalizedSerialization="false", ignoreMissingIdn="true")|
+encode-formeta(style="multiline")|
+write("stdout");

--- a/metafacture-strings/src/main/java/org/metafacture/strings/LineRecorder.java
+++ b/metafacture-strings/src/main/java/org/metafacture/strings/LineRecorder.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 hbz
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.metafacture.strings;
+
+import org.metafacture.framework.FluxCommand;
+import org.metafacture.framework.ObjectReceiver;
+import org.metafacture.framework.annotations.Description;
+import org.metafacture.framework.annotations.In;
+import org.metafacture.framework.annotations.Out;
+import org.metafacture.framework.helpers.DefaultObjectPipe;
+
+/**
+ * Joins strings and emits them as records when a line matches the pattern.
+ *
+ * @author Pascal Christoph (dr0i).
+ *
+ */
+@Description("Joins strings and emits them as records when a line matches the pattern.")
+@In(String.class)
+@Out(String.class)
+@FluxCommand("lines-to-records")
+public final class LineRecorder
+        extends DefaultObjectPipe<String, ObjectReceiver<String>> {
+
+    private final int SB_CAPACITY = 4096 * 7;
+    private String recordMarkerRegexp = "^\\s*$"; // empty line is default
+    StringBuilder record = new StringBuilder(SB_CAPACITY);
+
+    public void setRecordMarkerRegexp(final String regexp) {
+        this.recordMarkerRegexp = regexp;
+    }
+
+    @Override
+    public void process(final String line) {
+        assert !isClosed();
+        if (line.matches(recordMarkerRegexp)) {
+            getReceiver().process(record.toString());
+            record = new StringBuilder(SB_CAPACITY);
+        } else
+            record.append(line);
+    }
+
+}

--- a/metafacture-strings/src/main/resources/flux-commands.properties
+++ b/metafacture-strings/src/main/resources/flux-commands.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2016 Christoph Böhme
+# Copyright 2016, 2019 Christoph Böhme and Pascal Christoph
 #
 # Licensed under the Apache License, Version 2.0 the "License";
 # you may not use this file except in compliance with the License.
@@ -21,3 +21,4 @@ filter-strings org.metafacture.strings.StringFilter
 match org.metafacture.strings.StringMatcher
 read-string org.metafacture.strings.StringReader
 normalize-unicode-string org.metafacture.strings.UnicodeNormalizer
+lines-to-records org.metafacture.strings.LineRecorder

--- a/metafacture-strings/src/test/java/org/metafacture/strings/LineRecorderTest.java
+++ b/metafacture-strings/src/test/java/org/metafacture/strings/LineRecorderTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019 Pascal Christoph
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.metafacture.strings;
+
+import static org.mockito.Mockito.inOrder;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.metafacture.framework.ObjectReceiver;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Tests for class {@link LineRecorder}.
+ *
+ * @author Pascal Christoph (dr0i)
+ *
+ */
+public final class LineRecorderTest {
+
+    private static final String RECORD1_PART1 = "a1\n";
+    private static final String RECORD1_PART2 = "a2\n";
+    private static final String RECORD1_ENDMARKER = "\n";
+
+    private static final String RECORD2_PART1 = "b1\n";
+    private static final String RECORD2_PART2 = "b2\n";
+    private static final String RECORD2_ENDMARKER = "\n";
+
+    private static final String RECORD3_PART1 = "c1\n";
+    private static final String RECORD3_PART2 = "c2\n";
+    private static final String RECORD3_ENDMARKER = "EOR";
+
+    private LineRecorder lineRecorder;
+
+    @Mock
+    private ObjectReceiver<String> receiver;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        lineRecorder = new LineRecorder();
+        lineRecorder.setReceiver(receiver);
+    }
+
+    @Test
+    public void shouldEmitRecords() {
+        lineRecorder.process(RECORD1_PART1);
+        lineRecorder.process(RECORD1_PART2);
+        lineRecorder.process(RECORD1_ENDMARKER);
+
+        final InOrder ordered = inOrder(receiver);
+        ordered.verify(receiver).process(RECORD1_PART1 + RECORD1_PART2);
+
+        lineRecorder.process(RECORD2_PART1);
+        lineRecorder.process(RECORD2_PART2);
+        lineRecorder.process(RECORD2_ENDMARKER);
+
+        ordered.verify(receiver).process(RECORD2_PART1 + RECORD2_PART2);
+        ordered.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void shouldEmitRecordWithNonDefaultRecordMarker() {
+        lineRecorder.setRecordMarkerRegexp(RECORD3_ENDMARKER);
+        lineRecorder.process(RECORD3_PART1);
+        lineRecorder.process(RECORD3_PART2);
+        lineRecorder.process(RECORD3_ENDMARKER);
+
+        final InOrder ordered = inOrder(receiver);
+        ordered.verify(receiver).process(RECORD3_PART1 + RECORD3_PART2);
+        ordered.verifyNoMoreInteractions();
+    }
+
+}


### PR DESCRIPTION
This should be backwards compatible as the default is still the normalized
serialization.

- add LineRecorder to split non-normalized serialized PICA+ records
- add testing of LineRecorder
- add flux example
- add flux command

See #296.