### PR TITLE
Allow flushing collectors to only emit when complete.

### DIFF
--- a/metamorph-api/src/main/java/org/metafacture/metamorph/api/helpers/AbstractFlushingCollect.java
+++ b/metamorph-api/src/main/java/org/metafacture/metamorph/api/helpers/AbstractFlushingCollect.java
@@ -24,10 +24,16 @@ package org.metafacture.metamorph.api.helpers;
  */
 public abstract class AbstractFlushingCollect extends AbstractCollect {
 
+    private boolean flushIncomplete = true;
+
+    public final void setFlushIncomplete(final boolean flushIncomplete) {
+        this.flushIncomplete = flushIncomplete;
+    }
+
     @Override
     public final void flush(final int recordCount, final int entityCount) {
         if (isSameRecord(recordCount) && sameEntityConstraintSatisfied(entityCount)) {
-            if(isConditionMet()) {
+            if(isConditionMet() && (flushIncomplete || isComplete())) {
                 emit();
             }
             if (getReset()) {

--- a/metamorph/src/main/resources/schemata/metamorph.xsd
+++ b/metamorph/src/main/resources/schemata/metamorph.xsd
@@ -283,6 +283,8 @@
             <attribute name="name" type="string" use="required" />
             <attribute name="value" type="string" use="required" />
 
+            <attribute name="flushIncomplete" type="boolean" use="optional"
+                default="true" />
             <attribute name="reset" type="boolean" use="optional"
                 default="false" />
             <attribute name="sameEntity" type="boolean" use="optional"
@@ -301,6 +303,8 @@
             <attribute name="name" type="string" use="required" />
             <attribute name="value" type="string" use="required" />
 
+            <attribute name="flushIncomplete" type="boolean" use="optional"
+                       default="true" />
             <attribute name="reset" type="boolean" use="optional"
                        default="false" />
             <attribute name="sameEntity" type="boolean" use="optional"
@@ -442,6 +446,8 @@
                         have an entity-name element otherwise an empty name is emitted</documentation>
                 </annotation>
             </attribute>
+            <attribute name="flushIncomplete" type="boolean" use="optional"
+                default="true" />
             <attribute name="reset" type="boolean" use="optional"
                 default="false" />
             <attribute name="sameEntity" type="boolean" use="optional"


### PR DESCRIPTION
Primarily needed for `EqualsFilter` but may also be useful as a generic option for [flushing collectors](/metafacture/metafacture-core/search?q="extends+AbstractFlushingCollect"):

* `EqualsFilter`: Use case described below.
* `Combine`, `Entity`: No actual use case yet.
* `All`: Already built-in (as an internal condition in `emit()`).
* `Choose`, `Concat`, `Group`, `Range`, `Square`, `Tuples`: Inherently "incomplete" (`isComplete()` always `false`).

When transforming Alma publishing data, we need to select fields based on some other field's subfield value:

```xml
<combine name="date" value="${value}" sameEntity="true">
  <if>
    <equalsFilter name="" value="" flushWith="POC  .a" reset="true">
      <data name="" source="@portfolio" />
      <data name="" source="POC  .a" />
    </equalsFilter>
  </if>
  <data name="value" source="POC  .b" />
</combine>
```

But this fires (`emit()`s) on every flush, even if the target value (`@portfolio`) wasn't received (it's only populated at a later point in the stream). Having the option to restrict firing to only when the collector `isComplete()`, fixes the issue:

```xml
<combine name="date" value="${value}" sameEntity="true">
  <if>
    <equalsFilter name="" value="" flushWith="POC  .a" flushIncomplete="false" reset="true">
      <data name="" source="@portfolio" />
      <data name="" source="POC  .a" />
    </equalsFilter>
  </if>
  <data name="value" source="POC  .b" />
</combine>
```

NOTE: This option is only applicable in combination with `flushWith`. ~~Maybe the name should reflect that? (`flushIncomplete` with inverted default?)~~ [EDIT: Changed attribute from `complete="true"` to `flushIncomplete="false"`.]