### PR TITLE
Add original OAI-PMH opener by @dr0i

### DIFF
--- a/metafacture-biblio/build.gradle
+++ b/metafacture-biblio/build.gradle
@@ -21,6 +21,8 @@ dependencies {
   api project(':metafacture-framework')
   implementation project(':metafacture-commons')
   implementation project(':metafacture-flowcontrol')
+  implementation 'org.dspace:oclc-harvester2:0.1.12'
+  implementation 'xalan:xalan:2.7.1'
   testImplementation 'junit:junit:4.12'
   testImplementation 'org.mockito:mockito-core:2.5.5'
 }

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/OaiPmhOpener.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/OaiPmhOpener.java
@@ -1,0 +1,127 @@
+/* Copyright 2013 Pascal Christoph.
+ * Licensed under the Eclipse Public License 1.0 */
+
+package org.metafacture.biblio;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerException;
+
+import org.metafacture.framework.MetafactureException;
+import org.metafacture.framework.ObjectReceiver;
+import org.metafacture.framework.annotations.Description;
+import org.metafacture.framework.annotations.In;
+import org.metafacture.framework.annotations.Out;
+import org.metafacture.framework.helpers.DefaultObjectPipe;
+import org.xml.sax.SAXException;
+
+import ORG.oclc.oai.harvester2.app.RawWrite;
+
+/**
+ * Opens an OAI-PMH stream and passes a reader to the receiver.
+ * 
+ * @author Pascal Christoph (dr0i)
+ * 
+ */
+@Description("Opens an OAI-PMH stream and passes a reader to the receiver. Mandatory arguments are: BASE_URL, DATE_FROM, DATE_UNTIL, METADATA_PREFIX, SET_SPEC .")
+@In(String.class)
+@Out(java.io.Reader.class)
+public final class OaiPmhOpener extends
+		DefaultObjectPipe<String, ObjectReceiver<Reader>> {
+
+	private String encoding = "UTF-8";
+
+	final ByteArrayOutputStream OUTPUT_STREAM = new ByteArrayOutputStream();
+
+	private String dateFrom;
+
+	private String dateUntil;
+
+	private String setSpec;
+
+	private String metadataPrefix;
+
+	/**
+	 * Default constructor
+	 */
+	public OaiPmhOpener() {
+
+	}
+
+	/**
+	 * Sets the encoding to use. The default setting is UTF-8.
+	 * 
+	 * @param encoding new default encoding
+	 */
+	public void setEncoding(final String encoding) {
+		this.encoding = encoding;
+	}
+
+	/**
+	 * Sets the beginning of the retrieving of updated data. The form is
+	 * YYYY-MM-DD .
+	 * 
+	 * @param dateFrom The form is YYYY-MM-DD .
+	 */
+	public void setDateFrom(final String dateFrom) {
+		this.dateFrom = dateFrom;
+	}
+
+	/**
+	 * Sets the end of the retrieving of updated data. The form is YYYY-MM-DD .
+	 * 
+	 * @param dateUntil The form is YYYY-MM-DD .
+	 */
+	public void setDateUntil(final String dateUntil) {
+		this.dateUntil = dateUntil;
+	}
+
+	/**
+	 * Sets the OAI-PM metadata prefix .
+	 * 
+	 * @param metadataPrefix the OAI-PM metadata prefix
+	 */
+	public void setMetadataPrefix(final String metadataPrefix) {
+		this.metadataPrefix = metadataPrefix;
+	}
+
+	/**
+	 * Sets the OAI-PM set specification .
+	 * 
+	 * @param setSpec th OAI-PM set specification
+	 */
+	public void setSetSpec(final String setSpec) {
+		this.setSpec = setSpec;
+	}
+
+	@Override
+	public void process(final String baseUrl) {
+
+		try {
+			RawWrite.run(baseUrl, this.dateFrom, this.dateUntil, this.metadataPrefix,
+					this.setSpec, OUTPUT_STREAM);
+		} catch (IOException e) {
+			e.printStackTrace();
+		} catch (ParserConfigurationException e) {
+			e.printStackTrace();
+		} catch (SAXException e) {
+			e.printStackTrace();
+		} catch (TransformerException e) {
+			e.printStackTrace();
+		} catch (NoSuchFieldException e) {
+			e.printStackTrace();
+		}
+		try {
+			getReceiver().process(
+					new InputStreamReader(new ByteArrayInputStream(OUTPUT_STREAM
+							.toByteArray()), encoding));
+		} catch (IOException e) {
+			throw new MetafactureException(e);
+		}
+	}
+}

--- a/metafacture-biblio/src/main/resources/flux-commands.properties
+++ b/metafacture-biblio/src/main/resources/flux-commands.properties
@@ -27,3 +27,5 @@ handle-mabxml org.metafacture.biblio.AlephMabXmlHandler
 handle-comarcxml org.metafacture.biblio.ComarcXmlHandler
 decode-aseq org.metafacture.biblio.AseqDecoder
 decode-mab org.metafacture.biblio.MabDecoder
+
+open-oaipmh org.metafacture.biblio.OaiPmhOpener


### PR DESCRIPTION
From https://github.com/hbz/metafacture-core/blob/4.0.0-HBZ-SNAPSHOT/src/main/java/org/culturegraph/mf/stream/source/OaiPmhOpener.java

Sample flux usage:

```
"https://duepublico2.uni-due.de/servlets/OAIDataProvider"
|open-oaipmh(metadataPrefix="mods", dateFrom="2020-04-14")
|decode-xml
|handle-generic-xml
|encode-formeta(style="multiline")
|write("stdout");
```

To be used in https://gitlab.com/oersi/oersi-etl/-/issues/1, leaving as draft pull request until usage works.