### PR TITLE
ADD support of a custom separator as FLUX parameter for CsvDecoder 

### DIFF
--- a/metafacture-csv/src/main/java/org/metafacture/csv/CsvDecoder.java
+++ b/metafacture-csv/src/main/java/org/metafacture/csv/CsvDecoder.java
@@ -42,7 +42,7 @@ import com.opencsv.CSVReader;
 public final class CsvDecoder extends DefaultObjectPipe<String, StreamReceiver>  {
 
     private static final char DEFAULT_SEP = ',';
-    private final char separator;
+    private char separator;
 
     private String[] header = new String[0];
     private int count;
@@ -51,9 +51,9 @@ public final class CsvDecoder extends DefaultObjectPipe<String, StreamReceiver> 
     /**
      * @param separator to split lines
      */
-    public CsvDecoder(final char separator) {
+    public CsvDecoder(final String separator) {
         super();
-        this.separator = separator;
+        this.separator = separator.charAt(0);
     }
 
     public CsvDecoder() {
@@ -109,4 +109,5 @@ public final class CsvDecoder extends DefaultObjectPipe<String, StreamReceiver> 
         this.hasHeader = hasHeader;
     }
 
+    public void setSeparator(final String separator) { this.separator = separator.charAt(0); }
 }

--- a/metafacture-csv/src/main/java/org/metafacture/csv/CsvDecoder.java
+++ b/metafacture-csv/src/main/java/org/metafacture/csv/CsvDecoder.java
@@ -56,6 +56,14 @@ public final class CsvDecoder extends DefaultObjectPipe<String, StreamReceiver> 
         this.separator = separator.charAt(0);
     }
 
+    /**
+     * @param separator to split lines
+     */
+    public CsvDecoder(final char separator) {
+        super();
+        this.separator = separator;
+    }
+
     public CsvDecoder() {
         super();
         this.separator = DEFAULT_SEP;

--- a/metafacture-csv/src/test/java/org/metafacture/csv/CsvDecoderTest.java
+++ b/metafacture-csv/src/test/java/org/metafacture/csv/CsvDecoderTest.java
@@ -77,7 +77,7 @@ public final class CsvDecoderTest {
     @Test
     public void testTabSeparated() {
 
-        decoder.setSeparator('\t');
+        decoder.setSeparator("\t");
 
         decoder.process("a\tb\tc");
         final InOrder ordered = inOrder(receiver);

--- a/metafacture-csv/src/test/java/org/metafacture/csv/CsvDecoderTest.java
+++ b/metafacture-csv/src/test/java/org/metafacture/csv/CsvDecoderTest.java
@@ -74,4 +74,18 @@ public final class CsvDecoderTest {
         ordered.verify(receiver).endRecord();
     }
 
+    @Test
+    public void testTabSeparated() {
+
+        decoder.setSeparator('\t');
+
+        decoder.process("a\tb\tc");
+        final InOrder ordered = inOrder(receiver);
+        ordered.verify(receiver).startRecord("1");
+        ordered.verify(receiver).literal("h1", "a");
+        ordered.verify(receiver).literal("h2", "b");
+        ordered.verify(receiver).literal("h3", "c");
+        ordered.verify(receiver).endRecord();
+    }
+
 }


### PR DESCRIPTION
assume that the first char of a String is meant for this case (reason: char is needed for CSVReader)