### PR TITLE
Fix flux.bat for running on Windows

### DIFF
--- a/metafacture-runner/src/main/scripts/flux.bat
+++ b/metafacture-runner/src/main/scripts/flux.bat
@@ -55,7 +55,7 @@ REM default we make sure that it can always be substituted.
 IF "x%FLUX_JAVA_OPTIONS%" == "x" (
     REM The space character at the end of the following
     REM line is important and must not be removed:
-    SET FLUX_JAVA_OPTIONS=
+    SET FLUX_JAVA_OPTIONS= 
 )
 FOR /F "tokens=1,* delims==" %%I IN ('SET') DO (
     SET JAVA_OPTS=!JAVA_OPTS:$%%I=%%J!


### PR DESCRIPTION
Running flux.bat on Windows failed with a
`java.lang.ClassNotFoundException: $FLUX_JAVA_OPTIONS`

As the comment above the changed line mentions, the space is important. Seems it was accidentally removed when reformatting the file in 3e7f486f5f826a349b0773395dc1be7a8af26ccd