### PR TITLE
Preserve same entity in nested pass-through (_elseNested).

### DIFF
--- a/metamorph/src/main/java/org/metafacture/metamorph/Metamorph.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/Metamorph.java
@@ -122,7 +122,6 @@ public final class Metamorph implements StreamPipe<StreamReceiver>, NamedValuePi
 
     public Metamorph(final String morphDef, final Map<String, String> vars,
             final InterceptorFactory interceptorFactory) {
-
         this(getInputSource(morphDef), vars, interceptorFactory);
     }
 
@@ -140,7 +139,6 @@ public final class Metamorph implements StreamPipe<StreamReceiver>, NamedValuePi
 
     public Metamorph(final Reader morphDef, final Map<String, String> vars,
             final InterceptorFactory interceptorFactory) {
-
         this(new InputSource(morphDef), vars, interceptorFactory);
     }
 
@@ -158,7 +156,6 @@ public final class Metamorph implements StreamPipe<StreamReceiver>, NamedValuePi
 
     public Metamorph(final InputStream morphDef, final Map<String, String> vars,
             final InterceptorFactory interceptorFactory) {
-
         this(new InputSource(morphDef), vars, interceptorFactory);
     }
 
@@ -224,14 +221,16 @@ public final class Metamorph implements StreamPipe<StreamReceiver>, NamedValuePi
 
     protected void registerNamedValueReceiver(final String source, final NamedValueReceiver data) {
         if (ELSE_NESTED_KEYWORD.equals(source)) {
-            this.elseNested = true;
+            elseNested = true;
         }
+
         if (ELSE_KEYWORD.equals(source) || ELSE_FLATTENED_KEYWORD.equals(source) || elseNested) {
-            if (elseSources.isEmpty())
+            if (elseSources.isEmpty()) {
                 elseSources.add(data);
-            else
-                LOG.warn(
-                        "Only one of '_else', '_elseFlattened' and '_elseNested' is allowed. Ignoring the superflous ones.");
+            }
+            else {
+                LOG.warn("Only one of '_else', '_elseFlattened' and '_elseNested' is allowed. Ignoring the superflous ones.");
+            }
         } else {
             dataRegistry.register(source, data);
         }
@@ -258,7 +257,6 @@ public final class Metamorph implements StreamPipe<StreamReceiver>, NamedValuePi
 
     @Override
     public void endRecord() {
-
         for(final FlushListener listener: recordEndListener){
             listener.flush(recordCount, currentEntityCount);
         }
@@ -290,14 +288,12 @@ public final class Metamorph implements StreamPipe<StreamReceiver>, NamedValuePi
         dispatch(flattener.getCurrentPath(), "", null);
         currentEntityCount = entityCountStack.pop().intValue();
         flattener.endEntity();
-
     }
 
 
     @Override
     public void literal(final String name, final String value) {
         flattener.literal(name, value);
-
     }
 
     @Override

--- a/metamorph/src/test/java/org/metafacture/metamorph/TestMetamorphBasics.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/TestMetamorphBasics.java
@@ -421,6 +421,114 @@ public final class TestMetamorphBasics {
         );
     }
 
+    // https://github.com/hagbeck/metafacture-sandbox/tree/master/else-nested-entities
+    @Test
+    public void shouldHandleUseCaseSandboxElseNestedEntities() {
+        assertMorph(receiver,
+                "<rules>" +
+                  "<entity name='85640' flushWith='85640.3' reset='true'>" +
+                    "<data source='85640.u' name='u'>" +
+                      "<contains string='hdl.handle.net/2003/' />" +
+                      "<replace pattern='http://' with='https://' />" +
+                    "</data>" +
+                    "<data source='85640.u' name='u'>" +
+                      "<contains string='doi.org/10.17877/' />" +
+                      "<replace pattern='http://' with='https://' />" +
+                      "<replace pattern='dx.doi.org' with='doi.org' />" +
+                    "</data>" +
+                    "<data source='85640.x' name='x' />" +
+                    "<data source='85640.3' name='3' />" +
+                  "</entity>" +
+                  "<entity name='8564 ' flushWith='8564 .3' reset='true'>" +
+                    "<data source='8564 .u' name='u'>" +
+                      "<contains string='hdl.handle.net/2003/' />" +
+                      "<replace pattern='http://' with='https://' />" +
+                    "</data>" +
+                    "<data source='8564 .u' name='u'>" +
+                      "<contains string='doi.org/10.17877/' />" +
+                      "<replace pattern='http://' with='https://' />" +
+                      "<replace pattern='dx.doi.org' with='doi.org' />" +
+                    "</data>" +
+                    "<data source='8564 .x' name='x' />" +
+                    "<data source='8564 .3' name='3' />" +
+                  "</entity>" +
+                  "<data source='_elseNested' />" +
+                "</rules>",
+                i -> {
+                    i.startRecord("ID1687931");
+                    i.literal("leader", "00564nam a2200024 c 4500");
+                    i.literal("001", "1687931");
+                    i.literal("007", "|| ||||||||||||||||||||");
+                    i.literal("008", "||||||nuuuuuuuu|||||| | |||||||||||und||");
+                    i.startEntity("035  ");
+                    i.literal("a", "(UNION_SEAL)HT019953476");
+                    i.endEntity();
+                    i.startEntity("24500");
+                    i.literal("a", "Design and analysis of an asymmetric mutation operator");
+                    i.literal("c", "Thomas Jansen and Dirk Sudholt");
+                    i.endEntity();
+                    i.startEntity("8564 ");
+                    i.literal("z", "Freie Internetressource");
+                    i.endEntity();
+                    i.startEntity("85640");
+                    i.literal("u", "http://hdl.handle.net/2003/22116");
+                    i.literal("x", "Resolving-System");
+                    i.literal("3", "Volltext");
+                    i.endEntity();
+                    i.startEntity("85640");
+                    i.literal("u", "http://dx.doi.org/10.17877/DE290R-14123");
+                    i.literal("x", "Resolving-System");
+                    i.literal("3", "Volltext");
+                    i.endEntity();
+                    i.startEntity("9801 ");
+                    i.literal("e", "HBZ");
+                    i.endEntity();
+                    i.startEntity("997  ");
+                    i.literal("a", "20190130");
+                    i.endEntity();
+                    i.startEntity("9984 ");
+                    i.literal("z", "Freie Internetressource");
+                    i.endEntity();
+                },
+                o -> {
+                    o.get().startRecord("ID1687931");
+                    o.get().literal("leader", "00564nam a2200024 c 4500");
+                    o.get().literal("001", "1687931");
+                    o.get().literal("007", "|| ||||||||||||||||||||");
+                    o.get().literal("008", "||||||nuuuuuuuu|||||| | |||||||||||und||");
+                    o.get().startEntity("035  ");
+                    o.get().literal("a", "(UNION_SEAL)HT019953476");
+                    o.get().endEntity();
+                    o.get().startEntity("24500");
+                    o.get().literal("a", "Design and analysis of an asymmetric mutation operator");
+                    o.get().literal("c", "Thomas Jansen and Dirk Sudholt");
+                    o.get().endEntity();
+                    o.get().startEntity("8564 ");
+                    o.get().literal("z", "Freie Internetressource");
+                    o.get().endEntity();
+                    o.get().startEntity("85640");
+                    o.get().literal("u", "https://hdl.handle.net/2003/22116");
+                    o.get().literal("x", "Resolving-System");
+                    o.get().literal("3", "Volltext");
+                    o.get().endEntity();
+                    o.get().startEntity("85640");
+                    o.get().literal("u", "https://doi.org/10.17877/DE290R-14123");
+                    o.get().literal("x", "Resolving-System");
+                    o.get().literal("3", "Volltext");
+                    o.get().endEntity();
+                    o.get().startEntity("9801 ");
+                    o.get().literal("e", "HBZ");
+                    o.get().endEntity();
+                    o.get().startEntity("997  ");
+                    o.get().literal("a", "20190130");
+                    o.get().endEntity();
+                    o.get().startEntity("9984 ");
+                    o.get().literal("z", "Freie Internetressource");
+                    o.get().endEntity();
+                }
+        );
+    }
+
 
     @Test
     public void shouldMatchCharacterWithQuestionMarkWildcard() {

--- a/metamorph/src/test/java/org/metafacture/metamorph/TestMetamorphBasics.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/TestMetamorphBasics.java
@@ -87,24 +87,19 @@ public final class TestMetamorphBasics {
 
     @Test
     public void shouldHandleUnmatchedLiteralsAndEntitiesInElseSource() {
-        testElseData(
-                "<rules>" +
-                "    <data source='_else'/>" +
-                "</rules>"
-        );
+        testElseData("_else");
     }
 
     @Test
     public void shouldHandleUnmatchedLiteralsAndEntitiesInElseFlattenedSource() {
-        testElseData(
-                "<rules>" +
-                "    <data source='_elseFlattened'/>" +
-                "</rules>"
-        );
+        testElseData("_elseFlattened");
     }
 
-    private void testElseData(final String morphDef) {
-        assertMorph(receiver, morphDef,
+    private void testElseData(final String elseKeyword) {
+        assertMorph(receiver,
+                "<rules>" +
+                "  <data source='" + elseKeyword + "'/>" +
+                "</rules>",
                 i -> {
                     i.startRecord("1");
                     i.literal("Shikotan", "Aekap");

--- a/metamorph/src/test/java/org/metafacture/metamorph/TestMetamorphBasics.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/TestMetamorphBasics.java
@@ -356,6 +356,69 @@ public final class TestMetamorphBasics {
     }
 
     @Test
+    public void shouldNotHandleDataByElseNestedSourceIfDataBelonginToEntityIsRuledByMorph() {
+        assertMorph(receiver,
+                "<rules>" +
+                "  <entity name='USA1'>" +
+                "    <data source='USA1.Sylt' name='Hawaii' />" +
+                "  </entity>" +
+                "  <entity name='USA2' sameEntity='true' reset='true' flushWith='USA2' flushIncomplete='true'>" +
+                "    <data source='USA2.Sylt' name='Hawaii' />" +
+                "    <data source='USA2.Langeoog' name='Langeoog' />" +
+                "  </entity>" +
+                "  <entity name='USA3' sameEntity='true' reset='true' flushWith='USA3' flushIncomplete='true'>" +
+                "    <data source='USA3.Sylt' name='Hawaii' />" +
+                "  </entity>" +
+                "  <data source='_elseNested' />" +
+                "</rules>",
+                i -> {
+                    i.startRecord("1");
+                    i.literal("Shikotan", "Aekap");
+                    i.startEntity("Germany");
+                    i.literal("Langeoog", "Moin");
+                    i.literal("Baltrum", "Moin Moin");
+                    i.endEntity();
+                    i.startEntity("USA1");
+                    i.literal("Sylt", "Aloha");
+                    i.endEntity();
+                    i.startEntity("USA2");
+                    i.literal("Sylt", "Aloha");
+                    i.literal("Langeoog", "Moin");
+                    i.literal("Baltrum", "Moin Moin");
+                    i.endEntity();
+                    i.startEntity("USA2");
+                    i.literal("Langeoog", "Moin");
+                    i.literal("Baltrum", "Moin Moin");
+                    i.endEntity();
+                    i.startEntity("USA3");
+                    i.literal("Baltrum", "Moin Moin");
+                    i.endEntity();
+                    i.endRecord();
+                },
+                (o, f) -> {
+                    o.get().startRecord("1");
+                    o.get().literal("Shikotan", "Aekap");
+                    o.get().startEntity("Germany");
+                    o.get().literal("Langeoog", "Moin");
+                    o.get().literal("Baltrum", "Moin Moin");
+                    o.get().endEntity();
+                    o.get().startEntity("USA1");
+                    o.get().literal("Hawaii", "Aloha");
+                    o.get().endEntity();
+                    o.get().startEntity("USA2");
+                    o.get().literal("Hawaii", "Aloha");
+                    o.get().literal("Langeoog", "Moin");
+                    o.get().endEntity();
+                    o.get().startEntity("USA2");
+                    o.get().literal("Langeoog", "Moin");
+                    o.get().endEntity();
+                    o.get().endRecord();
+                }
+        );
+    }
+
+
+    @Test
     public void shouldMatchCharacterWithQuestionMarkWildcard() {
         assertMorph(receiver,
                 "<rules>" +

--- a/metamorph/src/test/java/org/metafacture/metamorph/TestMetamorphBasics.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/TestMetamorphBasics.java
@@ -294,8 +294,12 @@ public final class TestMetamorphBasics {
                     i.endRecord();
                 },
                 (o, f) -> {
+                    // Pass-through coordinates with morph whether to start/end an entity
                     final boolean coordinatesWithEntity = false;
+
+                    // Pass-through and morph entities are separated (one ends when the other starts)
                     final boolean separatesFromEntity = false;
+
                     o.get().startRecord("1");
                     o.get().literal("Shikotan", "Aekap");
                     o.get().startEntity("Germany");
@@ -308,8 +312,8 @@ public final class TestMetamorphBasics {
                     o.get().startEntity("USA2");
                     o.get().literal("Hawaii", "Aloha");
                     if (!coordinatesWithEntity) {
-                    o.get().endEntity();
-                    o.get().startEntity("USA2");
+                        o.get().endEntity();
+                        o.get().startEntity("USA2");
                     }
                     o.get().literal("Langeoog", "Moin");
                     o.get().literal("Baltrum", "Moin Moin");
@@ -317,19 +321,19 @@ public final class TestMetamorphBasics {
                     o.get().startEntity("USA3");
                     o.get().literal("Langeoog", "Moin");
                     if (!coordinatesWithEntity) {
-                    o.get().startEntity("USA3");
+                        o.get().startEntity("USA3");
                     }
                     else if (separatesFromEntity) {
-                    o.get().endEntity();
-                    o.get().startEntity("USA3");
+                        o.get().endEntity();
+                        o.get().startEntity("USA3");
                     }
                     o.get().literal("Hawaii", "Aloha");
                     if (!coordinatesWithEntity) {
-                    o.get().endEntity();
+                        o.get().endEntity();
                     }
                     else if (separatesFromEntity) {
-                    o.get().endEntity();
-                    o.get().startEntity("USA3");
+                        o.get().endEntity();
+                        o.get().startEntity("USA3");
                     }
                     o.get().literal("Baltrum", "Moin Moin");
                     o.get().endEntity();
@@ -337,18 +341,18 @@ public final class TestMetamorphBasics {
                     o.get().literal("Langeoog", "Moin");
                     o.get().literal("Baltrum", "Moin Moin");
                     if (!coordinatesWithEntity) {
-                    o.get().startEntity("USA4");
+                        o.get().startEntity("USA4");
                     }
                     else if (separatesFromEntity) {
-                    o.get().endEntity();
-                    o.get().startEntity("USA4");
+                        o.get().endEntity();
+                        o.get().startEntity("USA4");
                     }
                     o.get().literal("Hawaii", "Aloha");
                     if (!coordinatesWithEntity) {
-                    f.apply(2).endEntity();
+                        f.apply(2).endEntity();
                     }
                     else {
-                    o.get().endEntity();
+                        o.get().endEntity();
                     }
                     o.get().endRecord();
                 }
@@ -356,17 +360,17 @@ public final class TestMetamorphBasics {
     }
 
     @Test
-    public void shouldNotHandleDataByElseNestedSourceIfDataBelonginToEntityIsRuledByMorph() {
+    public void shouldNotHandleDataByElseNestedSourceIfDataBelongingToEntityIsRuledByMorph() {
         assertMorph(receiver,
                 "<rules>" +
                 "  <entity name='USA1'>" +
                 "    <data source='USA1.Sylt' name='Hawaii' />" +
                 "  </entity>" +
-                "  <entity name='USA2' sameEntity='true' reset='true' flushWith='USA2' flushIncomplete='true'>" +
+                "  <entity name='USA2' sameEntity='true' flushWith='USA2'>" +
                 "    <data source='USA2.Sylt' name='Hawaii' />" +
                 "    <data source='USA2.Langeoog' name='Langeoog' />" +
                 "  </entity>" +
-                "  <entity name='USA3' sameEntity='true' reset='true' flushWith='USA3' flushIncomplete='true'>" +
+                "  <entity name='USA3' sameEntity='true' flushWith='USA3'>" +
                 "    <data source='USA3.Sylt' name='Hawaii' />" +
                 "  </entity>" +
                 "  <data source='_elseNested' />" +
@@ -395,7 +399,7 @@ public final class TestMetamorphBasics {
                     i.endEntity();
                     i.endRecord();
                 },
-                (o, f) -> {
+                o -> {
                     o.get().startRecord("1");
                     o.get().literal("Shikotan", "Aekap");
                     o.get().startEntity("Germany");

--- a/metamorph/src/test/java/org/metafacture/metamorph/TestMetamorphBasics.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/TestMetamorphBasics.java
@@ -98,6 +98,10 @@ public final class TestMetamorphBasics {
     private void testElseData(final String elseKeyword) {
         assertMorph(receiver,
                 "<rules>" +
+                "  <entity name='Germany'>" +
+                "    <data source='Germany.Sylt' name='Hawaii' />" +
+                "    <data source='Germany.Borkum' />" +
+                "  </entity>" +
                 "  <data source='" + elseKeyword + "'/>" +
                 "</rules>",
                 i -> {
@@ -105,6 +109,8 @@ public final class TestMetamorphBasics {
                     i.literal("Shikotan", "Aekap");
                     i.startEntity("Germany");
                     i.literal("Langeoog", "Moin");
+                    i.literal("Sylt", "Aloha");
+                    i.literal("Borkum", "Tach");
                     i.endEntity();
                     i.startEntity("Germany");
                     i.literal("Baltrum", "Moin Moin");
@@ -115,7 +121,92 @@ public final class TestMetamorphBasics {
                     o.get().startRecord("1");
                     o.get().literal("Shikotan", "Aekap");
                     o.get().literal("Germany.Langeoog", "Moin");
+                    o.get().startEntity("Germany");
+                    o.get().literal("Hawaii", "Aloha");
+                    o.get().literal("Germany.Borkum", "Tach");
+                    o.get().endEntity();
                     o.get().literal("Germany.Baltrum", "Moin Moin");
+                    o.get().endRecord();
+                }
+        );
+    }
+
+    @Test
+    public void issue338_shouldPreserveSameEntitiesInElseNestedSource() {
+        assertMorph(receiver,
+                "<rules>" +
+                "  <data source='_elseNested' />" +
+                "</rules>",
+                i -> {
+                    i.startRecord("1");
+                    i.literal("lit1", "val1");
+                    i.startEntity("ent1");
+                    i.literal("lit2", "val2");
+                    i.literal("lit3", "val3");
+                    i.endEntity();
+                    i.literal("lit4", "val4");
+                    i.startEntity("ent2");
+                    i.literal("lit5", "val5");
+                    i.literal("lit6", "val6");
+                    i.literal("lit7", "val7");
+                    i.endEntity();
+                    i.startEntity("ent2"); // sic!
+                    i.literal("lit8", "val8");
+                    i.literal("lit9", "val9");
+                    i.endEntity();
+                    i.endRecord();
+                    i.startRecord("2");
+                    i.startEntity("ent1");
+                    i.literal("lit1", "val1");
+                    i.literal("lit2", "val2");
+                    i.endEntity();
+                    i.startEntity("ent2");
+                    i.literal("lit3", "val3");
+                    i.literal("lit4", "val4");
+                    i.literal("lit5", "val5");
+                    i.literal("lit6", "val6");
+                    i.endEntity();
+                    i.startEntity("ent3");
+                    i.literal("lit7", "val7");
+                    i.literal("lit8", "val8");
+                    i.endEntity();
+                    i.literal("lit9", "val9");
+                    i.endRecord();
+                },
+                o -> {
+                    o.get().startRecord("1");
+                    o.get().literal("lit1", "val1");
+                    o.get().startEntity("ent1");
+                    o.get().literal("lit2", "val2");
+                    o.get().literal("lit3", "val3");
+                    o.get().endEntity();
+                    o.get().literal("lit4", "val4");
+                    o.get().startEntity("ent2");
+                    o.get().literal("lit5", "val5");
+                    o.get().literal("lit6", "val6");
+                    o.get().literal("lit7", "val7");
+                    o.get().endEntity();
+                    o.get().startEntity("ent2");
+                    o.get().literal("lit8", "val8");
+                    o.get().literal("lit9", "val9");
+                    o.get().endEntity();
+                    o.get().endRecord();
+                    o.get().startRecord("2");
+                    o.get().startEntity("ent1");
+                    o.get().literal("lit1", "val1");
+                    o.get().literal("lit2", "val2");
+                    o.get().endEntity();
+                    o.get().startEntity("ent2");
+                    o.get().literal("lit3", "val3");
+                    o.get().literal("lit4", "val4");
+                    o.get().literal("lit5", "val5");
+                    o.get().literal("lit6", "val6");
+                    o.get().endEntity();
+                    o.get().startEntity("ent3");
+                    o.get().literal("lit7", "val7");
+                    o.get().literal("lit8", "val8");
+                    o.get().endEntity();
+                    o.get().literal("lit9", "val9");
                     o.get().endRecord();
                 }
         );
@@ -147,13 +238,118 @@ public final class TestMetamorphBasics {
                     o.get().literal("Shikotan", "Aekap");
                     o.get().startEntity("Germany");
                     o.get().literal("Langeoog", "Moin");
-                    o.get().endEntity();
-                    o.get().startEntity("Germany");
                     o.get().literal("Baltrum", "Moin Moin");
                     o.get().endEntity();
                     o.get().startEntity("USA");
                     o.get().literal("Hawaii", "Aloha");
                     o.get().endEntity();
+                    o.get().endRecord();
+                }
+        );
+    }
+
+    @Test
+    public void shouldHandlePartiallyUnmatchedLiteralsAndEntitiesInElseNestedSource() {
+        assertMorph(receiver,
+                "<rules>" +
+                "  <entity name='USA1'>" +
+                "    <data source='USA1.Sylt' name='Hawaii' />" +
+                "  </entity>" +
+                "  <entity name='USA2'>" +
+                "    <data source='USA2.Sylt' name='Hawaii' />" +
+                "  </entity>" +
+                "  <entity name='USA3'>" +
+                "    <data source='USA3.Sylt' name='Hawaii' />" +
+                "  </entity>" +
+                "  <entity name='USA4'>" +
+                "    <data source='USA4.Sylt' name='Hawaii' />" +
+                "  </entity>" +
+                "  <data source='_elseNested' />" +
+                "</rules>",
+                i -> {
+                    i.startRecord("1");
+                    i.literal("Shikotan", "Aekap");
+                    i.startEntity("Germany");
+                    i.literal("Langeoog", "Moin");
+                    i.literal("Baltrum", "Moin Moin");
+                    i.endEntity();
+                    i.startEntity("USA1");
+                    i.literal("Sylt", "Aloha");
+                    i.endEntity();
+                    i.startEntity("USA2");
+                    i.literal("Sylt", "Aloha");
+                    i.literal("Langeoog", "Moin");
+                    i.literal("Baltrum", "Moin Moin");
+                    i.endEntity();
+                    i.startEntity("USA3");
+                    i.literal("Langeoog", "Moin");
+                    i.literal("Sylt", "Aloha");
+                    i.literal("Baltrum", "Moin Moin");
+                    i.endEntity();
+                    i.startEntity("USA4");
+                    i.literal("Langeoog", "Moin");
+                    i.literal("Baltrum", "Moin Moin");
+                    i.literal("Sylt", "Aloha");
+                    i.endEntity();
+                    i.endRecord();
+                },
+                (o, f) -> {
+                    final boolean coordinatesWithEntity = false;
+                    final boolean separatesFromEntity = false;
+                    o.get().startRecord("1");
+                    o.get().literal("Shikotan", "Aekap");
+                    o.get().startEntity("Germany");
+                    o.get().literal("Langeoog", "Moin");
+                    o.get().literal("Baltrum", "Moin Moin");
+                    o.get().endEntity();
+                    o.get().startEntity("USA1");
+                    o.get().literal("Hawaii", "Aloha");
+                    o.get().endEntity();
+                    o.get().startEntity("USA2");
+                    o.get().literal("Hawaii", "Aloha");
+                    if (!coordinatesWithEntity) {
+                    o.get().endEntity();
+                    o.get().startEntity("USA2");
+                    }
+                    o.get().literal("Langeoog", "Moin");
+                    o.get().literal("Baltrum", "Moin Moin");
+                    o.get().endEntity();
+                    o.get().startEntity("USA3");
+                    o.get().literal("Langeoog", "Moin");
+                    if (!coordinatesWithEntity) {
+                    o.get().startEntity("USA3");
+                    }
+                    else if (separatesFromEntity) {
+                    o.get().endEntity();
+                    o.get().startEntity("USA3");
+                    }
+                    o.get().literal("Hawaii", "Aloha");
+                    if (!coordinatesWithEntity) {
+                    o.get().endEntity();
+                    }
+                    else if (separatesFromEntity) {
+                    o.get().endEntity();
+                    o.get().startEntity("USA3");
+                    }
+                    o.get().literal("Baltrum", "Moin Moin");
+                    o.get().endEntity();
+                    o.get().startEntity("USA4");
+                    o.get().literal("Langeoog", "Moin");
+                    o.get().literal("Baltrum", "Moin Moin");
+                    if (!coordinatesWithEntity) {
+                    o.get().startEntity("USA4");
+                    }
+                    else if (separatesFromEntity) {
+                    o.get().endEntity();
+                    o.get().startEntity("USA4");
+                    }
+                    o.get().literal("Hawaii", "Aloha");
+                    if (!coordinatesWithEntity) {
+                    f.apply(2).endEntity();
+                    }
+                    else {
+                    o.get().endEntity();
+                    }
                     o.get().endRecord();
                 }
         );


### PR DESCRIPTION
Fixes #338 (see test `shouldHandleUnmatchedLiteralsAndEntitiesInElseNestedSource`; e4c6fe5).

Doesn't work with **partially handled entities**, though (see test `shouldHandlePartiallyUnmatchedLiteralsAndEntitiesInElseNestedSource`):

* _It should either coordinate with `Entity` w.r.t. starting/ending entities._
  * If an entity has already been started by the morph, it must not be started again by the pass-through; conversely, if an entity has already been started by the pass-through, it must not be started again by the morph.
  * Similarly, only the last one of them may end the entity.
  * This corresponds to `coordinatesWithEntity` set to `true`.
* _Or separate pass-through entities from explicitly specified entities._
  * At every morph/pass-through boundary, start/end the entity; both "modes" will be internally consistent (i.e., preserve same entity etc.).
  * This corresponds to `separatesFromEntity` set to `true`.

I'd like a review of the actual fix and also some feedback concerning the ensuing bug (which remedy would be preferrable? is this considered a blocker for the PR to move forward?).