### PR TITLE
Add another name to flux command "stream-to-xml"

### DIFF
--- a/metafacture-runner/src/main/dist/examples/marc21-to-edm/MARC21-EDM.flux
+++ b/metafacture-runner/src/main/dist/examples/marc21-to-edm/MARC21-EDM.flux
@@ -15,5 +15,5 @@ handle-marcxml|
 morph(FLUX_DIR + "MARC21-EDM.xml", *)|
 add-oreaggregation|
 rdf-macros|
-stream-to-xml(roottag="rdf:RDF", recordtag="", namespacefile= FLUX_DIR+"edm-namespaces.properties")|
+encode-xml(roottag="rdf:RDF", recordtag="", namespacefile= FLUX_DIR+"edm-namespaces.properties")|
 write(out);

--- a/metafacture-xml/src/main/resources/flux-commands.properties
+++ b/metafacture-xml/src/main/resources/flux-commands.properties
@@ -16,6 +16,7 @@
 handle-cg-xml org.metafacture.xml.CGXmlHandler
 handle-generic-xml org.metafacture.xml.GenericXmlHandler
 stream-to-xml org.metafacture.xml.SimpleXmlEncoder
+encode-xml org.metafacture.xml.SimpleXmlEncoder
 decode-xml org.metafacture.xml.XmlDecoder
 split-xml-elements org.metafacture.xml.XmlElementSplitter
 write-xml-files org.metafacture.xml.XmlFilenameWriter


### PR DESCRIPTION
This name points to SimpleXmlEncoder.
Keeping the old name for compatibility reasons.

See #308.