### PR TITLE
107 pass data through metamorph

### DIFF
--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/marc21/MarcXmlEncoder.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/marc21/MarcXmlEncoder.java
@@ -103,8 +103,7 @@ public final class MarcXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Strin
     /**
      * Formats the resulting xml, by indentation.
      * 
-     * @param formatted
-     *            True, if formatting is activated.
+     * @param formatted True, if formatting is activated.
      */
     public void setFormatted(boolean formatted) {
         this.formatted = formatted;
@@ -144,10 +143,10 @@ public final class MarcXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Strin
         currentEntity = name;
         if (!name.equals(Marc21EventNames.LEADER_ENTITY)) {
             if (name.length() != 5) {
-                 String message = String.format("Entity too short." + "Got a string ('%s') of length %d."
-                         + "Expected a length of 5 (field + indicators).", name, name.length());
-                 throw new MetafactureException(message);
-             }
+                String message = String.format("Entity too short." + "Got a string ('%s') of length %d."
+                        + "Expected a length of 5 (field + indicators).", name, name.length());
+                throw new MetafactureException(message);
+            }
 
             String tag = name.substring(0, 3);
             String ind1 = name.substring(3, 4);
@@ -156,9 +155,10 @@ public final class MarcXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Strin
             writeRaw(String.format(DATAFIELD_OPEN_TEMPLATE, tag, ind1, ind2));
             prettyPrintNewLine();
             incrementIndentationLevel();
-        } else { prettyPrintIndentation();
-        writeRaw(LEADER_OPEN_TEMPLATE);
-    }
+        } else {
+            prettyPrintIndentation();
+            writeRaw(LEADER_OPEN_TEMPLATE);
+        }
 
     }
 
@@ -176,22 +176,22 @@ public final class MarcXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Strin
     @Override
     public void literal(final String name, final String value) {
         if (value == null || value.isEmpty())
-        return;
+            return;
         if (currentEntity.equals("")) {
             prettyPrintIndentation();
-            writeRaw(String.format(CONTROLFIELD_OPEN_TEMPLATE, name.replaceFirst("\\W","")));
+            writeRaw(String.format(CONTROLFIELD_OPEN_TEMPLATE, name.replaceFirst("\\W", "")));
             writeEscaped(value.trim());
             writeRaw(CONTROLFIELD_CLOSE);
             prettyPrintNewLine();
         } else if (!currentEntity.equals(Marc21EventNames.LEADER_ENTITY)) {
             prettyPrintIndentation();
-            writeRaw(String.format(SUBFIELD_OPEN_TEMPLATE, name.charAt(name.indexOf('.')+1)));
+            writeRaw(String.format(SUBFIELD_OPEN_TEMPLATE, name.charAt(name.indexOf('.') + 1)));
             writeEscaped(value.trim());
             writeRaw(SUBFIELD_CLOSE);
             prettyPrintNewLine();
         } else {
             {
-               writeRaw(value + LEADER_CLOSE_TEMPLATE);
+                writeRaw(value + LEADER_CLOSE_TEMPLATE);
                 prettyPrintNewLine();
             }
         }
@@ -245,8 +245,8 @@ public final class MarcXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Strin
 
     private void prettyPrintIndentation() {
         if (formatted) {
-          String prefix = String.join("", Collections.nCopies(indentationLevel, INDENT));
-          builder.append(prefix);
+            String prefix = String.join("", Collections.nCopies(indentationLevel, INDENT));
+            builder.append(prefix);
         }
     }
 

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/marc21/MarcXmlEncoder.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/marc21/MarcXmlEncoder.java
@@ -144,10 +144,10 @@ public final class MarcXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Strin
         currentEntity = name;
         if (!name.equals(Marc21EventNames.LEADER_ENTITY)) {
             if (name.length() != 5) {
-                String message = String.format("Entity too short." + "Got a string ('%s') of length %d."
-                        + "Expected a length of 5 (field + indicators).", name, name.length());
-                throw new MetafactureException(message);
-            }
+                 String message = String.format("Entity too short." + "Got a string ('%s') of length %d."
+                         + "Expected a length of 5 (field + indicators).", name, name.length());
+                 throw new MetafactureException(message);
+             }
 
             String tag = name.substring(0, 3);
             String ind1 = name.substring(3, 4);
@@ -156,7 +156,10 @@ public final class MarcXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Strin
             writeRaw(String.format(DATAFIELD_OPEN_TEMPLATE, tag, ind1, ind2));
             prettyPrintNewLine();
             incrementIndentationLevel();
-        }
+        } else { prettyPrintIndentation();
+        writeRaw(LEADER_OPEN_TEMPLATE);
+    }
+
     }
 
     @Override
@@ -172,22 +175,23 @@ public final class MarcXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Strin
 
     @Override
     public void literal(final String name, final String value) {
+        if (value == null || value.isEmpty())
+        return;
         if (currentEntity.equals("")) {
             prettyPrintIndentation();
-            writeRaw(String.format(CONTROLFIELD_OPEN_TEMPLATE, name));
+            writeRaw(String.format(CONTROLFIELD_OPEN_TEMPLATE, name.replaceFirst("\\W","")));
             writeEscaped(value.trim());
             writeRaw(CONTROLFIELD_CLOSE);
             prettyPrintNewLine();
         } else if (!currentEntity.equals(Marc21EventNames.LEADER_ENTITY)) {
             prettyPrintIndentation();
-            writeRaw(String.format(SUBFIELD_OPEN_TEMPLATE, name));
+            writeRaw(String.format(SUBFIELD_OPEN_TEMPLATE, name.charAt(name.indexOf('.')+1)));
             writeEscaped(value.trim());
             writeRaw(SUBFIELD_CLOSE);
             prettyPrintNewLine();
         } else {
-            if (name.equals(Marc21EventNames.LEADER_ENTITY)) {
-                prettyPrintIndentation();
-                writeRaw(LEADER_OPEN_TEMPLATE + value + LEADER_CLOSE_TEMPLATE);
+            {
+               writeRaw(value + LEADER_CLOSE_TEMPLATE);
                 prettyPrintNewLine();
             }
         }
@@ -241,8 +245,8 @@ public final class MarcXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Strin
 
     private void prettyPrintIndentation() {
         if (formatted) {
-            String prefix = String.join("", Collections.nCopies(indentationLevel, INDENT));
-            builder.append(prefix);
+          String prefix = String.join("", Collections.nCopies(indentationLevel, INDENT));
+          builder.append(prefix);
         }
     }
 

--- a/metamorph-test/src/main/resources/schemata/metamorph.xsd
+++ b/metamorph-test/src/main/resources/schemata/metamorph.xsd
@@ -54,12 +54,14 @@
         <complexType>
             <sequence>
                 <element ref="tns:name" maxOccurs="1" minOccurs="0" />
+                <element ref="tns:version" maxOccurs="1" minOccurs="0" />
                 <element ref="tns:annotation" maxOccurs="1" minOccurs="0" />
             </sequence>
         </complexType>
     </element>
 
     <element name="name" type="string" />
+    <element name="version" type="string" />
     <element name="annotation" type="string" />
 
     <element name="macros">
@@ -302,9 +304,9 @@
             <attribute name="value" type="string" use="required" />
 
             <attribute name="reset" type="boolean" use="optional"
-                default="false" />
+                       default="false" />
             <attribute name="sameEntity" type="boolean" use="optional"
-                default="false" />
+                       default="false" />
             <attribute name="flushWith" type="string" use="optional" />
         </complexType>
     </element>

--- a/metamorph/src/main/java/org/metafacture/metamorph/Metamorph.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/Metamorph.java
@@ -268,8 +268,8 @@ public final class Metamorph implements StreamPipe<StreamReceiver>, NamedValuePi
         entityCountStack.push(Integer.valueOf(entityCount));
 
         flattener.startEntity(name);
-
-
+        if (maps.containsKey(METADATA) && maps.get(METADATA).getOrDefault("version","").equals("1.1"))
+            outputStreamReceiver.startEntity(name);
 
     }
 
@@ -278,7 +278,8 @@ public final class Metamorph implements StreamPipe<StreamReceiver>, NamedValuePi
         dispatch(flattener.getCurrentPath(), "", null);
         currentEntityCount = entityCountStack.pop().intValue();
         flattener.endEntity();
-
+        if (maps.containsKey(METADATA) && maps.get(METADATA).getOrDefault("version","").equals("1.1"))
+            outputStreamReceiver.endEntity();
     }
 
 

--- a/metamorph/src/main/resources/schemata/metamorph.xsd
+++ b/metamorph/src/main/resources/schemata/metamorph.xsd
@@ -54,12 +54,14 @@
         <complexType>
             <sequence>
                 <element ref="tns:name" maxOccurs="1" minOccurs="0" />
+                <element ref="tns:version" maxOccurs="1" minOccurs="0" />
                 <element ref="tns:annotation" maxOccurs="1" minOccurs="0" />
             </sequence>
         </complexType>
     </element>
 
     <element name="name" type="string" />
+    <element name="version" type="string" />
     <element name="annotation" type="string" />
 
     <element name="macros">


### PR DESCRIPTION
See #107.

This incorporates the fork used in https://github.com/hagbeck/metafacture-sandbox/tree/master/enrich_marcxml.

Introduces a new metamorph version.
Lightweight tagged with `metamorph_v1.1`.