### PR TITLE
Allow to omit id in JsonToElasticsearchBulk

### DIFF
--- a/metafacture-elasticsearch/src/main/java/org/metafacture/elasticsearch/JsonToElasticsearchBulk.java
+++ b/metafacture-elasticsearch/src/main/java/org/metafacture/elasticsearch/JsonToElasticsearchBulk.java
@@ -79,6 +79,16 @@ public class JsonToElasticsearchBulk extends
     private String index;
 
     /**
+     * As an id is not required it can be omitted.
+     *
+     * @param type The Elasticsearch index type
+     * @param index The Elasticsearch index name
+     */
+    public JsonToElasticsearchBulk(String type, String index) {
+        this(new String[] { }, type, index);
+    }
+
+    /**
      * @param idPath The key path of the JSON value to be used as the ID for the record
      * @param type The Elasticsearch index type
      * @param index The Elasticsearch index name
@@ -116,7 +126,7 @@ public class JsonToElasticsearchBulk extends
             Map<String, Object> detailsMap = new HashMap<String, Object>();
             Map<String, Object> indexMap = new HashMap<String, Object>();
             indexMap.put("index", detailsMap);
-            detailsMap.put("_id", findId(json));
+            if (idPath.length > 0) detailsMap.put("_id", findId(json));
             detailsMap.put("_type", type);
             detailsMap.put("_index", index);
             mapper.writeValue(stringWriter, indexMap);
@@ -129,10 +139,6 @@ public class JsonToElasticsearchBulk extends
     }
 
     private Object findId(Object value) {
-        if (idPath.length < 1) {
-            return null;
-        }
-
         for (final String key : idPath) {
             if (value instanceof Map) {
                 @SuppressWarnings("unchecked")

--- a/metafacture-elasticsearch/src/test/java/org/metafacture/elasticsearch/JsonToElasticsearchBulkTest.java
+++ b/metafacture-elasticsearch/src/test/java/org/metafacture/elasticsearch/JsonToElasticsearchBulkTest.java
@@ -45,7 +45,7 @@ public final class JsonToElasticsearchBulkTest {
     private static final String TYPE1  = "T1";
     private static final String INDEX1 = "I1";
 
-    private static final String METADATA = "{'index':{'_index':'I1','_type':'T1','_id':%s}}";
+    private static final String METADATA = "{'index':{'_index':'I1','_type':'T1'%s}}";
 
     private static final String ENTITY_SEPARATOR1 = ".";
     private static final String ENTITY_SEPARATOR2 = ":";
@@ -122,7 +122,13 @@ public final class JsonToElasticsearchBulkTest {
     @Test
     public void testShouldNotExtractEmptyIdPath() {
         setBulk(new String[0]);
-        shouldNotExtractId("{'L1':'V1','L2':'V2','L3':'V3'}");
+        shouldExtractId("{'L1':'V1','L2':'V2','L3':'V3'}", null);
+    }
+
+    @Test
+    public void testShouldNotExtractOmittedIdPath() {
+        bulk = new JsonToElasticsearchBulk(TYPE1, INDEX1);
+        shouldExtractId("{'L1':'V1','L2':'V2','L3':'V3'}", null);
     }
 
     @Test
@@ -220,7 +226,9 @@ public final class JsonToElasticsearchBulkTest {
         bulk.setReceiver(receiver);
         bulk.process(fixQuotes(obj));
 
-        verify(receiver).process(fixQuotes(String.format(METADATA, idValue) + "\n" + resultObj));
+        final String metadata = String.format(METADATA, idValue != null ? ",'_id':" + idValue : "");
+
+        verify(receiver).process(fixQuotes(metadata + "\n" + resultObj));
         verifyNoMoreInteractions(receiver);
     }
 


### PR DESCRIPTION
Elasticsearch creates an internal id on its own when omitting and id
in the json bulk.