### PR TITLE
Escape feedback char in _else data.

### DIFF
--- a/metamorph/src/main/java/org/metafacture/metamorph/Metamorph.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/Metamorph.java
@@ -338,11 +338,11 @@ public final class Metamorph implements StreamPipe<StreamReceiver>, NamedValuePi
                             elseNestedEntityStarted = true;
                         }
 
-                        send(currentLiteralName, value, fallbackReceiver);
+                        send(escapeFeedbackChar(currentLiteralName), value, fallbackReceiver);
                     }
                 }
                 else {
-                    send(path, value, fallbackReceiver);
+                    send(escapeFeedbackChar(path), value, fallbackReceiver);
                 }
             }
         }
@@ -361,6 +361,14 @@ public final class Metamorph implements StreamPipe<StreamReceiver>, NamedValuePi
                 errorHandler.error(e);
             }
         }
+    }
+
+    private boolean startsWithFeedbackChar(final String name) {
+        return name.length() != 0 && name.charAt(0) == FEEDBACK_CHAR;
+    }
+
+    private String escapeFeedbackChar(final String name) {
+        return name == null ? null : (startsWithFeedbackChar(name) ? ESCAPE_CHAR : "") + name;
     }
 
     /**
@@ -388,7 +396,7 @@ public final class Metamorph implements StreamPipe<StreamReceiver>, NamedValuePi
                     "encountered literal with name='null'. This indicates a bug in a function or a collector.");
         }
 
-        if (name.length() != 0 && name.charAt(0) == FEEDBACK_CHAR) {
+        if (startsWithFeedbackChar(name)) {
             dispatch(name, value, null, false);
             return;
         }

--- a/metamorph/src/test/java/org/metafacture/metamorph/TestMetamorphBasics.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/TestMetamorphBasics.java
@@ -106,6 +106,7 @@ public final class TestMetamorphBasics {
                 "</rules>",
                 i -> {
                     i.startRecord("1");
+                    i.literal("@id", "123");
                     i.literal("Shikotan", "Aekap");
                     i.startEntity("Germany");
                     i.literal("Langeoog", "Moin");
@@ -113,18 +114,21 @@ public final class TestMetamorphBasics {
                     i.literal("Borkum", "Tach");
                     i.endEntity();
                     i.startEntity("Germany");
+                    i.literal("@foo", "bar");
                     i.literal("Baltrum", "Moin Moin");
                     i.endEntity();
                     i.endRecord();
                 },
                 o -> {
                     o.get().startRecord("1");
+                    o.get().literal("@id", "123");
                     o.get().literal("Shikotan", "Aekap");
                     o.get().literal("Germany.Langeoog", "Moin");
                     o.get().startEntity("Germany");
                     o.get().literal("Hawaii", "Aloha");
                     o.get().literal("Germany.Borkum", "Tach");
                     o.get().endEntity();
+                    o.get().literal("Germany.@foo", "bar");
                     o.get().literal("Germany.Baltrum", "Moin Moin");
                     o.get().endRecord();
                 }
@@ -223,8 +227,10 @@ public final class TestMetamorphBasics {
                 "</rules>",
                 i -> {
                     i.startRecord("1");
+                    i.literal("@id", "123");
                     i.literal("Shikotan", "Aekap");
                     i.startEntity("Germany");
+                    i.literal("@foo", "bar");
                     i.literal("Langeoog", "Moin");
                     i.literal("Baltrum", "Moin Moin");
                     i.endEntity();
@@ -235,8 +241,10 @@ public final class TestMetamorphBasics {
                 },
                 o -> {
                     o.get().startRecord("1");
+                    o.get().literal("@id", "123");
                     o.get().literal("Shikotan", "Aekap");
                     o.get().startEntity("Germany");
+                    o.get().literal("@foo", "bar");
                     o.get().literal("Langeoog", "Moin");
                     o.get().literal("Baltrum", "Moin Moin");
                     o.get().endEntity();


### PR DESCRIPTION
Pass-through (`_else*`) should bypass feedback/recursion mechanism.

Fixes #343.

P.S.: I'd prefer the two commits to be squashed in order to provide a complete view of the issue (failing test + fix) and also have the tests passing for each individual commit.