### PR TITLE
Migrate from travis to github actions to test build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,14 @@
+name: Build
+
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Build with gradle
+      run: ./gradlew check

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Metafacture](https://raw.github.com/wiki/metafacture/metafacture-core/img/metafacture.png)
 
-[![Build status](https://travis-ci.org/metafacture/metafacture-core.svg?branch=master)](https://travis-ci.org/metafacture/metafacture-core) [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=org.metafacture:metafacture-core&metric=alert_status)](https://sonarcloud.io/dashboard/index/org.metafacture:metafacture-core)
+[![Build](https://github.com/metafacture/metafacture-core/workflows/Build/badge.svg)](https://github.com/hbz/lobid-resources/actions?query=workflow%3ABuild) [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=org.metafacture:metafacture-core&metric=alert_status)](https://sonarcloud.io/dashboard/index/org.metafacture:metafacture-core)
 
 Metafacture is a toolkit for processing semi-structured data with a focus on library metadata. It provides a versatile set of tools for reading, writing and transforming data. Metafacture can be used as a stand-alone application or as a Java library in other applications. The name Metafacture is a portmanteau of the words *meta* data and manu*facture*.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Metafacture](https://raw.github.com/wiki/metafacture/metafacture-core/img/metafacture.png)
 
-[![Build](https://github.com/metafacture/metafacture-core/workflows/Build/badge.svg)](https://github.com/hbz/lobid-resources/actions?query=workflow%3ABuild) [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=org.metafacture:metafacture-core&metric=alert_status)](https://sonarcloud.io/dashboard/index/org.metafacture:metafacture-core)
+[![Build](https://github.com/metafacture/metafacture-core/workflows/Build/badge.svg?branch=master)](https://github.com/metafacture/metafacture-core/actions?query=workflow%3ABuild) [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=org.metafacture:metafacture-core&metric=alert_status)](https://sonarcloud.io/dashboard/index/org.metafacture:metafacture-core)
 
 Metafacture is a toolkit for processing semi-structured data with a focus on library metadata. It provides a versatile set of tools for reading, writing and transforming data. Metafacture can be used as a stand-alone application or as a Java library in other applications. The name Metafacture is a portmanteau of the words *meta* data and manu*facture*.
 


### PR DESCRIPTION
Note that the .travis.yml is deliberately not removed as it does more
than just testing the build.

- update badge in README

See https://github.com/metafacture/metafacture-core/issues/351.