### PR TITLE
Ignore null values in Regexp function.

### DIFF
--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/Regexp.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/Regexp.java
@@ -39,6 +39,9 @@ public final class Regexp extends AbstractFunction {
     public void receive(final String name, final String value,
             final NamedValueSource source, final int recordCount,
             final int entityCount) {
+        if (null == value) {
+            return;
+        }
         matcher.reset(value);
         if (null == format) {
             while (matcher.find()) {

--- a/metamorph/src/test/java/org/metafacture/metamorph/functions/RegexpTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/functions/RegexpTest.java
@@ -95,4 +95,27 @@ public final class RegexpTest {
     ordered.verify(receiver).endRecord();
     ordered.verifyNoMoreInteractions();
   }
+
+  @Test
+  public void shouldIgnoreNullValues() {
+    metamorph = InlineMorph.in(this)
+        .with("<rules>")
+        .with("  <data source='s'>")
+        .with("    <regexp match='a.*' />")
+        .with("  </data>")
+        .with("</rules>")
+        .createConnectedTo(receiver);
+
+    metamorph.startRecord("1");
+    metamorph.literal("s", "aaccdd");
+    metamorph.literal("s", null);
+    metamorph.endRecord();
+
+    final InOrder ordered = inOrder(receiver);
+    ordered.verify(receiver).startRecord("1");
+    ordered.verify(receiver).literal("s", "aaccdd");
+    ordered.verify(receiver).endRecord();
+    ordered.verifyNoMoreInteractions();
+  }
+
 }


### PR DESCRIPTION
Filtering values passed from MarcXmlHandler may throw NullPointerException (see also discussion in #264). Ignore `null` values in regexp filters instead.