### PR TITLE
Don't handle empty '[]' as character class 

### DIFF
--- a/metafacture-commons/src/main/java/org/metafacture/commons/tries/SimpleRegexTrie.java
+++ b/metafacture-commons/src/main/java/org/metafacture/commons/tries/SimpleRegexTrie.java
@@ -28,8 +28,11 @@ import java.util.List;
  */
 public class SimpleRegexTrie<P> {
 
+    // Non-empty character class, containing non-[] characters, e.g.
+    // matches: `lit-[A]`, `lit-[AB]`, does not match: `a[].1`, `a[].1.b[].1`
+    public static final String SIMPLE_CHARACTER_CLASS = ".*\\[[^\\[\\]]+\\].*";
+
     private final WildcardTrie<P> trie;
-    public static final String SIMPLE_CHARACTER_CLASS = "\\[.+\\]";
 
     public SimpleRegexTrie() {
         trie = new WildcardTrie<P>();
@@ -43,7 +46,7 @@ public class SimpleRegexTrie<P> {
      * @param value value to associate with the key pattern
      */
     public void put(final String keys, final P value) {
-        if (keys.matches(".*" + SIMPLE_CHARACTER_CLASS + ".*")) {
+        if (keys.matches(SIMPLE_CHARACTER_CLASS)) {
             int charClassStart = keys.indexOf('[', 0);
             final int charClassEnd = keys.indexOf(']', 1);
             String begin = keys.substring(0, charClassStart);

--- a/metafacture-commons/src/main/java/org/metafacture/commons/tries/SimpleRegexTrie.java
+++ b/metafacture-commons/src/main/java/org/metafacture/commons/tries/SimpleRegexTrie.java
@@ -29,7 +29,7 @@ import java.util.List;
 public class SimpleRegexTrie<P> {
 
     private final WildcardTrie<P> trie;
-    public static final String SIMPLE_CHARACTER_CLASS = "\\[.*\\]";
+    public static final String SIMPLE_CHARACTER_CLASS = "\\[.+\\]";
 
     public SimpleRegexTrie() {
         trie = new WildcardTrie<P>();

--- a/metafacture-commons/src/test/java/org/metafacture/commons/tries/SimpleRegexTrieTest.java
+++ b/metafacture-commons/src/test/java/org/metafacture/commons/tries/SimpleRegexTrieTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2013, 2014 Pascal Christoph, hbz
+ *  Copyright 2013, 2020 Pascal Christoph, hbz and others
  *  Licensed under the Apache License, Version 2.0 the "License";
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -21,17 +21,27 @@ import org.junit.Test;
 /**
  * tests {@link SimpleRegexTrie}
  *
- * @author Pascal Christoph
+ * @author Pascal Christoph, Fabian Steeg
  *
  */
 public final class SimpleRegexTrieTest {
-    private static final String SCC = "aacbb|a[ab]bb";
+
     private static final String AACBB = "aacbb";
+    private static final String ABCBB = "abcbb";
 
     @Test
     public void testWithSimpleCharacterClass() {
         final SimpleRegexTrie<String> trie = new SimpleRegexTrie<String>();
-        trie.put(SCC, SCC);
-        assertTrue(AACBB, trie.get(AACBB).size() == 1);
+        trie.put("a[ab]cbb", "value");
+        assertTrue("Expecting to find: " + AACBB, trie.get(AACBB).size() == 1);
+        assertTrue("Expecting to find: " + ABCBB, trie.get(ABCBB).size() == 1);
+    }
+
+    @Test
+    public void testWithEmptyCharacterClass() {
+        final SimpleRegexTrie<String> trie = new SimpleRegexTrie<String>();
+        // Should not be treated as character class (used for JSON arrays):
+        trie.put("a[].1", "value");
+        assertTrue("Expecting to find: a[].1", trie.get("a[].1").size() == 1);
     }
 }

--- a/metafacture-commons/src/test/java/org/metafacture/commons/tries/SimpleRegexTrieTest.java
+++ b/metafacture-commons/src/test/java/org/metafacture/commons/tries/SimpleRegexTrieTest.java
@@ -41,7 +41,8 @@ public final class SimpleRegexTrieTest {
     public void testWithEmptyCharacterClass() {
         final SimpleRegexTrie<String> trie = new SimpleRegexTrie<String>();
         // Should not be treated as character class (used for JSON arrays):
-        trie.put("a[].1", "value");
-        assertTrue("Expecting to find: a[].1", trie.get("a[].1").size() == 1);
+        final String key = "a[].1.b[].1";
+        trie.put(key, "value");
+        assertTrue("Expecting to find: " + key, trie.get(key).size() == 1);
     }
 }


### PR DESCRIPTION
Fix processing input field names like `a[].1.b[].1` (coming from JSON input).

Assigning @dr0i (original author of the code) for review.