### PR TITLE
Implement record path filter.

### DIFF
--- a/metafacture-mangling/build.gradle
+++ b/metafacture-mangling/build.gradle
@@ -23,3 +23,10 @@ dependencies {
   testImplementation 'junit:junit:4.12'
   testImplementation 'org.mockito:mockito-core:2.5.5'
 }
+
+test {
+  testLogging {
+    showStandardStreams = true
+    exceptionFormat = 'full'
+  }
+}

--- a/metafacture-mangling/src/main/java/org/metafacture/mangling/RecordPathFilter.java
+++ b/metafacture-mangling/src/main/java/org/metafacture/mangling/RecordPathFilter.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2021 hbz NRW
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.metafacture.mangling;
+
+import org.metafacture.framework.FluxCommand;
+import org.metafacture.framework.StreamReceiver;
+import org.metafacture.framework.annotations.Description;
+import org.metafacture.framework.annotations.In;
+import org.metafacture.framework.annotations.Out;
+import org.metafacture.framework.helpers.DefaultStreamPipe;
+
+/**
+  Splits a stream into records based on entity path.
+ */
+@Description("Splits a stream into records based on entity path")
+@In(StreamReceiver.class)
+@Out(StreamReceiver.class)
+@FluxCommand("filter-records-by-path")
+public final class RecordPathFilter extends DefaultStreamPipe<StreamReceiver> {
+
+    public static final String DEFAULT_RECORD_ID_FORMAT = "%s[%d]";
+
+    public static final String ROOT_PATH = "";
+
+    private final EntityPathTracker entityPathTracker = new EntityPathTracker();
+
+    private String path;
+    private String recordIdFormat;
+    private String recordIdentifier;
+    private boolean inMatch;
+    private boolean recordStarted;
+    private int recordCount;
+
+    public RecordPathFilter() {
+        this(ROOT_PATH);
+    }
+
+    public RecordPathFilter(final String path) {
+        super();
+        resetRecord();
+        setPath(path);
+        setRecordIdFormat(DEFAULT_RECORD_ID_FORMAT);
+    }
+
+    public void setEntitySeparator(final String entitySeparator) {
+        entityPathTracker.setEntitySeparator(entitySeparator);
+    }
+
+    public String getEntitySeparator() {
+        return entityPathTracker.getEntitySeparator();
+    }
+
+    public void setPath(final String path) {
+        this.path = path;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setRecordIdFormat(final String recordIdFormat) {
+        this.recordIdFormat = recordIdFormat;
+    }
+
+    public String getRecordIdFormat() {
+        return recordIdFormat;
+    }
+
+    @Override
+    public void startRecord(final String identifier) {
+        assert !isClosed();
+
+        recordCount = 0;
+        recordIdentifier = identifier;
+        entityPathTracker.startRecord(identifier);
+    }
+
+    @Override
+    public void endRecord() {
+        assert !isClosed();
+
+        endRecordIfNeeded();
+        entityPathTracker.endRecord();
+    }
+
+    @Override
+    public void startEntity(final String name) {
+        entityPathTracker.startEntity(name);
+
+        if (inMatch()) {
+            startRecordIfNeeded();
+            getReceiver().startEntity(name);
+        }
+        else if (pathMatching()) {
+            inMatch = true;
+        }
+    }
+
+    @Override
+    public void endEntity() {
+        if (pathMatching()) {
+            endRecordIfNeeded();
+            inMatch = false;
+        }
+        else if (inMatch()) {
+            getReceiver().endEntity();
+        }
+
+        entityPathTracker.endEntity();
+    }
+
+    @Override
+    public void literal(final String name, final String value) {
+        if (inMatch()) {
+            startRecordIfNeeded();
+            getReceiver().literal(name, value);
+        }
+    }
+
+    @Override
+    public void onResetStream() {
+        entityPathTracker.resetStream();
+        resetRecord();
+    }
+
+    @Override
+    public void onCloseStream() {
+        entityPathTracker.closeStream();
+    }
+
+    private void resetRecord() {
+        recordStarted = false;
+        inMatch = false;
+    }
+
+    private void startRecordIfNeeded() {
+        if (!recordStarted) {
+            getReceiver().startRecord(String.format(recordIdFormat, recordIdentifier, ++recordCount));
+            recordStarted = true;
+        }
+    }
+
+    private void endRecordIfNeeded() {
+        if (recordStarted) {
+            getReceiver().endRecord();
+            resetRecord();
+        }
+    }
+
+    private boolean pathMatching() {
+        return path.equals(entityPathTracker.getCurrentPath());
+    }
+
+    private boolean inMatch() {
+        return inMatch || path.equals(ROOT_PATH);
+    }
+
+}

--- a/metafacture-mangling/src/main/resources/flux-commands.properties
+++ b/metafacture-mangling/src/main/resources/flux-commands.properties
@@ -13,11 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+change-id org.metafacture.mangling.RecordIdChanger
+discard-events org.metafacture.mangling.StreamEventDiscarder
 filter-duplicate-objects org.metafacture.mangling.DuplicateObjectFilter
 filter-null-values org.metafacture.mangling.NullFilter
+filter-records-by-path org.metafacture.mangling.RecordPathFilter
+flatten org.metafacture.mangling.StreamFlattener
 literal-to-object org.metafacture.mangling.LiteralToObject
 object-to-literal org.metafacture.mangling.ObjectToLiteral
-change-id org.metafacture.mangling.RecordIdChanger
 record-to-entity org.metafacture.mangling.RecordToEntity
-discard-events org.metafacture.mangling.StreamEventDiscarder
-flatten org.metafacture.mangling.StreamFlattener

--- a/metafacture-mangling/src/test/java/org/metafacture/mangling/RecordPathFilterTest.java
+++ b/metafacture-mangling/src/test/java/org/metafacture/mangling/RecordPathFilterTest.java
@@ -1,0 +1,446 @@
+/*
+ * Copyright 2021 hbz NRW
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.metafacture.mangling;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.metafacture.framework.StreamReceiver;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public final class RecordPathFilterTest {
+
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private StreamReceiver receiver;
+
+    @Test
+    public void shouldFilterRootPath() {
+        assertFilter(
+                i -> {
+                    i.startRecord("1");
+                    i.startEntity("data");
+                    i.literal("lit", "record 1");
+                    i.endEntity();
+                    i.endRecord();
+                    i.startRecord("2");
+                    i.startEntity("data");
+                    i.literal("lit", "record 2");
+                    i.endEntity();
+                    i.endRecord();
+                },
+                o -> {
+                    o.get().startRecord("1[1]");
+                    o.get().startEntity("data");
+                    o.get().literal("lit", "record 1");
+                    o.get().endEntity();
+                    o.get().endRecord();
+                    o.get().startRecord("2[1]");
+                    o.get().startEntity("data");
+                    o.get().literal("lit", "record 2");
+                    o.get().endEntity();
+                    o.get().endRecord();
+                }
+        );
+    }
+
+    @Test
+    public void shouldFilterSimplePathWithLiterals() {
+        assertFilter(
+                i -> {
+                    i.setPath("data");
+
+                    i.startRecord("1");
+                    i.startEntity("data");
+                    i.literal("lit", "record 1");
+                    i.endEntity();
+                    i.endRecord();
+                    i.startRecord("2");
+                    i.startEntity("junk");
+                    i.literal("lit", "skipped");
+                    i.endEntity();
+                    i.startEntity("data");
+                    i.literal("lit", "record 2");
+                    i.endEntity();
+                    i.endRecord();
+                },
+                o -> {
+                    o.get().startRecord("1[1]");
+                    o.get().literal("lit", "record 1");
+                    o.get().endRecord();
+                    o.get().startRecord("2[1]");
+                    o.get().literal("lit", "record 2");
+                    o.get().endRecord();
+                }
+        );
+    }
+
+    @Test
+    public void shouldFilterNestedPathWithLiterals() {
+        assertFilter(
+                i -> {
+                    i.setPath("nested.data");
+
+                    i.startRecord("1");
+                    i.startEntity("nested");
+                    i.startEntity("data");
+                    i.literal("lit", "record 1");
+                    i.endEntity();
+                    i.endEntity();
+                    i.endRecord();
+                    i.startRecord("2");
+                    i.startEntity("nested");
+                    i.startEntity("junk");
+                    i.literal("lit", "skipped");
+                    i.endEntity();
+                    i.startEntity("data");
+                    i.literal("lit", "record 2");
+                    i.endEntity();
+                    i.endEntity();
+                    i.endRecord();
+                },
+                o -> {
+                    o.get().startRecord("1[1]");
+                    o.get().literal("lit", "record 1");
+                    o.get().endRecord();
+                    o.get().startRecord("2[1]");
+                    o.get().literal("lit", "record 2");
+                    o.get().endRecord();
+                }
+        );
+    }
+
+    @Test
+    public void shouldFilterSimplePathWithEntities() {
+        assertFilter(
+                i -> {
+                    i.setPath("data");
+
+                    i.startRecord("1");
+                    i.startEntity("data");
+                    i.startEntity("ent1");
+                    i.literal("lit", "record 1.1");
+                    i.endEntity();
+                    i.startEntity("ent2");
+                    i.literal("lit", "record 1.2");
+                    i.endEntity();
+                    i.endEntity();
+                    i.endRecord();
+                    i.startRecord("2");
+                    i.startEntity("junk");
+                    i.literal("lit", "skipped");
+                    i.endEntity();
+                    i.startEntity("data");
+                    i.literal("lit", "record 2");
+                    i.endEntity();
+                    i.endRecord();
+                },
+                o -> {
+                    o.get().startRecord("1[1]");
+                    o.get().startEntity("ent1");
+                    o.get().literal("lit", "record 1.1");
+                    o.get().endEntity();
+                    o.get().startEntity("ent2");
+                    o.get().literal("lit", "record 1.2");
+                    o.get().endEntity();
+                    o.get().endRecord();
+                    o.get().startRecord("2[1]");
+                    o.get().literal("lit", "record 2");
+                    o.get().endRecord();
+                }
+        );
+    }
+
+    @Test
+    public void shouldFilterNestedPathWithEntities() {
+        assertFilter(
+                i -> {
+                    i.setPath("nested.data");
+
+                    i.startRecord("1");
+                    i.startEntity("nested");
+                    i.startEntity("data");
+                    i.startEntity("ent1");
+                    i.literal("lit", "record 1.1");
+                    i.endEntity();
+                    i.startEntity("ent2");
+                    i.literal("lit", "record 1.2");
+                    i.endEntity();
+                    i.endEntity();
+                    i.endEntity();
+                    i.endRecord();
+                    i.startRecord("2");
+                    i.startEntity("nested");
+                    i.startEntity("junk");
+                    i.literal("lit", "skipped");
+                    i.endEntity();
+                    i.startEntity("data");
+                    i.literal("lit", "record 2");
+                    i.endEntity();
+                    i.endEntity();
+                    i.endRecord();
+                },
+                o -> {
+                    o.get().startRecord("1[1]");
+                    o.get().startEntity("ent1");
+                    o.get().literal("lit", "record 1.1");
+                    o.get().endEntity();
+                    o.get().startEntity("ent2");
+                    o.get().literal("lit", "record 1.2");
+                    o.get().endEntity();
+                    o.get().endRecord();
+                    o.get().startRecord("2[1]");
+                    o.get().literal("lit", "record 2");
+                    o.get().endRecord();
+                }
+        );
+    }
+
+    @Test
+    public void shouldFilterMultiplePathMatches() {
+        assertFilter(
+                i -> {
+                    i.setPath("data");
+
+                    i.startRecord("1");
+                    i.startEntity("data");
+                    i.literal("lit", "record 1.1");
+                    i.endEntity();
+                    i.startEntity("data");
+                    i.literal("lit", "record 1.2");
+                    i.endEntity();
+                    i.startEntity("junk");
+                    i.literal("lit", "skipped");
+                    i.endEntity();
+                    i.startEntity("data");
+                    i.literal("lit", "record 1.3");
+                    i.startEntity("ent1");
+                    i.literal("lit", "record 1.3");
+                    i.endEntity();
+                    i.endEntity();
+                    i.endRecord();
+                    i.startRecord("2");
+                    i.startEntity("data");
+                    i.startEntity("ent1");
+                    i.literal("lit", "record 2.1");
+                    i.endEntity();
+                    i.endEntity();
+                    i.startEntity("data");
+                    i.literal("lit", "record 2.2");
+                    i.endEntity();
+                    i.endRecord();
+                },
+                o -> {
+                    o.get().startRecord("1[1]");
+                    o.get().literal("lit", "record 1.1");
+                    o.get().endRecord();
+                    o.get().startRecord("1[2]");
+                    o.get().literal("lit", "record 1.2");
+                    o.get().endRecord();
+                    o.get().startRecord("1[3]");
+                    o.get().literal("lit", "record 1.3");
+                    o.get().startEntity("ent1");
+                    o.get().literal("lit", "record 1.3");
+                    o.get().endEntity();
+                    o.get().endRecord();
+                    o.get().startRecord("2[1]");
+                    o.get().startEntity("ent1");
+                    o.get().literal("lit", "record 2.1");
+                    o.get().endEntity();
+                    o.get().endRecord();
+                    o.get().startRecord("2[2]");
+                    o.get().literal("lit", "record 2.2");
+                    o.get().endRecord();
+                }
+        );
+    }
+
+    @Test
+    public void shouldNotFilterNonMatchingRecord() {
+        assertFilter(
+                i -> {
+                    i.setPath("data");
+
+                    i.startRecord("1");
+                    i.startEntity("data");
+                    i.literal("lit", "record 1");
+                    i.endEntity();
+                    i.endRecord();
+                    i.startRecord("2");
+                    i.startEntity("other-data");
+                    i.literal("lit", "record 2");
+                    i.endEntity();
+                    i.endRecord();
+                },
+                o -> {
+                    o.get().startRecord("1[1]");
+                    o.get().literal("lit", "record 1");
+                    o.get().endRecord();
+                }
+        );
+    }
+
+    @Test
+    public void shouldFilterPathWithEntitySeparator() {
+        assertFilter(
+                i -> {
+                    i.setPath("dotted.data");
+
+                    i.startRecord("1");
+                    i.startEntity("dotted.data");
+                    i.literal("lit", "record 1.1");
+                    i.endEntity();
+                    i.startEntity("dotted");
+                    i.startEntity("data");
+                    i.literal("lit", "record 1.2");
+                    i.endEntity();
+                    i.endEntity();
+                    i.endRecord();
+                },
+                o -> {
+                    o.get().startRecord("1[1]");
+                    o.get().literal("lit", "record 1.1");
+                    o.get().endRecord();
+                    o.get().startRecord("1[2]");
+                    o.get().literal("lit", "record 1.2");
+                    o.get().endRecord();
+                }
+        );
+    }
+
+    @Test
+    public void shouldFilterPathWithSpecifiedEntitySeparator() {
+        assertFilter(
+                i -> {
+                    i.setPath("dotted.data");
+                    i.setEntitySeparator("/");
+
+                    i.startRecord("1");
+                    i.startEntity("dotted.data");
+                    i.literal("lit", "record 1.1");
+                    i.endEntity();
+                    i.startEntity("dotted");
+                    i.startEntity("data");
+                    i.literal("lit", "record 1.2");
+                    i.endEntity();
+                    i.endEntity();
+                    i.endRecord();
+                },
+                o -> {
+                    o.get().startRecord("1[1]");
+                    o.get().literal("lit", "record 1.1");
+                    o.get().endRecord();
+                }
+        );
+    }
+
+    @Test
+    public void shouldFilterNestedPathWithSpecifiedEntitySeparator() {
+        assertFilter(
+                i -> {
+                    i.setPath("nested/dotted.data");
+                    i.setEntitySeparator("/");
+
+                    i.startRecord("1");
+                    i.startEntity("nested");
+                    i.startEntity("dotted.data");
+                    i.literal("lit", "record 1.1");
+                    i.endEntity();
+                    i.startEntity("dotted");
+                    i.startEntity("data");
+                    i.literal("lit", "record 1.2");
+                    i.endEntity();
+                    i.endEntity();
+                    i.endEntity();
+                    i.endRecord();
+                },
+                o -> {
+                    o.get().startRecord("1[1]");
+                    o.get().literal("lit", "record 1.1");
+                    o.get().endRecord();
+                }
+        );
+    }
+
+    @Test
+    public void shouldRespectRecordIdFormat() {
+        assertFilter(
+                i -> {
+                    i.setRecordIdFormat("%s.%d");
+
+                    i.startRecord("1");
+                    i.startEntity("data");
+                    i.literal("lit", "record 1");
+                    i.endEntity();
+                    i.endRecord();
+                    i.startRecord("2");
+                    i.startEntity("data");
+                    i.literal("lit", "record 2");
+                    i.endEntity();
+                    i.endRecord();
+                },
+                o -> {
+                    o.get().startRecord("1.1");
+                    o.get().startEntity("data");
+                    o.get().literal("lit", "record 1");
+                    o.get().endEntity();
+                    o.get().endRecord();
+                    o.get().startRecord("2.1");
+                    o.get().startEntity("data");
+                    o.get().literal("lit", "record 2");
+                    o.get().endEntity();
+                    o.get().endRecord();
+                }
+        );
+    }
+
+    @Test
+    public void shouldNotFilterLiteralPath() {
+        assertFilter(
+                i -> {
+                    i.setPath("data");
+
+                    i.startRecord("1");
+                    i.startEntity("data");
+                    i.literal("lit", "record 1");
+                    i.endEntity();
+                    i.endRecord();
+                    i.startRecord("2");
+                    i.literal("data", "record 2");
+                    i.endRecord();
+                },
+                o -> {
+                    o.get().startRecord("1[1]");
+                    o.get().literal("lit", "record 1");
+                    o.get().endRecord();
+                }
+        );
+    }
+
+    private void assertFilter(final Consumer<RecordPathFilter> in, final Consumer<Supplier<StreamReceiver>> out) {
+        final RecordPathFilter recordPathFilter = new RecordPathFilter();
+        recordPathFilter.setReceiver(receiver);
+
+        TestHelpers.assertProcess(receiver, () -> in.accept(recordPathFilter), out);
+    }
+
+}

--- a/metafacture-mangling/src/test/java/org/metafacture/mangling/TestHelpers.java
+++ b/metafacture-mangling/src/test/java/org/metafacture/mangling/TestHelpers.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 hbz NRW
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.metafacture.mangling;
+
+import org.metafacture.framework.StreamReceiver;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.mockito.exceptions.base.MockitoAssertionError;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.IntFunction;
+import java.util.function.Supplier;
+
+public final class TestHelpers {
+
+    public static void assertProcess(final StreamReceiver receiver, final Runnable process, final Consumer<Supplier<StreamReceiver>> out) {
+        assertProcess(receiver, process, (s, f) -> out.accept(s));
+    }
+
+    public static void assertProcess(final StreamReceiver receiver, final Runnable process, final BiConsumer<Supplier<StreamReceiver>, IntFunction<StreamReceiver>> out) {
+        final InOrder ordered = Mockito.inOrder(receiver);
+
+        process.run();
+
+        try {
+            out.accept(() -> ordered.verify(receiver), i -> ordered.verify(receiver, Mockito.times(i)));
+
+            ordered.verifyNoMoreInteractions();
+            Mockito.verifyNoMoreInteractions(receiver);
+        }
+        catch (final MockitoAssertionError e) {
+            System.out.println(Mockito.mockingDetails(receiver).printInvocations());
+            throw e;
+        }
+    }
+
+}


### PR DESCRIPTION
Split event stream into records based on entity path.

Related to #382 and `org.metafacture.xml.XmlElementSplitter`.

Resolves #385.