### PR TITLE
Allow namespace prefixes to be emitted

### DIFF
--- a/metafacture-xml/src/main/java/org/metafacture/xml/GenericXmlHandler.java
+++ b/metafacture-xml/src/main/java/org/metafacture/xml/GenericXmlHandler.java
@@ -18,7 +18,6 @@ package org.metafacture.xml;
 import java.util.regex.Pattern;
 
 import org.metafacture.framework.FluxCommand;
-import org.metafacture.framework.MetafactureException;
 import org.metafacture.framework.StreamReceiver;
 import org.metafacture.framework.XmlReceiver;
 import org.metafacture.framework.annotations.Description;
@@ -48,6 +47,8 @@ public final class GenericXmlHandler extends DefaultXmlPipe<StreamReceiver> {
 
     private boolean inRecord;
     private StringBuilder valueBuffer = new StringBuilder();
+
+    private boolean emitNamespace = false;
 
     public GenericXmlHandler() {
         super();
@@ -91,13 +92,32 @@ public final class GenericXmlHandler extends DefaultXmlPipe<StreamReceiver> {
         return recordTagName;
     }
 
+    /**
+     * On entity level namespaces can be emitted, e.g.: "foo:bar". The default is to
+     * ignore the namespace so that only "bar" is emitted.
+     *
+     * @param emitNamespace set to "true" if namespace should be emitted. Defaults
+     *                      to "false".
+     */
+    public void setEmitNamespace(boolean emitNamespace) {
+        this.emitNamespace = emitNamespace;
+    }
+
+    public boolean getEmitNamespace() {
+        return this.emitNamespace;
+    }
+
     @Override
     public void startElement(final String uri, final String localName,
             final String qName, final Attributes attributes) {
 
         if (inRecord) {
             writeValue();
-            getReceiver().startEntity(localName);
+            if (emitNamespace) {
+                getReceiver().startEntity(qName);
+            } else {
+                getReceiver().startEntity(localName);
+            }
             writeAttributes(attributes);
         } else if (localName.equals(recordTagName)) {
             final String identifier = attributes.getValue("id");

--- a/metafacture-xml/src/test/java/org/metafacture/xml/GenericXMLHandlerTest.java
+++ b/metafacture-xml/src/test/java/org/metafacture/xml/GenericXMLHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013, 2014 Deutsche Nationalbibliothek
+ * Copyright 2013, 2014, 2021 Deutsche Nationalbibliothek et al
  *
  * Licensed under the Apache License, Version 2.0 the "License";
  * you may not use this file except in compliance with the License.
@@ -131,4 +131,13 @@ public final class GenericXMLHandlerTest {
         ordered.verify(receiver).literal("value", "char-data");
     }
 
+    @Test
+    public void shouldEmitNamespaceOnEntityElement() {
+        genericXmlHandler.setEmitNamespace(true);
+        genericXmlHandler.startElement("", "record", "record", attributes);
+        genericXmlHandler.startElement("", "entity", "ns:entity", attributes);
+
+        final InOrder ordered = inOrder(receiver);
+        ordered.verify(receiver).startEntity("ns:entity");
+    }
 }


### PR DESCRIPTION
This Introduces the new parameter "emitNamespace" to GenericXMLHandler.
If set to "true" input data like "<foo:bar>" will be passed through as
"foo:bar".
For backward compatibility the default is set to "false", thus only "bar" is
emitted.

See #377.