### PR TITLE
Add filter-null-values Flux command for NullFilter

### DIFF
--- a/metafacture-mangling/src/main/java/org/metafacture/mangling/NullFilter.java
+++ b/metafacture-mangling/src/main/java/org/metafacture/mangling/NullFilter.java
@@ -15,6 +15,7 @@
  */
 package org.metafacture.mangling;
 
+import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.StreamReceiver;
 import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
@@ -31,6 +32,7 @@ import org.metafacture.framework.helpers.ForwardingStreamPipe;
 @Description("Discards or replaces null values")
 @In(StreamReceiver.class)
 @Out(StreamReceiver.class)
+@FluxCommand("filter-null-values")
 public final class NullFilter extends ForwardingStreamPipe {
 
     private String replacement = null;

--- a/metafacture-mangling/src/main/resources/flux-commands.properties
+++ b/metafacture-mangling/src/main/resources/flux-commands.properties
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 filter-duplicate-objects org.metafacture.mangling.DuplicateObjectFilter
+filter-null-values org.metafacture.mangling.NullFilter
 literal-to-object org.metafacture.mangling.LiteralToObject
 object-to-literal org.metafacture.mangling.ObjectToLiteral
 change-id org.metafacture.mangling.RecordIdChanger


### PR DESCRIPTION
Named it `filter-null-values` for consistency with `filter-duplicate-objects`.