### PR TITLE
Fix exception by removing a whitespace

### DIFF
--- a/metafacture-biblio/src/main/resources/flux-commands.properties
+++ b/metafacture-biblio/src/main/resources/flux-commands.properties
@@ -16,7 +16,7 @@
 decode-marc21 org.metafacture.biblio.marc21.Marc21Decoder
 encode-marc21 org.metafacture.biblio.marc21.Marc21Encoder
 handle-marcxml org.metafacture.biblio.marc21.MarcXmlHandler
-encode-marcxml org.metafacture.biblio.marc21.MarcXmlEncoder 
+encode-marcxml org.metafacture.biblio.marc21.MarcXmlEncoder
 
 decode-pica org.metafacture.biblio.pica.PicaDecoder
 encode-pica org.metafacture.biblio.pica.PicaEncoder


### PR DESCRIPTION
The whitespace at the end of the flux-commands.properties resulted in a
"class not found: org.metafacture.biblio.marc21.MarcXmlEncoder" exception
when executing "flush.sh".

See #300.