### PR TITLE
Support flux options via setters in JsonToElasticsearchBulk

### DIFF
--- a/metafacture-elasticsearch/src/main/java/org/metafacture/elasticsearch/JsonToElasticsearchBulk.java
+++ b/metafacture-elasticsearch/src/main/java/org/metafacture/elasticsearch/JsonToElasticsearchBulk.java
@@ -78,6 +78,25 @@ public class JsonToElasticsearchBulk extends
     private String type;
     private String index;
 
+    public void setIdKey(String idKey) {
+        this.idPath = new String[]{idKey};
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public void setIndex(String index) {
+        this.index = index;
+    }
+
+    public JsonToElasticsearchBulk() {
+        super();
+        this.idPath = new String[]{};
+        this.type = null;
+        this.index = null;
+    }
+
     /**
      * As an id is not required it can be omitted.
      *


### PR DESCRIPTION
For flux usage like:

`json-to-elasticsearch-bulk(idKey="id",type="oerbw",index="oersi")`