### PR TITLE
Make MARCXML namespace for record elements configurable.

### DIFF
--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/marc21/MarcXmlHandler.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/marc21/MarcXmlHandler.java
@@ -45,7 +45,16 @@ public final class MarcXmlHandler extends DefaultXmlPipe<StreamReceiver> {
     private static final String LEADER = "leader";
     private static final String TYPE = "type";
     private String currentTag = "";
+    private String namespace = NAMESPACE;
     private StringBuilder builder = new StringBuilder();
+
+    public void setNamespace(final String namespace) {
+        this.namespace = namespace;
+    }
+
+    private boolean checkNamespace(final String uri) {
+        return namespace == null || namespace.equals(uri);
+    }
 
     @Override
     public void startElement(final String uri, final String localName, final String qName, final Attributes attributes)
@@ -58,7 +67,7 @@ public final class MarcXmlHandler extends DefaultXmlPipe<StreamReceiver> {
             }else if(CONTROLFIELD.equals(localName)){
                 builder = new StringBuilder();
                 currentTag = attributes.getValue("tag");
-            }else if(RECORD.equals(localName) && NAMESPACE.equals(uri)){
+            }else if(RECORD.equals(localName) && checkNamespace(uri)){
                 getReceiver().startRecord("");
                 getReceiver().literal(TYPE, attributes.getValue(TYPE));
             }else if(LEADER.equals(localName)){
@@ -77,7 +86,7 @@ public final class MarcXmlHandler extends DefaultXmlPipe<StreamReceiver> {
         }else if(CONTROLFIELD.equals(localName)){
             getReceiver().literal(currentTag, builder.toString().trim());
 
-        }else if(RECORD.equals(localName)  && NAMESPACE.equals(uri)){
+        }else if(RECORD.equals(localName) && checkNamespace(uri)){
             getReceiver().endRecord();
 
         }else if(LEADER.equals(localName)){

--- a/metafacture-biblio/src/test/java/org/metafacture/biblio/marc21/MarcXmlHandlerTest.java
+++ b/metafacture-biblio/src/test/java/org/metafacture/biblio/marc21/MarcXmlHandlerTest.java
@@ -16,6 +16,7 @@
 package org.metafacture.biblio.marc21;
 
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import org.junit.After;
 import org.junit.Before;
@@ -37,6 +38,8 @@ public final class MarcXmlHandlerTest {
     private static final String LEADER = "leader";
     private static final String CONTROLFIELD = "controlfield";
     private static final String NAMESPACE = "http://www.loc.gov/MARC21/slim";
+    private static final String RECORD = "record";
+    private static final String TYPE = "type";
 
     private MarcXmlHandler marcXmlHandler;
 
@@ -82,6 +85,48 @@ public final class MarcXmlHandlerTest {
         marcXmlHandler.endElement(NAMESPACE, LEADER, "");
 
         verify(receiver).literal("leader", leaderValue);
+    }
+
+    @Test
+    public void shouldRecognizeRecordsWithNamespace()
+            throws SAXException {
+        final AttributesImpl attributes = new AttributesImpl();
+
+        marcXmlHandler.startElement(NAMESPACE, RECORD, "", attributes);
+        marcXmlHandler.endElement(NAMESPACE, RECORD, "");
+
+        verify(receiver).startRecord("");
+        verify(receiver).literal(TYPE, null);
+        verify(receiver).endRecord();
+
+        verifyNoMoreInteractions(receiver);
+    }
+
+    @Test
+    public void shouldNotRecognizeRecordsWithoutNamespace()
+            throws SAXException {
+        final AttributesImpl attributes = new AttributesImpl();
+
+        marcXmlHandler.startElement(null, RECORD, "", attributes);
+        marcXmlHandler.endElement(null, RECORD, "");
+
+        verifyNoMoreInteractions(receiver);
+    }
+
+    @Test
+    public void issue330ShouldOptionallyRecognizeRecordsWithoutNamespace()
+            throws SAXException {
+        final AttributesImpl attributes = new AttributesImpl();
+
+        marcXmlHandler.setNamespace(null);
+        marcXmlHandler.startElement(null, RECORD, "", attributes);
+        marcXmlHandler.endElement(null, RECORD, "");
+
+        verify(receiver).startRecord("");
+        verify(receiver).literal(TYPE, null);
+        verify(receiver).endRecord();
+
+        verifyNoMoreInteractions(receiver);
     }
 
 }


### PR DESCRIPTION
Not all MARCXML sources specify the required namespace URI (notably, Alma General Publishing). By allowing the expected namespace to be configured, or even skipped (by setting it to `null`), this will resolve #330.

The record element is the only element that is restricted by namespace; however, the original [commit](https://sourceforge.net/p/culturegraph/code/1507/) doesn't provide any context as to why the change was introduced.