### PR TITLE
Add and apply Checkstyle config.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,7 @@ subprojects {
 
   checkstyle {
     toolVersion '8.30'
+    checkstyleTest.enabled = false
   }
 
   signing {

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ subprojects {
   apply plugin: 'signing'
   apply plugin: 'maven'
   apply plugin: 'jacoco'
+  apply plugin: 'checkstyle'
 
   check.dependsOn(editorconfigCheck)
 
@@ -83,6 +84,10 @@ subprojects {
   artifacts {
     archives sourceJar
     archives javadocJar
+  }
+
+  checkstyle {
+    toolVersion '8.30'
   }
 
   signing {

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC
+    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="SuppressWarningsFilter" />
+    <module name="TreeWalker">
+        <module name="AbstractClassName"/>
+        <module name="AnnotationUseStyle"/>
+        <module name="AnonInnerLength"/>
+        <module name="ArrayTypeStyle"/>
+        <module name="AvoidNestedBlocks"/>
+        <module name="AvoidNoArgumentSuperConstructorCall"/>
+        <module name="AvoidStarImport"/>
+        <module name="AvoidStaticImport"/>
+        <module name="BooleanExpressionComplexity"/>
+        <module name="CatchParameterName">
+            <property name="format" value="^e$"/>
+        </module>
+        <module name="ClassDataAbstractionCoupling"/>
+        <module name="ClassFanOutComplexity"/>
+        <module name="ClassTypeParameterName"/>
+        <module name="ConstantName"/>
+        <module name="CovariantEquals"/>
+        <module name="CustomImportOrder">
+            <property name="customImportOrderRules" value="SAME_PACKAGE(2)###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS###STATIC"/>
+            <property name="separateLineBetweenGroups" value="true"/>
+        </module>
+        <module name="CyclomaticComplexity"/>
+        <module name="DeclarationOrder"/>
+        <module name="DefaultComesLast"/>
+        <module name="EmptyLineSeparator">
+            <property name="allowMultipleEmptyLines" value="false"/>
+            <property name="allowMultipleEmptyLinesInsideClassMembers" value="false"/>
+            <property name="allowNoEmptyLineBetweenFields" value="true"/>
+        </module>
+        <module name="EmptyStatement"/>
+        <module name="EqualsAvoidNull"/>
+        <module name="EqualsHashCode"/>
+        <module name="ExecutableStatementCount"/>
+        <module name="ExplicitInitialization"/>
+        <module name="FallThrough"/>
+        <module name="FinalLocalVariable">
+            <property name="validateEnhancedForLoopVariable" value="true"/>
+        </module>
+        <module name="FinalParameters">
+            <property name="tokens" value="CTOR_DEF,LITERAL_CATCH,METHOD_DEF"/>
+        </module>
+        <module name="GenericWhitespace"/>
+        <module name="HiddenField">
+            <property name="ignoreConstructorParameter" value="true"/>
+            <property name="ignoreSetter" value="true"/>
+        </module>
+        <module name="HideUtilityClassConstructor"/>
+        <module name="IllegalCatch"/>
+        <module name="IllegalThrows"/>
+        <module name="IllegalToken">
+            <property name="tokens" value="POST_INC,POST_DEC"/>
+        </module>
+        <module name="IllegalType"/>
+        <module name="Indentation"/>
+        <module name="InnerAssignment"/>
+        <module name="InnerTypeLast"/>
+        <module name="InterfaceIsType"/>
+        <module name="InterfaceTypeParameterName"/>
+        <module name="JavaNCSS"/>
+        <module name="JavadocType"/>
+        <module name="LambdaParameterName"/>
+        <module name="LeftCurly"/>
+        <module name="LocalFinalVariableName"/>
+        <module name="LocalVariableName"/>
+        <module name="MagicNumber"/>
+        <module name="MemberName"/>
+        <module name="MethodLength"/>
+        <module name="MethodName"/>
+        <module name="MethodParamPad"/>
+        <module name="MethodTypeParameterName"/>
+        <module name="MissingCtor"/>
+        <module name="MissingDeprecated"/>
+        <module name="MissingOverride"/>
+        <module name="MissingSwitchDefault"/>
+        <module name="ModifiedControlVariable"/>
+        <module name="ModifierOrder"/>
+        <module name="MultipleStringLiterals">
+            <property name="allowedDuplicates" value="2"/>
+            <property name="ignoreStringsRegexp" value="^&quot;.?.?&quot;$"/>
+        </module>
+        <module name="MultipleVariableDeclarations"/>
+        <module name="MutableException"/>
+        <module name="NeedBraces"/>
+        <module name="NPathComplexity"/>
+        <module name="NoArrayTrailingComma"/>
+        <module name="NoClone"/>
+        <module name="NoEnumTrailingComma"/>
+        <module name="NoFinalizer"/>
+        <module name="NoWhitespaceAfter"/>
+        <module name="NoWhitespaceBefore"/>
+        <module name="OneStatementPerLine">
+            <property name="treatTryResourcesAsStatement" value="true"/>
+        </module>
+        <module name="OneTopLevelClass"/>
+        <module name="OperatorWrap">
+            <property name="option" value="eol"/>
+        </module>
+        <module name="OuterTypeFilename"/>
+        <module name="OuterTypeNumber"/>
+        <module name="OverloadMethodsDeclarationOrder"/>
+        <module name="PackageDeclaration"/>
+        <module name="PackageName"/>
+        <module name="ParameterAssignment"/>
+        <module name="ParameterName"/>
+        <module name="ParameterNumber">
+            <property name="max" value="5"/>
+        </module>
+        <module name="ParenPad"/>
+        <module name="RedundantImport"/>
+        <module name="RedundantModifier"/>
+        <module name="RequireThis"/>
+        <module name="ReturnCount"/>
+        <module name="RightCurly">
+            <property name="option" value="alone"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="tokens" value="COMMA,SEMI,ELLIPSIS,ARRAY_DECLARATOR"/>
+            <property name="option" value="eol"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="tokens" value="DOT,AT,METHOD_REF"/>
+            <property name="option" value="nl"/>
+        </module>
+        <module name="SimplifyBooleanExpression"/>
+        <module name="SimplifyBooleanReturn"/>
+        <module name="StaticVariableName"/>
+        <module name="StringLiteralEquality"/>
+        <module name="SuperClone"/>
+        <module name="SuperFinalize"/>
+        <module name="SuppressWarnings">
+            <!-- allow: fallthrough, unchecked (cf. https://docs.oracle.com/javase/8/docs/technotes/tools/unix/javac.html#BHCJBHDF) -->
+            <property name="format" value="^\s*(?:all|cast|classfile|deprecation|dep-ann|divzero|empty|finally|options|overrides|path|processing|rawtypes|Serial|static|try|varargs)\s*$"/>
+        </module>
+        <module name="SuppressWithNearbyCommentFilter">
+            <property name="checkFormat" value="$1"/>
+            <property name="commentFormat" value="checkstyle-disable-line (\w+(?:\|\w+)?)"/>
+        </module>
+        <module name="SuppressWarningsHolder" />
+        <module name="ThrowsCount">
+            <property name="max" value="2"/>
+        </module>
+        <module name="TypecastParenPad"/>
+        <module name="TypeName"/>
+        <module name="UnnecessaryParentheses"/>
+        <module name="UnnecessarySemicolonAfterTypeMemberDeclaration"/>
+        <module name="UnnecessarySemicolonInEnumeration"/>
+        <module name="UnnecessarySemicolonInTryWithResources">
+            <property name="allowWhenNoBraceAfterSemicolon" value="false"/>
+        </module>
+        <module name="UnusedImports"/>
+        <module name="UpperEll"/>
+        <module name="VisibilityModifier"/>
+        <module name="WhitespaceAfter"/>
+        <module name="WhitespaceAround"/>
+    </module>
+</module>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -4,6 +4,10 @@
     "https://checkstyle.org/dtds/configuration_1_3.dtd">
 <module name="Checker">
     <module name="SuppressWarningsFilter" />
+    <module name="SuppressionSingleFilter">
+        <property name="checks" value=".*"/>
+        <property name="files" value="generated-src"/>
+    </module>
     <module name="TreeWalker">
         <module name="AbstractClassName"/>
         <module name="AnnotationUseStyle"/>

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/AlephMabXmlHandler.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/AlephMabXmlHandler.java
@@ -12,6 +12,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
 package org.metafacture.biblio;
 
 import org.metafacture.framework.FluxCommand;
@@ -21,6 +22,7 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultXmlPipe;
+
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 
@@ -48,6 +50,9 @@ public final class AlephMabXmlHandler extends DefaultXmlPipe<StreamReceiver> {
     private String currentTag = "";
     private StringBuilder builder = new StringBuilder();
 
+    public AlephMabXmlHandler() {
+    }
+
     @Override
     public void characters(final char[] chars, final int start, final int length)
             throws SAXException {
@@ -60,11 +65,14 @@ public final class AlephMabXmlHandler extends DefaultXmlPipe<StreamReceiver> {
         if (AlephMabXmlHandler.CONTROLLFIELD.equals(localName)) {
             getReceiver().literal(this.currentTag, this.builder.toString().trim());
             getReceiver().endEntity();
-        } else if (AlephMabXmlHandler.SUBFIELD.equals(localName)) {
+        }
+        else if (AlephMabXmlHandler.SUBFIELD.equals(localName)) {
             getReceiver().literal(this.currentTag, this.builder.toString().trim());
-        } else if (AlephMabXmlHandler.DATAFIELD.equals(localName)) {
+        }
+        else if (AlephMabXmlHandler.DATAFIELD.equals(localName)) {
             getReceiver().endEntity();
-        } else if (AlephMabXmlHandler.RECORD.equals(localName)) {
+        }
+        else if (AlephMabXmlHandler.RECORD.equals(localName)) {
             getReceiver().endRecord();
         }
     }
@@ -76,16 +84,20 @@ public final class AlephMabXmlHandler extends DefaultXmlPipe<StreamReceiver> {
             this.builder = new StringBuilder();
             this.currentTag = "";
             getReceiver().startEntity(attributes.getValue(AlephMabXmlHandler.DATAFIELD_ATTRIBUTE));
-        } else if (AlephMabXmlHandler.SUBFIELD.equals(localName)) {
+        }
+        else if (AlephMabXmlHandler.SUBFIELD.equals(localName)) {
             this.builder = new StringBuilder();
             this.currentTag = attributes.getValue(AlephMabXmlHandler.SUBFIELD_ATTRIBUTE);
-        } else if (AlephMabXmlHandler.DATAFIELD.equals(localName)) {
-            getReceiver().startEntity(attributes.getValue(AlephMabXmlHandler.DATAFIELD_ATTRIBUTE)
-                    + attributes.getValue(AlephMabXmlHandler.INDICATOR1)
-                    + attributes.getValue(AlephMabXmlHandler.INDICATOR2));
-        } else if (AlephMabXmlHandler.RECORD.equals(localName)) {
+        }
+        else if (AlephMabXmlHandler.DATAFIELD.equals(localName)) {
+            getReceiver().startEntity(attributes.getValue(AlephMabXmlHandler.DATAFIELD_ATTRIBUTE) +
+                    attributes.getValue(AlephMabXmlHandler.INDICATOR1) +
+                    attributes.getValue(AlephMabXmlHandler.INDICATOR2));
+        }
+        else if (AlephMabXmlHandler.RECORD.equals(localName)) {
             getReceiver().startRecord("");
-        } else if (AlephMabXmlHandler.LEADER.equals(localName)) {
+        }
+        else if (AlephMabXmlHandler.LEADER.equals(localName)) {
             this.builder = new StringBuilder();
             this.currentTag = AlephMabXmlHandler.LEADER;
         }

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/AseqDecoder.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/AseqDecoder.java
@@ -13,6 +13,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
 package org.metafacture.biblio;
 
 import org.metafacture.framework.FluxCommand;
@@ -31,10 +32,18 @@ import org.metafacture.framework.helpers.DefaultObjectPipe;
 @In(String.class)
 @Out(StreamReceiver.class)
 @FluxCommand("decode-aseq")
-public final class AseqDecoder
-        extends DefaultObjectPipe<String, StreamReceiver> {
+public final class AseqDecoder extends DefaultObjectPipe<String, StreamReceiver> {
 
     private static final String FIELD_DELIMITER = "\n";
+
+    private static final int CATEGORY_BEGIN = 10;
+    private static final int CATEGORY_END = 15;
+    private static final int FIELD_CONTENT_BEGIN = 18;
+    private static final int RECORD_IDENTIFIER_BEGIN = 0;
+    private static final int RECORD_IDENTIFIER_END = 9;
+
+    public AseqDecoder() {
+    }
 
     @Override
     public void process(final String record) {
@@ -44,16 +53,17 @@ public final class AseqDecoder
             return;
         }
         final String[] lines = trimedRecord.split(FIELD_DELIMITER);
-        for (int i = 0; i < lines.length; i++) {
+        for (int i = 0; i < lines.length; ++i) {
             final String field = lines[i];
             if (i == 0) {
-                getReceiver().startRecord(field.substring(0, 9));
+                getReceiver().startRecord(field.substring(RECORD_IDENTIFIER_BEGIN, RECORD_IDENTIFIER_END));
             }
-            final String category = field.substring(10, 15).trim();
-            final String fieldContent = field.substring(18).trim();
+            final String category = field.substring(CATEGORY_BEGIN, CATEGORY_END).trim();
+            final String fieldContent = field.substring(FIELD_CONTENT_BEGIN).trim();
             if (!fieldContent.startsWith("$$")) {
                 getReceiver().literal(category, fieldContent);
-            } else {
+            }
+            else {
                 getReceiver().startEntity(category);
                 final String[] subfields = fieldContent.split("\\$\\$");
                 for (final String subfield : subfields) {

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/MabDecoder.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/MabDecoder.java
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.biblio;
 
-import java.util.regex.Pattern;
+package org.metafacture.biblio;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.FormatException;
@@ -26,6 +25,7 @@ import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
 
+import java.util.regex.Pattern;
 
 /**
  * Parses a raw Mab2 stream (utf-8 encoding assumed). Events are handled by a
@@ -40,8 +40,7 @@ import org.metafacture.framework.helpers.DefaultObjectPipe;
 @In(String.class)
 @Out(StreamReceiver.class)
 @FluxCommand("decode-mab")
-public final class MabDecoder
-        extends DefaultObjectPipe<String, StreamReceiver> {
+public final class MabDecoder extends DefaultObjectPipe<String, StreamReceiver> {
 
     private static final String FIELD_END = "\u001e";
     private static final Pattern FIELD_PATTERN =
@@ -58,6 +57,9 @@ public final class MabDecoder
     private static final String ID_TAG = "001 ";
     private static final int TAG_LENGTH = 4;
 
+    public MabDecoder() {
+    }
+
     @Override
     public void process(final String record) {
         assert !isClosed();
@@ -70,7 +72,7 @@ public final class MabDecoder
 
         try {
             getReceiver().literal(LEADER, record.substring(0, HEADER_SIZE));
-            getReceiver().literal(TYPE, String.valueOf(record.charAt(HEADER_SIZE-1)));
+            getReceiver().literal(TYPE, String.valueOf(record.charAt(HEADER_SIZE - 1)));
             final String content = record.substring(HEADER_SIZE);
             for (final String part : FIELD_PATTERN.split(content)) {
                 if (!part.startsWith(RECORD_END)) {
@@ -80,7 +82,8 @@ public final class MabDecoder
 
                     if (subFields.length == 1) {
                         getReceiver().literal(fieldName, subFields[0]);
-                    } else {
+                    }
+                    else {
                         getReceiver().startEntity(fieldName);
 
                         for (int i = 1; i < subFields.length; ++i) {
@@ -92,7 +95,8 @@ public final class MabDecoder
                     }
                 }
             }
-        } catch (final IndexOutOfBoundsException e) {
+        }
+        catch (final IndexOutOfBoundsException e) {
             throw new FormatException("[" + record + "]", e);
         }
 
@@ -100,13 +104,14 @@ public final class MabDecoder
     }
 
     private String extractIdFromRecord(final String record) {
-        try{
+        try {
             final int fieldEnd = record.indexOf(FIELD_END, HEADER_SIZE);
-            if(record.substring(HEADER_SIZE, HEADER_SIZE + TAG_LENGTH).equals(ID_TAG)){
+            if (record.substring(HEADER_SIZE, HEADER_SIZE + TAG_LENGTH).equals(ID_TAG)) {
                 return record.substring(HEADER_SIZE + TAG_LENGTH, fieldEnd);
             }
             throw new MissingIdException(record);
-        } catch (IndexOutOfBoundsException e) {
+        }
+        catch (final IndexOutOfBoundsException e) {
             throw new FormatException(INVALID_FORMAT + record, e);
         }
     }

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/OaiPmhOpener.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/OaiPmhOpener.java
@@ -3,24 +3,23 @@
 
 package org.metafacture.biblio;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
-
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.TransformerException;
-
 import org.metafacture.framework.MetafactureException;
 import org.metafacture.framework.ObjectReceiver;
 import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
-import org.xml.sax.SAXException;
 
 import ORG.oclc.oai.harvester2.app.RawWrite;
+import org.xml.sax.SAXException;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerException;
 
 /**
  * Opens an OAI-PMH stream and passes a reader to the receiver.
@@ -31,97 +30,99 @@ import ORG.oclc.oai.harvester2.app.RawWrite;
 @Description("Opens an OAI-PMH stream and passes a reader to the receiver. Mandatory arguments are: BASE_URL, DATE_FROM, DATE_UNTIL, METADATA_PREFIX, SET_SPEC .")
 @In(String.class)
 @Out(java.io.Reader.class)
-public final class OaiPmhOpener extends
-		DefaultObjectPipe<String, ObjectReceiver<Reader>> {
+public final class OaiPmhOpener extends DefaultObjectPipe<String, ObjectReceiver<Reader>> {
 
-	private String encoding = "UTF-8";
+    private String encoding = "UTF-8";
 
-	final ByteArrayOutputStream OUTPUT_STREAM = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
-	private String dateFrom;
+    private String dateFrom;
 
-	private String dateUntil;
+    private String dateUntil;
 
-	private String setSpec;
+    private String setSpec;
 
-	private String metadataPrefix;
+    private String metadataPrefix;
 
-	/**
-	 * Default constructor
-	 */
-	public OaiPmhOpener() {
+    /**
+     * Default constructor
+     */
+    public OaiPmhOpener() {
+    }
 
-	}
+    /**
+     * Sets the encoding to use. The default setting is UTF-8.
+     *
+     * @param encoding new default encoding
+     */
+    public void setEncoding(final String encoding) {
+        this.encoding = encoding;
+    }
 
-	/**
-	 * Sets the encoding to use. The default setting is UTF-8.
-	 *
-	 * @param encoding new default encoding
-	 */
-	public void setEncoding(final String encoding) {
-		this.encoding = encoding;
-	}
+    /**
+     * Sets the beginning of the retrieving of updated data. The form is
+     * YYYY-MM-DD .
+     *
+     * @param dateFrom The form is YYYY-MM-DD .
+     */
+    public void setDateFrom(final String dateFrom) {
+        this.dateFrom = dateFrom;
+    }
 
-	/**
-	 * Sets the beginning of the retrieving of updated data. The form is
-	 * YYYY-MM-DD .
-	 *
-	 * @param dateFrom The form is YYYY-MM-DD .
-	 */
-	public void setDateFrom(final String dateFrom) {
-		this.dateFrom = dateFrom;
-	}
+    /**
+     * Sets the end of the retrieving of updated data. The form is YYYY-MM-DD .
+     *
+     * @param dateUntil The form is YYYY-MM-DD .
+     */
+    public void setDateUntil(final String dateUntil) {
+        this.dateUntil = dateUntil;
+    }
 
-	/**
-	 * Sets the end of the retrieving of updated data. The form is YYYY-MM-DD .
-	 *
-	 * @param dateUntil The form is YYYY-MM-DD .
-	 */
-	public void setDateUntil(final String dateUntil) {
-		this.dateUntil = dateUntil;
-	}
+    /**
+     * Sets the OAI-PM metadata prefix .
+     *
+     * @param metadataPrefix the OAI-PM metadata prefix
+     */
+    public void setMetadataPrefix(final String metadataPrefix) {
+        this.metadataPrefix = metadataPrefix;
+    }
 
-	/**
-	 * Sets the OAI-PM metadata prefix .
-	 *
-	 * @param metadataPrefix the OAI-PM metadata prefix
-	 */
-	public void setMetadataPrefix(final String metadataPrefix) {
-		this.metadataPrefix = metadataPrefix;
-	}
+    /**
+     * Sets the OAI-PM set specification .
+     *
+     * @param setSpec th OAI-PM set specification
+     */
+    public void setSetSpec(final String setSpec) {
+        this.setSpec = setSpec;
+    }
 
-	/**
-	 * Sets the OAI-PM set specification .
-	 *
-	 * @param setSpec th OAI-PM set specification
-	 */
-	public void setSetSpec(final String setSpec) {
-		this.setSpec = setSpec;
-	}
+    @Override
+    public void process(final String baseUrl) {
 
-	@Override
-	public void process(final String baseUrl) {
-
-		try {
-			RawWrite.run(baseUrl, this.dateFrom, this.dateUntil, this.metadataPrefix,
-					this.setSpec, OUTPUT_STREAM);
-		} catch (IOException e) {
-			e.printStackTrace();
-		} catch (ParserConfigurationException e) {
-			e.printStackTrace();
-		} catch (SAXException e) {
-			e.printStackTrace();
-		} catch (TransformerException e) {
-			e.printStackTrace();
-		} catch (NoSuchFieldException e) {
-			e.printStackTrace();
-		}
-		try {
-			getReceiver().process(
-					new InputStreamReader(new ByteArrayInputStream(OUTPUT_STREAM
-							.toByteArray()), encoding));
-		} catch (IOException e) {
-			throw new MetafactureException(e);
-		}
-	}
+        try {
+            RawWrite.run(baseUrl, this.dateFrom, this.dateUntil, this.metadataPrefix, this.setSpec, outputStream);
+        }
+        catch (final IOException e) {
+            e.printStackTrace();
+        }
+        catch (final ParserConfigurationException e) {
+            e.printStackTrace();
+        }
+        catch (final SAXException e) {
+            e.printStackTrace();
+        }
+        catch (final TransformerException e) {
+            e.printStackTrace();
+        }
+        catch (final NoSuchFieldException e) {
+            e.printStackTrace();
+        }
+        try {
+            getReceiver().process(
+                    new InputStreamReader(new ByteArrayInputStream(outputStream.toByteArray()), encoding));
+        }
+        catch (final IOException e) {
+            throw new MetafactureException(e);
+        }
+    }
 }

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/iso2709/DirectoryBuilder.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/iso2709/DirectoryBuilder.java
@@ -13,11 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.biblio.iso2709;
 
-import static org.metafacture.biblio.iso2709.Iso2709Constants.FIELD_SEPARATOR;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.MAX_PAYLOAD_LENGTH;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.TAG_LENGTH;
+package org.metafacture.biblio.iso2709;
 
 import org.metafacture.framework.FormatException;
 
@@ -31,6 +28,8 @@ import org.metafacture.framework.FormatException;
  */
 final class DirectoryBuilder {
 
+    private static final int RADIX = 10;
+
     private final Iso646ByteBuffer buffer;
 
     private final int fieldStartLength;
@@ -41,11 +40,11 @@ final class DirectoryBuilder {
     private final int maxFieldLength;
 
     DirectoryBuilder(final RecordFormat format) {
-        buffer = new Iso646ByteBuffer(MAX_PAYLOAD_LENGTH);
+        buffer = new Iso646ByteBuffer(Iso2709Constants.MAX_PAYLOAD_LENGTH);
         fieldStartLength = format.getFieldStartLength();
         fieldLengthLength = format.getFieldLengthLength();
         implDefinedPartLength = format.getImplDefinedPartLength();
-        entryLength = TAG_LENGTH + fieldStartLength + fieldLengthLength +
+        entryLength = Iso2709Constants.TAG_LENGTH + fieldStartLength + fieldLengthLength +
                 implDefinedPartLength;
         maxFieldStart = calculateMaxValue(fieldStartLength);
         maxFieldLength = calculateMaxValue(fieldLengthLength);
@@ -54,15 +53,15 @@ final class DirectoryBuilder {
     private int calculateMaxValue(final int digits) {
         assert digits >= 0;
         int maxValue = 1;
-        for (int i = 0; i < digits; i++) {
-            maxValue *= 10;
+        for (int i = 0; i < digits; ++i) {
+            maxValue *= RADIX;
         }
         return maxValue - 1;
     }
 
     void addEntries(final char[] tag, final char[] implDefinedPart,
             final int fieldStart, final int fieldEnd) {
-        assert tag.length == TAG_LENGTH;
+        assert tag.length == Iso2709Constants.TAG_LENGTH;
         assert implDefinedPart.length == implDefinedPartLength;
         assert fieldStart >= 0;
         assert fieldEnd >= fieldStart;
@@ -125,7 +124,7 @@ final class DirectoryBuilder {
         System.arraycopy(buffer.getByteArray(), 0, destBuffer, fromIndex,
                 directoryLength);
         final int directoryEnd = fromIndex + directoryLength;
-        destBuffer[directoryEnd] = FIELD_SEPARATOR;
+        destBuffer[directoryEnd] = Iso2709Constants.FIELD_SEPARATOR;
     }
 
     @Override

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/iso2709/DirectoryEntry.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/iso2709/DirectoryEntry.java
@@ -13,12 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.biblio.iso2709;
 
-import static org.metafacture.biblio.iso2709.Iso2709Constants.MAX_BASE_ADDRESS;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.MIN_BASE_ADDRESS;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.RECORD_LABEL_LENGTH;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.TAG_LENGTH;
+package org.metafacture.biblio.iso2709;
 
 /**
  * Provides access to a directory entry. A {@code DirectoryEntry} works like
@@ -43,21 +39,21 @@ class DirectoryEntry {
     DirectoryEntry(final Iso646ByteBuffer buffer, final RecordFormat recordFormat,
             final int baseAddress) {
         assert buffer != null;
-        assert baseAddress >= MIN_BASE_ADDRESS;
-        assert baseAddress <= MAX_BASE_ADDRESS;
+        assert baseAddress >= Iso2709Constants.MIN_BASE_ADDRESS;
+        assert baseAddress <= Iso2709Constants.MAX_BASE_ADDRESS;
 
         this.buffer = buffer;
         directoryEnd = baseAddress - Byte.BYTES;
         fieldLengthLength = recordFormat.getFieldLengthLength();
         fieldStartLength = recordFormat.getFieldStartLength();
         implDefinedPartLength = recordFormat.getImplDefinedPartLength();
-        entryLength = TAG_LENGTH + fieldLengthLength + fieldStartLength +
+        entryLength = Iso2709Constants.TAG_LENGTH + fieldLengthLength + fieldStartLength +
                 implDefinedPartLength;
         rewind();
     }
 
     void rewind() {
-        currentPosition = RECORD_LABEL_LENGTH;
+        currentPosition = Iso2709Constants.RECORD_LABEL_LENGTH;
     }
 
     void gotoNext() {
@@ -71,25 +67,25 @@ class DirectoryEntry {
 
     char[] getTag() {
         assert currentPosition < directoryEnd;
-        return buffer.charsAt(currentPosition, TAG_LENGTH);
+        return buffer.charsAt(currentPosition, Iso2709Constants.TAG_LENGTH);
     }
 
     int getFieldLength() {
         assert currentPosition < directoryEnd;
-        final int fieldLengthStart = currentPosition + TAG_LENGTH;
+        final int fieldLengthStart = currentPosition + Iso2709Constants.TAG_LENGTH;
         return buffer.parseIntAt(fieldLengthStart, fieldLengthLength);
     }
 
     int getFieldStart() {
         assert currentPosition < directoryEnd;
-        final int fieldStartStart = currentPosition + TAG_LENGTH +
+        final int fieldStartStart = currentPosition + Iso2709Constants.TAG_LENGTH +
                 fieldLengthLength;
         return buffer.parseIntAt(fieldStartStart, fieldStartLength);
     }
 
     char[] getImplDefinedPart() {
         assert currentPosition < directoryEnd;
-        final int implDefinedPartStart = currentPosition + TAG_LENGTH +
+        final int implDefinedPartStart = currentPosition + Iso2709Constants.TAG_LENGTH +
                 fieldLengthLength + fieldStartLength;
         return buffer.charsAt(implDefinedPartStart, implDefinedPartLength);
     }

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/iso2709/FieldHandler.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/iso2709/FieldHandler.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.biblio.iso2709;
 
 /**

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/iso2709/FieldsBuilder.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/iso2709/FieldsBuilder.java
@@ -13,16 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.biblio.iso2709;
 
-import static org.metafacture.biblio.iso2709.Iso2709Constants.FIELD_SEPARATOR;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.IDENTIFIER_MARKER;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.RECORD_SEPARATOR;
+import org.metafacture.framework.FormatException;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-
-import org.metafacture.framework.FormatException;
 
 /**
  * Builds a list of fields in ISO 2709:2008 format.
@@ -42,7 +39,6 @@ final class FieldsBuilder {
 
     private int undoMarker = NO_MARKER_SET;
     private boolean inField;
-
 
     FieldsBuilder(final RecordFormat format, final int maxSize) {
         buffer = new Iso646ByteBuffer(maxSize);
@@ -75,7 +71,7 @@ final class FieldsBuilder {
         assert inField;
         checkCapacity(Byte.BYTES);
         inField = false;
-        buffer.writeByte(FIELD_SEPARATOR);
+        buffer.writeByte(Iso2709Constants.FIELD_SEPARATOR);
         return buffer.getWritePosition();
     }
 
@@ -91,7 +87,7 @@ final class FieldsBuilder {
         final byte[] bytes = value.getBytes(charset);
         checkCapacity(bytes.length + identifierLength + Byte.BYTES);
         if (identifierLength > 0) {
-            buffer.writeByte(IDENTIFIER_MARKER);
+            buffer.writeByte(Iso2709Constants.IDENTIFIER_MARKER);
             buffer.writeChars(identifier);
         }
         buffer.writeBytes(bytes);
@@ -126,7 +122,7 @@ final class FieldsBuilder {
         System.arraycopy(buffer.getByteArray(), 0, destBuffer, fromIndex,
                 fieldLength);
         final int fieldsEnd = fromIndex + fieldLength;
-        destBuffer[fieldsEnd] = RECORD_SEPARATOR;
+        destBuffer[fieldsEnd] = Iso2709Constants.RECORD_SEPARATOR;
     }
 
     @Override

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/iso2709/Iso2709Constants.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/iso2709/Iso2709Constants.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.biblio.iso2709;
 
 /**

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/iso2709/Iso646ByteBuffer.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/iso2709/Iso646ByteBuffer.java
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.biblio.iso2709;
 
-import java.nio.charset.Charset;
-
 import org.metafacture.framework.FormatException;
+
+import java.nio.charset.Charset;
 
 /**
  * Provides methods for reading and writing strings and integers in a byte
@@ -255,7 +256,7 @@ final class Iso646ByteBuffer {
     }
 
     void writeInt(final int value) {
-        assert 0 <= value && value < 10;
+        assert 0 <= value && value < RADIX;
         byteArray[writePosition] = (byte) (Iso646Constants.ZERO + value);
         writePosition += 1;
     }
@@ -265,7 +266,7 @@ final class Iso646ByteBuffer {
         assert digits >= 0;
         assert (writePosition + digits) <= byteArray.length;
         int head = value;
-        for (int i = writePosition + digits - 1; i >= writePosition; i--) {
+        for (int i = writePosition + digits - 1; i >= writePosition; --i) {
             byteArray[i] = (byte) (Iso646Constants.ZERO + head % RADIX);
             head /= RADIX;
         }

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/iso2709/Iso646Constants.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/iso2709/Iso646Constants.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.biblio.iso2709;
 
 import java.nio.charset.Charset;

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/iso2709/Label.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/iso2709/Label.java
@@ -13,24 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.biblio.iso2709;
 
-import static org.metafacture.biblio.iso2709.Iso2709Constants.BASE_ADDRESS_LENGTH;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.BASE_ADDRESS_START;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.FIELD_LENGTH_LENGTH_POS;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.FIELD_START_LENGTH_POS;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.IDENTIFIER_LENGTH_POS;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.IMPL_CODES_LENGTH;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.IMPL_CODES_START;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.IMPL_DEFINED_PART_LENGTH_POS;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.INDICATOR_LENGTH_POS;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.RECORD_LABEL_LENGTH;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.RECORD_LENGTH_LENGTH;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.RECORD_LENGTH_START;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.RECORD_STATUS_POS;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.RESERVED_CHAR_POS;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.SYSTEM_CHARS_LENGTH;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.SYSTEM_CHARS_START;
+package org.metafacture.biblio.iso2709;
 
 /**
  * Provides read access to the record label of a ISO 2709:2008 formatted
@@ -46,7 +30,7 @@ class Label {
 
     Label(final Iso646ByteBuffer buffer) {
         final int bufferLength = buffer.getLength();
-        assert bufferLength >= RECORD_LABEL_LENGTH;
+        assert bufferLength >= Iso2709Constants.RECORD_LABEL_LENGTH;
         this.buffer = buffer;
     }
 
@@ -61,52 +45,52 @@ class Label {
     }
 
     int getRecordLength() {
-        return buffer.parseIntAt(RECORD_LENGTH_START, RECORD_LENGTH_LENGTH);
+        return buffer.parseIntAt(Iso2709Constants.RECORD_LENGTH_START, Iso2709Constants.RECORD_LENGTH_LENGTH);
     }
 
     char getRecordStatus() {
-        return buffer.charAt(RECORD_STATUS_POS);
+        return buffer.charAt(Iso2709Constants.RECORD_STATUS_POS);
     }
 
     char[] getImplCodes() {
-        return buffer.charsAt(IMPL_CODES_START, IMPL_CODES_LENGTH);
+        return buffer.charsAt(Iso2709Constants.IMPL_CODES_START, Iso2709Constants.IMPL_CODES_LENGTH);
     }
 
     int getIndicatorLength() {
-        return buffer.parseIntAt(INDICATOR_LENGTH_POS);
+        return buffer.parseIntAt(Iso2709Constants.INDICATOR_LENGTH_POS);
     }
 
     int getIdentifierLength() {
-        return buffer.parseIntAt(IDENTIFIER_LENGTH_POS);
+        return buffer.parseIntAt(Iso2709Constants.IDENTIFIER_LENGTH_POS);
     }
 
     int getBaseAddress() {
-        return buffer.parseIntAt(BASE_ADDRESS_START, BASE_ADDRESS_LENGTH);
+        return buffer.parseIntAt(Iso2709Constants.BASE_ADDRESS_START, Iso2709Constants.BASE_ADDRESS_LENGTH);
     }
 
     char[] getSystemChars() {
-        return buffer.charsAt(SYSTEM_CHARS_START, SYSTEM_CHARS_LENGTH);
+        return buffer.charsAt(Iso2709Constants.SYSTEM_CHARS_START, Iso2709Constants.SYSTEM_CHARS_LENGTH);
     }
 
     int getFieldLengthLength() {
-        return buffer.parseIntAt(FIELD_LENGTH_LENGTH_POS);
+        return buffer.parseIntAt(Iso2709Constants.FIELD_LENGTH_LENGTH_POS);
     }
 
     int getFieldStartLength() {
-        return buffer.parseIntAt(FIELD_START_LENGTH_POS);
+        return buffer.parseIntAt(Iso2709Constants.FIELD_START_LENGTH_POS);
     }
 
     int getImplDefinedPartLength() {
-        return buffer.parseIntAt(IMPL_DEFINED_PART_LENGTH_POS);
+        return buffer.parseIntAt(Iso2709Constants.IMPL_DEFINED_PART_LENGTH_POS);
     }
 
     char getReservedChar() {
-        return buffer.charAt(RESERVED_CHAR_POS);
+        return buffer.charAt(Iso2709Constants.RESERVED_CHAR_POS);
     }
 
     @Override
     public String toString() {
-        return buffer.stringAt(0, RECORD_LABEL_LENGTH, Iso646Constants.CHARSET);
+        return buffer.stringAt(0, Iso2709Constants.RECORD_LABEL_LENGTH, Iso646Constants.CHARSET);
     }
 
 }

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/iso2709/LabelBuilder.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/iso2709/LabelBuilder.java
@@ -13,28 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.biblio.iso2709;
 
-import static org.metafacture.biblio.iso2709.Iso2709Constants.BASE_ADDRESS_LENGTH;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.BASE_ADDRESS_START;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.FIELD_LENGTH_LENGTH_POS;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.FIELD_START_LENGTH_POS;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.IDENTIFIER_LENGTH_POS;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.IMPL_CODES_LENGTH;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.IMPL_CODES_START;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.IMPL_DEFINED_PART_LENGTH_POS;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.INDICATOR_LENGTH_POS;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.MAX_BASE_ADDRESS;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.MAX_RECORD_LENGTH;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.MIN_BASE_ADDRESS;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.MIN_RECORD_LENGTH;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.RECORD_LABEL_LENGTH;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.RECORD_LENGTH_LENGTH;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.RECORD_LENGTH_START;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.RECORD_STATUS_POS;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.RESERVED_CHAR_POS;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.SYSTEM_CHARS_LENGTH;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.SYSTEM_CHARS_START;
+package org.metafacture.biblio.iso2709;
 
 import java.util.Arrays;
 
@@ -49,87 +29,87 @@ import java.util.Arrays;
 class LabelBuilder {
 
     private static final char DEFAULT_RECORD_STATUS = ' ';
-    private static final char[] DEFAULT_IMPL_CODES = { ' ', ' ', ' ', ' ' };
-    private static final char[] DEFAULT_SYSTEM_CHARS = { ' ', ' ', ' ' };
+    private static final char[] DEFAULT_IMPL_CODES = {' ', ' ', ' ', ' '};
+    private static final char[] DEFAULT_SYSTEM_CHARS = {' ', ' ', ' '};
     private static final char DEFAULT_RESERVED_CHAR = ' ';
 
     private final Iso646ByteBuffer buffer;
     private final byte[] defaultLabel;
 
     LabelBuilder(final RecordFormat recordFormat) {
-        buffer = new Iso646ByteBuffer(RECORD_LABEL_LENGTH);
+        buffer = new Iso646ByteBuffer(Iso2709Constants.RECORD_LABEL_LENGTH);
         defaultLabel = buildDefaultLabel(recordFormat);
     }
 
     private byte[] buildDefaultLabel(final RecordFormat recordFormat) {
         writeRecordFormatToLabel(recordFormat);
-        setRecordLength(MIN_RECORD_LENGTH);
+        setRecordLength(Iso2709Constants.MIN_RECORD_LENGTH);
         setRecordStatus(DEFAULT_RECORD_STATUS);
         setImplCodes(DEFAULT_IMPL_CODES);
-        setBaseAddress(MIN_BASE_ADDRESS);
+        setBaseAddress(Iso2709Constants.MIN_BASE_ADDRESS);
         setSystemChars(DEFAULT_SYSTEM_CHARS);
         setReservedChar(DEFAULT_RESERVED_CHAR);
         return Arrays.copyOf(buffer.getByteArray(), buffer.getLength());
     }
 
     private void writeRecordFormatToLabel(final RecordFormat recordFormat) {
-        buffer.setWritePosition(INDICATOR_LENGTH_POS);
+        buffer.setWritePosition(Iso2709Constants.INDICATOR_LENGTH_POS);
         buffer.writeInt(recordFormat.getIndicatorLength());
-        buffer.setWritePosition(IDENTIFIER_LENGTH_POS);
+        buffer.setWritePosition(Iso2709Constants.IDENTIFIER_LENGTH_POS);
         buffer.writeInt(recordFormat.getIdentifierLength());
-        buffer.setWritePosition(FIELD_LENGTH_LENGTH_POS);
+        buffer.setWritePosition(Iso2709Constants.FIELD_LENGTH_LENGTH_POS);
         buffer.writeInt(recordFormat.getFieldLengthLength());
-        buffer.setWritePosition(FIELD_START_LENGTH_POS);
+        buffer.setWritePosition(Iso2709Constants.FIELD_START_LENGTH_POS);
         buffer.writeInt(recordFormat.getFieldStartLength());
-        buffer.setWritePosition(IMPL_DEFINED_PART_LENGTH_POS);
+        buffer.setWritePosition(Iso2709Constants.IMPL_DEFINED_PART_LENGTH_POS);
         buffer.writeInt(recordFormat.getImplDefinedPartLength());
     }
 
     void setRecordLength(final int recordLength) {
-        assert recordLength >= MIN_RECORD_LENGTH;
-        assert recordLength <= MAX_RECORD_LENGTH;
-        buffer.setWritePosition(RECORD_LENGTH_START);
-        buffer.writeInt(recordLength, RECORD_LENGTH_LENGTH);
+        assert recordLength >= Iso2709Constants.MIN_RECORD_LENGTH;
+        assert recordLength <= Iso2709Constants.MAX_RECORD_LENGTH;
+        buffer.setWritePosition(Iso2709Constants.RECORD_LENGTH_START);
+        buffer.writeInt(recordLength, Iso2709Constants.RECORD_LENGTH_LENGTH);
     }
 
     void setRecordStatus(final char recordStatus) {
-        buffer.setWritePosition(RECORD_STATUS_POS);
+        buffer.setWritePosition(Iso2709Constants.RECORD_STATUS_POS);
         buffer.writeChar(recordStatus);
     }
 
     void setImplCodes(final char[] implCodes) {
-        assert implCodes.length == IMPL_CODES_LENGTH;
-        buffer.setWritePosition(IMPL_CODES_START);
+        assert implCodes.length == Iso2709Constants.IMPL_CODES_LENGTH;
+        buffer.setWritePosition(Iso2709Constants.IMPL_CODES_START);
         buffer.writeChars(implCodes);
     }
 
     void setImplCode(final int index, final char value) {
-        assert 0 <= index && index < IMPL_CODES_LENGTH;
-        buffer.setWritePosition(IMPL_CODES_START + index);
+        assert 0 <= index && index < Iso2709Constants.IMPL_CODES_LENGTH;
+        buffer.setWritePosition(Iso2709Constants.IMPL_CODES_START + index);
         buffer.writeChar(value);
     }
 
     void setBaseAddress(final int baseAddress) {
-        assert baseAddress >= MIN_BASE_ADDRESS;
-        assert baseAddress <= MAX_BASE_ADDRESS;
-        buffer.setWritePosition(BASE_ADDRESS_START);
-        buffer.writeInt(baseAddress, BASE_ADDRESS_LENGTH);
+        assert baseAddress >= Iso2709Constants.MIN_BASE_ADDRESS;
+        assert baseAddress <= Iso2709Constants.MAX_BASE_ADDRESS;
+        buffer.setWritePosition(Iso2709Constants.BASE_ADDRESS_START);
+        buffer.writeInt(baseAddress, Iso2709Constants.BASE_ADDRESS_LENGTH);
     }
 
     void setSystemChars(final char[] systemChars) {
-        assert systemChars.length == SYSTEM_CHARS_LENGTH;
-        buffer.setWritePosition(SYSTEM_CHARS_START);
+        assert systemChars.length == Iso2709Constants.SYSTEM_CHARS_LENGTH;
+        buffer.setWritePosition(Iso2709Constants.SYSTEM_CHARS_START);
         buffer.writeChars(systemChars);
     }
 
     void setSystemChar(final int index, final char value) {
-        assert 0 <= index && index < SYSTEM_CHARS_LENGTH;
-        buffer.setWritePosition(SYSTEM_CHARS_START + index);
+        assert 0 <= index && index < Iso2709Constants.SYSTEM_CHARS_LENGTH;
+        buffer.setWritePosition(Iso2709Constants.SYSTEM_CHARS_START + index);
         buffer.writeChar(value);
     }
 
     void setReservedChar(final char reservedChar) {
-        buffer.setWritePosition(RESERVED_CHAR_POS);
+        buffer.setWritePosition(Iso2709Constants.RESERVED_CHAR_POS);
         buffer.writeChar(reservedChar);
     }
 

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/iso2709/Record.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/iso2709/Record.java
@@ -13,18 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.biblio.iso2709;
-
-import static org.metafacture.biblio.iso2709.Iso2709Constants.FIELD_SEPARATOR;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.IDENTIFIER_MARKER;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.MIN_BASE_ADDRESS;
-import static org.metafacture.biblio.iso2709.Iso2709Constants.MIN_RECORD_LENGTH;
-
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 
 import org.metafacture.commons.Require;
 import org.metafacture.framework.FormatException;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Reads a record in ISO 2709:2008 format from a byte array.
@@ -36,7 +32,7 @@ public final class Record {
     private static final int RECORD_ID_MISSING = -1;
     private static final char[] EMPTY_IDENTIFIER = new char[0];
     private static final byte[] DATA_SEPARATORS = {
-            FIELD_SEPARATOR, IDENTIFIER_MARKER
+        Iso2709Constants.FIELD_SEPARATOR, Iso2709Constants.IDENTIFIER_MARKER
     };
 
     private final Iso646ByteBuffer buffer;
@@ -73,13 +69,13 @@ public final class Record {
     }
 
     private void checkRecordDataLength(final byte[] recordData) {
-        if (recordData.length < MIN_RECORD_LENGTH) {
+        if (recordData.length < Iso2709Constants.MIN_RECORD_LENGTH) {
             throw new FormatException("record is too short");
         }
     }
 
     private void checkBaseAddress() {
-        if (baseAddress < MIN_BASE_ADDRESS || baseAddress > buffer.getLength() - 1) {
+        if (baseAddress < Iso2709Constants.MIN_BASE_ADDRESS || baseAddress > buffer.getLength() - 1) {
             throw new FormatException("base address is out of range");
         }
     }
@@ -164,40 +160,43 @@ public final class Record {
     public String getLabel() {
         return label.toString();
     }
+
     /**
      * Iterates through all fields in the record and calls the appropriate method
      * on the supplied {@link FieldHandler} instance.
      *
-     * @param fieldHandler instance of field handler. Must not be null.
+     * @param currentFieldHandler instance of field handler. Must not be null.
      */
-    public void processFields(final FieldHandler fieldHandler) {
-        this.fieldHandler = Require.notNull(fieldHandler);
+    public void processFields(final FieldHandler currentFieldHandler) {
+        fieldHandler = Require.notNull(currentFieldHandler);
         boolean continuedField = false;
         directoryEntry.rewind();
         while (!directoryEntry.endOfDirectoryReached()) {
             if (continuedField) {
                 fieldHandler.additionalImplDefinedPart(
                         directoryEntry.getImplDefinedPart());
-            } else {
+            }
+            else {
                 processField();
             }
             continuedField = directoryEntry.isContinuedField();
             directoryEntry.gotoNext();
         }
-        this.fieldHandler = null;
+        fieldHandler = null;
     }
 
     private void processField() {
         if (directoryEntry.isReferenceField()) {
             processReferenceField();
-        } else {
+        }
+        else {
             processDataField();
         }
     }
 
     private void processReferenceField() {
         final int fieldStart = baseAddress + directoryEntry.getFieldStart();
-        final int fieldLength = buffer.distanceTo(FIELD_SEPARATOR, fieldStart);
+        final int fieldLength = buffer.distanceTo(Iso2709Constants.FIELD_SEPARATOR, fieldStart);
         final String value = buffer.stringAt(fieldStart, fieldLength, charset);
         fieldHandler.referenceField(directoryEntry.getTag(),
                 directoryEntry.getImplDefinedPart(), value);
@@ -214,7 +213,7 @@ public final class Record {
 
     private void processDataValues(final int fromIndex) {
         int start = fromIndex;
-        while (buffer.byteAt(start) != FIELD_SEPARATOR) {
+        while (buffer.byteAt(start) != Iso2709Constants.FIELD_SEPARATOR) {
             start = processDataValue(start);
         }
     }

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/iso2709/RecordFormat.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/iso2709/RecordFormat.java
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.biblio.iso2709;
 
-import java.util.Arrays;
-
 import org.metafacture.commons.Require;
+
+import java.util.Arrays;
 
 /**
  * Holds the configuration of an instance of the ISO2709:2008 format.
@@ -30,19 +31,19 @@ public final class RecordFormat {
     /**
      * The number of characters in the field tags.
      */
-    public final int TAG_LENGTH = Iso2709Constants.TAG_LENGTH;
+    public static final int TAG_LENGTH = Iso2709Constants.TAG_LENGTH;
 
     /**
      * The number of characters in the implementation codes element of the
      * record leader.
      */
-    public final int IMPL_CODES_LENGTH = Iso2709Constants.IMPL_CODES_LENGTH;
+    public static final int IMPL_CODES_LENGTH = Iso2709Constants.IMPL_CODES_LENGTH;
 
     /**
      * The number of characters in the system characters element of the
      * record leader.
      */
-    public final int SYSTEM_CHARS_LENGTH = Iso2709Constants.SYSTEM_CHARS_LENGTH;
+    public static final int SYSTEM_CHARS_LENGTH = Iso2709Constants.SYSTEM_CHARS_LENGTH;
 
     private final int indicatorLength;
     private final int identifierLength;
@@ -110,19 +111,19 @@ public final class RecordFormat {
         }
         if (obj instanceof RecordFormat) {
             final RecordFormat other = (RecordFormat) obj;
-            return indicatorLength == other.indicatorLength
-                    && identifierLength == other.identifierLength
-                    && fieldLengthLength == other.fieldLengthLength
-                    && fieldStartLength == other.fieldStartLength
-                    && implDefinedPartLength == other.implDefinedPartLength;
+            return indicatorLength == other.indicatorLength &&
+                    identifierLength == other.identifierLength &&
+                    fieldLengthLength == other.fieldLengthLength &&
+                    fieldStartLength == other.fieldStartLength &&
+                    implDefinedPartLength == other.implDefinedPartLength;
         }
         return false;
     }
 
     @Override
     public int hashCode() {
-        final int[] items = { indicatorLength, identifierLength, fieldLengthLength,
-                fieldStartLength, implDefinedPartLength };
+        final int[] items = {indicatorLength, identifierLength, fieldLengthLength,
+            fieldStartLength, implDefinedPartLength};
         return Arrays.hashCode(items);
     }
 
@@ -137,44 +138,49 @@ public final class RecordFormat {
 
     public static class Builder {
 
+        private static final int RADIX = 10;
+
         private int indicatorLength;
         private int identifierLength;
         private int fieldLengthLength;
         private int fieldStartLength;
         private int implDefinedPartLength;
 
-        public Builder withIndicatorLength(final int indicatorLength) {
-            Require.notNegative(indicatorLength);
-            Require.that(indicatorLength <= 9);
-            this.indicatorLength = indicatorLength;
+        Builder() {
+        }
+
+        public Builder withIndicatorLength(final int currentIndicatorLength) {
+            Require.notNegative(currentIndicatorLength);
+            Require.that(currentIndicatorLength < RADIX);
+            indicatorLength = currentIndicatorLength;
             return this;
         }
 
-        public Builder withIdentifierLength(final int identifierLength) {
-            Require.notNegative(identifierLength);
-            Require.that(identifierLength <= 9);
-            this.identifierLength = identifierLength;
+        public Builder withIdentifierLength(final int currentIdentifierLength) {
+            Require.notNegative(currentIdentifierLength);
+            Require.that(currentIdentifierLength < RADIX);
+            identifierLength = currentIdentifierLength;
             return this;
         }
 
-        public Builder withFieldLengthLength(final int fieldLengthLength) {
-            Require.that(fieldLengthLength > 0);
-            Require.that(fieldLengthLength <= 9);
-            this.fieldLengthLength = fieldLengthLength;
+        public Builder withFieldLengthLength(final int currentFieldLengthLength) {
+            Require.that(currentFieldLengthLength > 0);
+            Require.that(currentFieldLengthLength < RADIX);
+            fieldLengthLength = currentFieldLengthLength;
             return this;
         }
 
-        public Builder withFieldStartLength(final int fieldStartLength) {
-            Require.that(fieldStartLength > 0);
-            Require.that(fieldStartLength <= 9);
-            this.fieldStartLength = fieldStartLength;
+        public Builder withFieldStartLength(final int currentFieldStartLength) {
+            Require.that(currentFieldStartLength > 0);
+            Require.that(currentFieldStartLength < RADIX);
+            fieldStartLength = currentFieldStartLength;
             return this;
         }
 
-        public Builder withImplDefinedPartLength(final int implDefinedPartLength) {
-            Require.notNegative(implDefinedPartLength);
-            Require.that(implDefinedPartLength <= 9);
-            this.implDefinedPartLength = implDefinedPartLength;
+        public Builder withImplDefinedPartLength(final int currentImplDefinedPartLength) {
+            Require.notNegative(currentImplDefinedPartLength);
+            Require.that(currentImplDefinedPartLength < RADIX);
+            implDefinedPartLength = currentImplDefinedPartLength;
             return this;
         }
 

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/marc21/Marc21Constants.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/marc21/Marc21Constants.java
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.biblio.marc21;
+
+import org.metafacture.biblio.iso2709.RecordFormat;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-
-import org.metafacture.biblio.iso2709.RecordFormat;
 
 /**
  * Useful constants for the MARC 21 format.
@@ -27,43 +28,43 @@ import org.metafacture.biblio.iso2709.RecordFormat;
  */
 final class Marc21Constants {
 
-  static final RecordFormat MARC21_FORMAT = RecordFormat.create()
-      .withIndicatorLength(2)
-      .withIdentifierLength(2)
-      .withFieldLengthLength(4)
-      .withFieldStartLength(5)
-      .withImplDefinedPartLength(0)
-      .build();
+    static final RecordFormat MARC21_FORMAT = RecordFormat.create()
+        .withIndicatorLength(2)
+        .withIdentifierLength(2)
+        .withFieldLengthLength(4) // checkstyle-disable-line MagicNumber
+        .withFieldStartLength(5) // checkstyle-disable-line MagicNumber
+        .withImplDefinedPartLength(0)
+        .build();
 
-  static final Charset MARC21_CHARSET = StandardCharsets.UTF_8;
+    static final Charset MARC21_CHARSET = StandardCharsets.UTF_8;
 
-  static final int RECORD_TYPE_INDEX = 0;
-  static final int BIBLIOGRAPHIC_LEVEL_INDEX = 1;
-  static final int TYPE_OF_CONTROL_INDEX = 2;
-  static final int CHARACTER_CODING_INDEX = 3;
-  static final int ENCODING_LEVEL_INDEX = 0;
-  static final int CATALOGING_FORM_INDEX = 1;
-  static final int MULTIPART_LEVEL_INDEX = 2;
+    static final int RECORD_TYPE_INDEX = 0;
+    static final int BIBLIOGRAPHIC_LEVEL_INDEX = 1;
+    static final int TYPE_OF_CONTROL_INDEX = 2;
+    static final int CHARACTER_CODING_INDEX = 3;
+    static final int ENCODING_LEVEL_INDEX = 0;
+    static final int CATALOGING_FORM_INDEX = 1;
+    static final int MULTIPART_LEVEL_INDEX = 2;
 
-  static final char[] RECORD_STATUS_CODES = { 'a', 'c', 'd', 'n', 'p' };
-  static final char[] RECORD_TYPE_CODES = {
-    'a', 'c', 'd', 'e', 'f', 'g', 'i', 'j', 'k', 'm', 'o', 'p', 'r', 't'
-  };
-  static final char[] BIBLIOGRAPHIC_LEVEL_CODES = {
-    'a', 'b', 'c', 'd', 'i', 'm', 's'
-  };
-  static final char[] TYPE_OF_CONTROL_CODES = { ' ', 'a' };
-  static final char[] CHARACTER_CODING_CODES = { 'a' };
-  static final char[] ENCODING_LEVEL_CODES = {
-    ' ', '1', '2', '3', '4', '5', '7', '8', 'u', 'z'
-  };
-  static final char[] CATALOGING_FORM_CODES = { ' ', 'a', 'c', 'i', 'u' };
-  static final char[] MULTIPART_LEVEL_CODES = { ' ', 'a', 'b', 'c' };
+    static final char[] RECORD_STATUS_CODES = {'a', 'c', 'd', 'n', 'p'};
+    static final char[] RECORD_TYPE_CODES = {
+        'a', 'c', 'd', 'e', 'f', 'g', 'i', 'j', 'k', 'm', 'o', 'p', 'r', 't'
+    };
+    static final char[] BIBLIOGRAPHIC_LEVEL_CODES = {
+        'a', 'b', 'c', 'd', 'i', 'm', 's'
+    };
+    static final char[] TYPE_OF_CONTROL_CODES = {' ', 'a'};
+    static final char[] CHARACTER_CODING_CODES = {'a'};
+    static final char[] ENCODING_LEVEL_CODES = {
+        ' ', '1', '2', '3', '4', '5', '7', '8', 'u', 'z'
+    };
+    static final char[] CATALOGING_FORM_CODES = {' ', 'a', 'c', 'i', 'u'};
+    static final char[] MULTIPART_LEVEL_CODES = {' ', 'a', 'b', 'c'};
 
-  static final char RESERVED_CHAR = '0';
+    static final char RESERVED_CHAR = '0';
 
-  private Marc21Constants() {
-    throw new AssertionError("class should not be instantiated");
-  }
+    private Marc21Constants() {
+        throw new AssertionError("class should not be instantiated");
+    }
 
 }

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/marc21/Marc21Decoder.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/marc21/Marc21Decoder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.biblio.marc21;
 
 import org.metafacture.biblio.iso2709.FieldHandler;
@@ -134,13 +135,15 @@ import org.metafacture.framework.helpers.DefaultObjectPipe;
 @Out(StreamReceiver.class)
 @Description("Decodes MARC 21 records")
 @FluxCommand("decode-marc21")
-public final class Marc21Decoder
-        extends DefaultObjectPipe<String, StreamReceiver> {
+public final class Marc21Decoder extends DefaultObjectPipe<String, StreamReceiver> {
 
     private final FieldHandler fieldHandler = new Marc21Handler();
 
     private boolean ignoreMissingId;
     private boolean emitLeaderAsWhole;
+
+    public Marc21Decoder() {
+    }
 
     /**
      * Controls whether the decoder aborts processing if a record has no
@@ -227,27 +230,28 @@ public final class Marc21Decoder
 
     private void emitLeader(final Record record) {
         getReceiver().startEntity(Marc21EventNames.LEADER_ENTITY);
-        if (emitLeaderAsWhole){
+        if (emitLeaderAsWhole) {
             getReceiver().literal(Marc21EventNames.LEADER_ENTITY, record.getLabel());
-        }else {
-        final char[] implCodes = record.getImplCodes();
-        final char[] systemChars = record.getSystemChars();
-        getReceiver().literal(Marc21EventNames.RECORD_STATUS_LITERAL, String.valueOf(
-                record.getRecordStatus()));
-        getReceiver().literal(Marc21EventNames.RECORD_TYPE_LITERAL, String.valueOf(
-                implCodes[Marc21Constants.RECORD_TYPE_INDEX]));
-        getReceiver().literal(Marc21EventNames.BIBLIOGRAPHIC_LEVEL_LITERAL, String.valueOf(
-                implCodes[Marc21Constants.BIBLIOGRAPHIC_LEVEL_INDEX]));
-        getReceiver().literal(Marc21EventNames.TYPE_OF_CONTROL_LITERAL, String.valueOf(
-                implCodes[Marc21Constants.TYPE_OF_CONTROL_INDEX]));
-        getReceiver().literal(Marc21EventNames.CHARACTER_CODING_LITERAL, String.valueOf(
-                implCodes[Marc21Constants.CHARACTER_CODING_INDEX]));
-        getReceiver().literal(Marc21EventNames.ENCODING_LEVEL_LITERAL, String.valueOf(
-                systemChars[Marc21Constants.ENCODING_LEVEL_INDEX]));
-        getReceiver().literal(Marc21EventNames.CATALOGING_FORM_LITERAL, String.valueOf(
-                systemChars[Marc21Constants.CATALOGING_FORM_INDEX]));
-        getReceiver().literal(Marc21EventNames.MULTIPART_LEVEL_LITERAL, String.valueOf(
-                systemChars[Marc21Constants.MULTIPART_LEVEL_INDEX]));
+        }
+        else {
+            final char[] implCodes = record.getImplCodes();
+            final char[] systemChars = record.getSystemChars();
+            getReceiver().literal(Marc21EventNames.RECORD_STATUS_LITERAL, String.valueOf(
+                        record.getRecordStatus()));
+            getReceiver().literal(Marc21EventNames.RECORD_TYPE_LITERAL, String.valueOf(
+                        implCodes[Marc21Constants.RECORD_TYPE_INDEX]));
+            getReceiver().literal(Marc21EventNames.BIBLIOGRAPHIC_LEVEL_LITERAL, String.valueOf(
+                        implCodes[Marc21Constants.BIBLIOGRAPHIC_LEVEL_INDEX]));
+            getReceiver().literal(Marc21EventNames.TYPE_OF_CONTROL_LITERAL, String.valueOf(
+                        implCodes[Marc21Constants.TYPE_OF_CONTROL_INDEX]));
+            getReceiver().literal(Marc21EventNames.CHARACTER_CODING_LITERAL, String.valueOf(
+                        implCodes[Marc21Constants.CHARACTER_CODING_INDEX]));
+            getReceiver().literal(Marc21EventNames.ENCODING_LEVEL_LITERAL, String.valueOf(
+                        systemChars[Marc21Constants.ENCODING_LEVEL_INDEX]));
+            getReceiver().literal(Marc21EventNames.CATALOGING_FORM_LITERAL, String.valueOf(
+                        systemChars[Marc21Constants.CATALOGING_FORM_INDEX]));
+            getReceiver().literal(Marc21EventNames.MULTIPART_LEVEL_LITERAL, String.valueOf(
+                        systemChars[Marc21Constants.MULTIPART_LEVEL_INDEX]));
         }
         getReceiver().endEntity();
     }
@@ -256,6 +260,9 @@ public final class Marc21Decoder
      * Emits the fields in a MARC 21 record as stream events.
      */
     private final class Marc21Handler implements FieldHandler {
+
+        Marc21Handler() {
+        }
 
         @Override
         public void referenceField(final char[] tag, final char[] implDefinedPart,

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/marc21/Marc21Encoder.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/marc21/Marc21Encoder.java
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.biblio.marc21;
 
-import java.util.Arrays;
+package org.metafacture.biblio.marc21;
 
 import org.metafacture.biblio.iso2709.RecordBuilder;
 import org.metafacture.framework.FluxCommand;
@@ -26,6 +25,8 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultStreamPipe;
+
+import java.util.Arrays;
 
 /**
  * Encodes a stream in MARC21 format.
@@ -83,6 +84,7 @@ public final class Marc21Encoder extends
         builder = new RecordBuilder(Marc21Constants.MARC21_FORMAT);
         builder.setCharset(Marc21Constants.MARC21_CHARSET);
     }
+
     /**
      * Controls whether the record identifier field (&quot;001&quot;) is
      * generated from the record id in the <i>start-record</i> event. If id field
@@ -117,8 +119,8 @@ public final class Marc21Encoder extends
 
     private void initLeader() {
         builder.setRecordStatus(' ');
-        builder.setImplCodes(new char[]{ ' ', ' ', ' ', ' ' });
-        builder.setSystemChars(new char[]{ ' ', ' ', ' ' });
+        builder.setImplCodes(new char[]{' ', ' ', ' ', ' '});
+        builder.setSystemChars(new char[]{' ', ' ', ' '});
         builder.setReservedChar(Marc21Constants.RESERVED_CHAR);
     }
 
@@ -136,7 +138,8 @@ public final class Marc21Encoder extends
         }
         if (Marc21EventNames.LEADER_ENTITY.equals(name)) {
             state = State.IN_LEADER_ENTITY;
-        } else {
+        }
+        else {
             startField(name);
             state = State.IN_FIELD_ENTITY;
         }
@@ -152,7 +155,6 @@ public final class Marc21Encoder extends
         name.getChars(tag.length, name.length(), indicators, 0);
         builder.startDataField(tag, indicators);
     }
-
 
     @Override
     public void endEntity() {
@@ -229,18 +231,17 @@ public final class Marc21Encoder extends
                 return;
             }
         }
-        throw new FormatException("invalid code '" + code + "'; allowed codes are: "
-                + Arrays.toString(validCodes));
+        throw new FormatException("invalid code '" + code + "'; allowed codes are: " + Arrays.toString(validCodes));
     }
 
     private void processTopLevelLiteral(final String name, final String value) {
-    if (Marc21EventNames.MARCXML_TYPE_LITERAL.equals(name)) {
-      // MarcXmlHandler may output `type` literals. The
-      // information in these literals is not included in
-      // marc21 records. Therefore, we need to ignore
-      // these literals here.
+        if (Marc21EventNames.MARCXML_TYPE_LITERAL.equals(name)) {
+            // MarcXmlHandler may output `type` literals. The
+            // information in these literals is not included in
+            // marc21 records. Therefore, we need to ignore
+            // these literals here.
             return;
-    }
+        }
         builder.appendReferenceField(name.toCharArray(), value);
     }
 

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/marc21/Marc21EventNames.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/marc21/Marc21EventNames.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.biblio.marc21;
 
 /**
@@ -22,127 +23,127 @@ package org.metafacture.biblio.marc21;
  */
 public final class Marc21EventNames {
 
-  /**
-   * Name of the <i>literal</i> event which contains the value of the
-   * <i>type</i> attribute of the <i>record</i> element.
-   */
-  public static final String MARCXML_TYPE_LITERAL = "type";
+    /**
+     * Name of the <i>literal</i> event which contains the value of the
+     * <i>type</i> attribute of the <i>record</i> element.
+     */
+    public static final String MARCXML_TYPE_LITERAL = "type";
 
-  /**
-   * Name of the <i>entity</i> event which contains the bibliographic
-   * information in the record leader.
-   *
-   * @see <a href="http://www.loc.gov/marc/bibliographic/bdleader.html">MARC 21
-   * Standard: Record Leader</a>
-   */
-  public static final String LEADER_ENTITY = "leader";
+    /**
+     * Name of the <i>entity</i> event which contains the bibliographic
+     * information in the record leader.
+     *
+     * @see <a href="http://www.loc.gov/marc/bibliographic/bdleader.html">MARC 21
+     * Standard: Record Leader</a>
+     */
+    public static final String LEADER_ENTITY = "leader";
 
-  /**
-   * Name of the <i>literal</i> event emitted for the record status field.
-   * <p>
-   * The name of the literal is &quot;{@value #RECORD_STATUS_LITERAL}&quot;.
-   * <p>
-   * The record status is specified at position 5 in the record leader.
-   *
-   * @see <a href="http://www.loc.gov/marc/bibliographic/bdleader.html">MARC 21
-   * Standard: Record Leader</a>
-   */
-  public static final String RECORD_STATUS_LITERAL = "status";
+    /**
+     * Name of the <i>literal</i> event emitted for the record status field.
+     * <p>
+     * The name of the literal is &quot;{@value #RECORD_STATUS_LITERAL}&quot;.
+     * <p>
+     * The record status is specified at position 5 in the record leader.
+     *
+     * @see <a href="http://www.loc.gov/marc/bibliographic/bdleader.html">MARC 21
+     * Standard: Record Leader</a>
+     */
+    public static final String RECORD_STATUS_LITERAL = "status";
 
-  /**
-   * Name of the <i>literal</i> event emitted for the bibliographic level
-   * field.
-   * <p>
-   * The name of the literal is
-   * &quot;{@value #BIBLIOGRAPHIC_LEVEL_LITERAL}&quot;.
-   * <p>
-   * The bibliographic level is specified at position 7 in the record leader.
-   *
-   * @see <a href="http://www.loc.gov/marc/bibliographic/bdleader.html">MARC 21
-   * Standard: Record Leader</a>
-   */
-  public static final String BIBLIOGRAPHIC_LEVEL_LITERAL = "bibliographicLevel";
+    /**
+     * Name of the <i>literal</i> event emitted for the bibliographic level
+     * field.
+     * <p>
+     * The name of the literal is
+     * &quot;{@value #BIBLIOGRAPHIC_LEVEL_LITERAL}&quot;.
+     * <p>
+     * The bibliographic level is specified at position 7 in the record leader.
+     *
+     * @see <a href="http://www.loc.gov/marc/bibliographic/bdleader.html">MARC 21
+     * Standard: Record Leader</a>
+     */
+    public static final String BIBLIOGRAPHIC_LEVEL_LITERAL = "bibliographicLevel";
 
-  /**
-   * Name of the <i>literal</i> event emitted for the type of control field.
-   * <p>
-   * The name of the literal is &quot;{@value #TYPE_OF_CONTROL_LITERAL}&quot;.
-   * <p>
-   * The type of control is specified at position 8 in the record leader.
-   *
-   * @see <a href="http://www.loc.gov/marc/bibliographic/bdleader.html">MARC 21
-   * Standard: Record Leader</a>
-   */
-  public static final String TYPE_OF_CONTROL_LITERAL = "typeOfControl";
+    /**
+     * Name of the <i>literal</i> event emitted for the type of control field.
+     * <p>
+     * The name of the literal is &quot;{@value #TYPE_OF_CONTROL_LITERAL}&quot;.
+     * <p>
+     * The type of control is specified at position 8 in the record leader.
+     *
+     * @see <a href="http://www.loc.gov/marc/bibliographic/bdleader.html">MARC 21
+     * Standard: Record Leader</a>
+     */
+    public static final String TYPE_OF_CONTROL_LITERAL = "typeOfControl";
 
-  /**
-   * Name of the <i>literal</i> event emitted for the character coding scheme
-   * field.
-   * <p>
-   * The name of the literal is &quot;{@value #CHARACTER_CODING_LITERAL}&quot;.
-   * <p>
-   * The character coding scheme is specified at position 9 in the record
-   * leader.
-   *
-   * @see <a href="http://www.loc.gov/marc/bibliographic/bdleader.html">MARC 21
-   * Standard: Record Leader</a>
-   */
-  public static final String CHARACTER_CODING_LITERAL = "characterCodingScheme";
+    /**
+     * Name of the <i>literal</i> event emitted for the character coding scheme
+     * field.
+     * <p>
+     * The name of the literal is &quot;{@value #CHARACTER_CODING_LITERAL}&quot;.
+     * <p>
+     * The character coding scheme is specified at position 9 in the record
+     * leader.
+     *
+     * @see <a href="http://www.loc.gov/marc/bibliographic/bdleader.html">MARC 21
+     * Standard: Record Leader</a>
+     */
+    public static final String CHARACTER_CODING_LITERAL = "characterCodingScheme";
 
-  /**
-   * Name of the <i>literal</i> event emitted for the encoding level field.
-   * <p>
-   * The name of the literal is &quot;{@value #ENCODING_LEVEL_LITERAL}&quot;.
-   * <p>
-   * The encoding level is specified at position 17 in the record leader.
-   *
-   * @see <a href="http://www.loc.gov/marc/bibliographic/bdleader.html">MARC 21
-   * Standard: Record Leader</a>
-   */
-  public static final String ENCODING_LEVEL_LITERAL = "encodingLevel";
+    /**
+     * Name of the <i>literal</i> event emitted for the encoding level field.
+     * <p>
+     * The name of the literal is &quot;{@value #ENCODING_LEVEL_LITERAL}&quot;.
+     * <p>
+     * The encoding level is specified at position 17 in the record leader.
+     *
+     * @see <a href="http://www.loc.gov/marc/bibliographic/bdleader.html">MARC 21
+     * Standard: Record Leader</a>
+     */
+    public static final String ENCODING_LEVEL_LITERAL = "encodingLevel";
 
-  /**
-   * Name of the <i>literal</i> event emitted for the descriptive cataloging
-   * form field.
-   * <p>
-   * The name of the literal is &quot;{@value #CATALOGING_FORM_LITERAL}&quot;.
-   * <p>
-   * The descriptive cataloging form is specified at position 18 in the record
-   * leader.
-   *
-   * @see <a href="http://www.loc.gov/marc/bibliographic/bdleader.html">MARC 21
-   * Standard: Record Leader</a>
-   */
-  public static final String CATALOGING_FORM_LITERAL = "catalogingForm";
+    /**
+     * Name of the <i>literal</i> event emitted for the descriptive cataloging
+     * form field.
+     * <p>
+     * The name of the literal is &quot;{@value #CATALOGING_FORM_LITERAL}&quot;.
+     * <p>
+     * The descriptive cataloging form is specified at position 18 in the record
+     * leader.
+     *
+     * @see <a href="http://www.loc.gov/marc/bibliographic/bdleader.html">MARC 21
+     * Standard: Record Leader</a>
+     */
+    public static final String CATALOGING_FORM_LITERAL = "catalogingForm";
 
-  /**
-   * Name of the <i>literal</i> event emitted for the multipart resource
-   * record level field.
-   * <p>
-   * The name of the literal is &quot;{@value #MULTIPART_LEVEL_LITERAL}&quot;.
-   * <p>
-   * The multipart resource record level is specified at position 19 in the
-   * record leader.
-   *
-   * @see <a href="http://www.loc.gov/marc/bibliographic/bdleader.html">MARC 21
-   * Standard: Record Leader</a>
-   */
-  public static final String MULTIPART_LEVEL_LITERAL = "multipartLevel";
+    /**
+     * Name of the <i>literal</i> event emitted for the multipart resource
+     * record level field.
+     * <p>
+     * The name of the literal is &quot;{@value #MULTIPART_LEVEL_LITERAL}&quot;.
+     * <p>
+     * The multipart resource record level is specified at position 19 in the
+     * record leader.
+     *
+     * @see <a href="http://www.loc.gov/marc/bibliographic/bdleader.html">MARC 21
+     * Standard: Record Leader</a>
+     */
+    public static final String MULTIPART_LEVEL_LITERAL = "multipartLevel";
 
-  /**
-   * Name of the <i>literal</i> event emitted for the type of record field.
-   * <p>
-   * The name of the literal is &quot;{@value #RECORD_TYPE_LITERAL}&quot;.
-   * <p>
-   * The type of record is specified at position 6 in the record leader.
-   *
-   * @see <a href="http://www.loc.gov/marc/bibliographic/bdleader.html">MARC 21
-   * Standard: Record Leader</a>
-   */
-  public static final String RECORD_TYPE_LITERAL = "type";
+    /**
+     * Name of the <i>literal</i> event emitted for the type of record field.
+     * <p>
+     * The name of the literal is &quot;{@value #RECORD_TYPE_LITERAL}&quot;.
+     * <p>
+     * The type of record is specified at position 6 in the record leader.
+     *
+     * @see <a href="http://www.loc.gov/marc/bibliographic/bdleader.html">MARC 21
+     * Standard: Record Leader</a>
+     */
+    public static final String RECORD_TYPE_LITERAL = "type";
 
-  private Marc21EventNames() {
-    throw new AssertionError("class should not be instantiated");
-  }
+    private Marc21EventNames() {
+        throw new AssertionError("class should not be instantiated");
+    }
 
 }

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/marc21/MarcXmlHandler.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/marc21/MarcXmlHandler.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.biblio.marc21;
 
 import org.metafacture.framework.FluxCommand;
@@ -22,9 +23,9 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultXmlPipe;
+
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
-
 
 /**
  * A marc xml reader.
@@ -48,6 +49,9 @@ public final class MarcXmlHandler extends DefaultXmlPipe<StreamReceiver> {
     private String namespace = NAMESPACE;
     private StringBuilder builder = new StringBuilder();
 
+    public MarcXmlHandler() {
+    }
+
     public void setNamespace(final String namespace) {
         this.namespace = namespace;
     }
@@ -57,39 +61,46 @@ public final class MarcXmlHandler extends DefaultXmlPipe<StreamReceiver> {
     }
 
     @Override
-    public void startElement(final String uri, final String localName, final String qName, final Attributes attributes)
-            throws SAXException {
-            if(SUBFIELD.equals(localName)){
-                builder = new StringBuilder();
-                currentTag = attributes.getValue("code");
-            }else if(DATAFIELD.equals(localName)){
-                getReceiver().startEntity(attributes.getValue("tag") + attributes.getValue("ind1") + attributes.getValue("ind2"));
-            }else if(CONTROLFIELD.equals(localName)){
-                builder = new StringBuilder();
-                currentTag = attributes.getValue("tag");
-            }else if(RECORD.equals(localName) && checkNamespace(uri)){
-                getReceiver().startRecord("");
-                getReceiver().literal(TYPE, attributes.getValue(TYPE));
-            }else if(LEADER.equals(localName)){
-                builder = new StringBuilder();
-                currentTag = LEADER;
-            }
+    public void startElement(final String uri, final String localName, final String qName, final Attributes attributes) throws SAXException {
+        if (SUBFIELD.equals(localName)) {
+            builder = new StringBuilder();
+            currentTag = attributes.getValue("code");
+        }
+        else if (DATAFIELD.equals(localName)) {
+            getReceiver().startEntity(attributes.getValue("tag") + attributes.getValue("ind1") + attributes.getValue("ind2"));
+        }
+        else if (CONTROLFIELD.equals(localName)) {
+            builder = new StringBuilder();
+            currentTag = attributes.getValue("tag");
+        }
+        else if (RECORD.equals(localName) && checkNamespace(uri)) {
+            getReceiver().startRecord("");
+            getReceiver().literal(TYPE, attributes.getValue(TYPE));
+        }
+        else if (LEADER.equals(localName)) {
+            builder = new StringBuilder();
+            currentTag = LEADER;
+        }
     }
 
     @Override
     public void endElement(final String uri, final String localName, final String qName) throws SAXException {
-        if(SUBFIELD.equals(localName)){
+        if (SUBFIELD.equals(localName)) {
             getReceiver().literal(currentTag, builder.toString().trim());
 
-        }else if(DATAFIELD.equals(localName)){
+        }
+        else if (DATAFIELD.equals(localName)) {
             getReceiver().endEntity();
-        }else if(CONTROLFIELD.equals(localName)){
+        }
+        else if (CONTROLFIELD.equals(localName)) {
             getReceiver().literal(currentTag, builder.toString().trim());
 
-        }else if(RECORD.equals(localName) && checkNamespace(uri)){
+        }
+        else if (RECORD.equals(localName) && checkNamespace(uri)) {
             getReceiver().endRecord();
 
-        }else if(LEADER.equals(localName)){
+        }
+        else if (LEADER.equals(localName)) {
             getReceiver().literal(currentTag, builder.toString());
         }
     }

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/pica/PicaConstants.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/pica/PicaConstants.java
@@ -26,31 +26,31 @@ package org.metafacture.biblio.pica;
  *
  */
 enum PicaConstants {
-	// We use '\0' for null/empty
-	RECORD_MARKER('\u001d', '\n'), //
-	FIELD_MARKER('\u001e', '\0'), //
-	SUBFIELD_MARKER('\u001f', '$'), //
-	FIELD_END_MARKER('\n', '\n'), //
-	NO_MARKER('\0', '\0');
+    // We use '\0' for null/empty
+    RECORD_MARKER('\u001d', '\n'), //
+    FIELD_MARKER('\u001e', '\0'), //
+    SUBFIELD_MARKER('\u001f', '$'), //
+    FIELD_END_MARKER('\n', '\n'), //
+    NO_MARKER('\0', '\0');
 
-	char normalized;
-	char nonNormalized;
+    private final char normalized;
+    private final char nonNormalized;
 
-	PicaConstants(char normalized, char nonNormalized) {
-		this.normalized = normalized;
-		this.nonNormalized = nonNormalized;
-	}
+    PicaConstants(final char normalized, final char nonNormalized) {
+        this.normalized = normalized;
+        this.nonNormalized = nonNormalized;
+    }
 
-	public char get(boolean isNormalized) {
-		return isNormalized ? normalized : nonNormalized;
-	}
+    public char get(final boolean isNormalized) {
+        return isNormalized ? normalized : nonNormalized;
+    }
 
-	public static PicaConstants from(boolean isNormalized, char ch) {
-		for (PicaConstants value : values()) {
-			if (ch == (isNormalized ? value.normalized : value.nonNormalized)) {
-				return value;
-			}
-		}
-		return NO_MARKER;
-	}
+    public static PicaConstants from(final boolean isNormalized, final char ch) {
+        for (final PicaConstants value : values()) {
+            if (ch == (isNormalized ? value.normalized : value.nonNormalized)) {
+                return value;
+            }
+        }
+        return NO_MARKER;
+    }
 }

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/pica/PicaDecoder.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/pica/PicaDecoder.java
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.biblio.pica;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+package org.metafacture.biblio.pica;
 
 import org.metafacture.commons.StringUtil;
 import org.metafacture.framework.FluxCommand;
@@ -26,6 +24,9 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Parses pica+ records. The parser only parses single records. A string
@@ -153,11 +154,8 @@ import org.metafacture.framework.helpers.DefaultObjectPipe;
 @In(String.class)
 @Out(StreamReceiver.class)
 @FluxCommand("decode-pica")
-public final class PicaDecoder
-        extends DefaultObjectPipe<String, StreamReceiver> {
+public final class PicaDecoder extends DefaultObjectPipe<String, StreamReceiver> {
 
-    private static String START_MARKERS;
-    private static Pattern ID_FIELDS_PATTERN;
     private static final int BUFFER_SIZE = 1024 * 1024;
 
     private Matcher idFieldMatcher;
@@ -174,7 +172,7 @@ public final class PicaDecoder
         this(true);
     }
 
-    public PicaDecoder(boolean normalized) {
+    public PicaDecoder(final boolean normalized) {
         setNormalizedSerialization(normalized);
     }
 
@@ -185,21 +183,19 @@ public final class PicaDecoder
      * @param normalized if true, the input is treated as normalized pica+ ;
      *                   if false, it's treated as non-normalized.
      */
-    public void setNormalizedSerialization(boolean normalized) {
+    public void setNormalizedSerialization(final boolean normalized) {
         this.isNormalized = normalized;
-        makeConstants();
+
+        final String startMarkers = "(?:^|" + PicaConstants.FIELD_MARKER.get(isNormalized) + "|" +
+                PicaConstants.FIELD_END_MARKER.get(isNormalized) + "|" +
+                PicaConstants.RECORD_MARKER.get(isNormalized) + "|.*\n" + ")";
+        final Pattern idFieldsPattern = Pattern
+                .compile(startMarkers + "(?:003@|203@(?:/..+)?|107F) " +
+                        " ?(\\" + PicaConstants.SUBFIELD_MARKER.get(isNormalized) + "|" +
+                        PicaConstants.SUBFIELD_MARKER.get(isNormalized) + ")0");
+        idFieldMatcher = idFieldsPattern.matcher("");
     }
 
-    private void makeConstants() {
-        START_MARKERS = "(?:^|" + PicaConstants.FIELD_MARKER.get(isNormalized) + "|"
-                + PicaConstants.FIELD_END_MARKER.get(isNormalized) + "|"
-                + PicaConstants.RECORD_MARKER.get(isNormalized) + "|.*\n" + ")";
-        ID_FIELDS_PATTERN = Pattern
-                .compile(START_MARKERS + "(?:003@|203@(?:/..+)?|107F) "
-                        + " ?(\\" + PicaConstants.SUBFIELD_MARKER.get(isNormalized) + "|"
-                        + PicaConstants.SUBFIELD_MARKER.get(isNormalized) + ")0");
-        idFieldMatcher = ID_FIELDS_PATTERN.matcher("");
-    }
     /**
      * Controls whether records having no record id are reported as faulty. By
      * default such records are reported by the {@code PicaDecoder} by throwing
@@ -281,6 +277,7 @@ public final class PicaDecoder
     public boolean getTrimFieldNames() {
         return parserContext.getTrimFieldNames();
     }
+
     @Override
     public void process(final String record) {
         assert !isClosed();

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/pica/PicaEncoder.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/pica/PicaEncoder.java
@@ -13,12 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.biblio.pica;
 
-import java.text.Normalizer;
-import java.text.Normalizer.Form;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+package org.metafacture.biblio.pica;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.FormatException;
@@ -30,6 +26,10 @@ import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultStreamPipe;
 
+import java.text.Normalizer.Form;
+import java.text.Normalizer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Encodes an event stream in pica+ format.
@@ -68,6 +68,9 @@ public final class PicaEncoder extends DefaultStreamPipe<ObjectReceiver<String>>
 
     private String id;
 
+    public PicaEncoder() {
+    }
+
     @Override
     public void startRecord(final String recordId) {
         // the name is a idn, which should be found in the encoded data under 003@.
@@ -97,7 +100,7 @@ public final class PicaEncoder extends DefaultStreamPipe<ObjectReceiver<String>>
         if (entityOpen) { //No nested entities are allowed in pica+.
             throw new FormatException(name);
         }
-        builder.append(name.trim()+ " ");
+        builder.append(name.trim() + " ");
 
         idnControlSubField = !ignoreRecordId && FIELD_IDN_INTERN.equals(name.trim());
         //Now literals can be opened but no more entities.
@@ -124,7 +127,7 @@ public final class PicaEncoder extends DefaultStreamPipe<ObjectReceiver<String>>
         builder.append(SUB_DELIMITER);
         builder.append(name);
         builder.append(valueNew);
-}
+    }
 
     @Override
     public void endEntity() {

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/pica/PicaParserContext.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/pica/PicaParserContext.java
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.biblio.pica;
 
-import java.text.Normalizer;
-import java.text.Normalizer.Form;
-
 import org.metafacture.framework.StreamReceiver;
+
+import java.text.Normalizer.Form;
+import java.text.Normalizer;
 
 /**
  * Parser context for the PICA+ parser.The context implements
@@ -42,6 +43,9 @@ final class PicaParserContext {
     private boolean literalsEmitted;
 
     private String subfieldName;
+
+    PicaParserContext() {
+    }
 
     public void setNormalizeUTF8(final boolean normalizeUTF8) {
         this.normalizeUTF8 = normalizeUTF8;

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/pica/PicaParserState.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/pica/PicaParserState.java
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.biblio.pica;
 
+package org.metafacture.biblio.pica;
 
 /**
  * A parser for PICA+ records. Only single records can be parsed as the parser
@@ -37,23 +37,23 @@ enum PicaParserState {
 
     FIELD_NAME {
         @Override
-        protected PicaParserState parseChar(final char ch, final PicaParserContext ctx, boolean normalized) {
+        protected PicaParserState parseChar(final char ch, final PicaParserContext ctx, final boolean normalized) {
             final PicaParserState next;
             switch (PicaConstants.from(normalized, ch)) {
-            case RECORD_MARKER:
-            case FIELD_MARKER:
-            case FIELD_END_MARKER:
-                ctx.emitStartEntity();
-                ctx.emitEndEntity();
-                next = FIELD_NAME;
-                break;
-            case SUBFIELD_MARKER:
-                ctx.emitStartEntity();
-                next = SUBFIELD_NAME;
-                break;
-            default:
-                ctx.appendText(ch);
-                next = this;
+                case RECORD_MARKER:
+                case FIELD_MARKER:
+                case FIELD_END_MARKER:
+                    ctx.emitStartEntity();
+                    ctx.emitEndEntity();
+                    next = FIELD_NAME;
+                    break;
+                case SUBFIELD_MARKER:
+                    ctx.emitStartEntity();
+                    next = SUBFIELD_NAME;
+                    break;
+                default:
+                    ctx.appendText(ch);
+                    next = this;
             }
             return next;
         }
@@ -66,21 +66,21 @@ enum PicaParserState {
     },
     SUBFIELD_NAME {
         @Override
-        protected PicaParserState parseChar(final char ch, final PicaParserContext ctx, boolean normalized) {
+        protected PicaParserState parseChar(final char ch, final PicaParserContext ctx, final boolean normalized) {
             final PicaParserState next;
             switch (PicaConstants.from(normalized, ch)) {
-            case RECORD_MARKER:
-            case FIELD_MARKER:
-            case FIELD_END_MARKER:
-                ctx.emitEndEntity();
-                next = FIELD_NAME;
-                break;
-            case SUBFIELD_MARKER:
-                next = this;
-                break;
-            default:
-                ctx.setSubfieldName(ch);
-                next = SUBFIELD_VALUE;
+                case RECORD_MARKER:
+                case FIELD_MARKER:
+                case FIELD_END_MARKER:
+                    ctx.emitEndEntity();
+                    next = FIELD_NAME;
+                    break;
+                case SUBFIELD_MARKER:
+                    next = this;
+                    break;
+                default:
+                    ctx.setSubfieldName(ch);
+                    next = SUBFIELD_VALUE;
             }
             return next;
         }
@@ -92,23 +92,23 @@ enum PicaParserState {
     },
     SUBFIELD_VALUE {
         @Override
-        protected PicaParserState parseChar(final char ch, final PicaParserContext ctx, boolean normalized) {
+        protected PicaParserState parseChar(final char ch, final PicaParserContext ctx, final boolean normalized) {
             final PicaParserState next;
             switch (PicaConstants.from(normalized, ch)) {
-            case RECORD_MARKER:
-            case FIELD_MARKER:
-            case FIELD_END_MARKER:
-                ctx.emitLiteral();
-                ctx.emitEndEntity();
-                next = FIELD_NAME;
-                break;
-            case SUBFIELD_MARKER:
-                ctx.emitLiteral();
-                next = SUBFIELD_NAME;
-                break;
-            default:
-                ctx.appendText(ch);
-                next = this;
+                case RECORD_MARKER:
+                case FIELD_MARKER:
+                case FIELD_END_MARKER:
+                    ctx.emitLiteral();
+                    ctx.emitEndEntity();
+                    next = FIELD_NAME;
+                    break;
+                case SUBFIELD_MARKER:
+                    ctx.emitLiteral();
+                    next = SUBFIELD_NAME;
+                    break;
+                default:
+                    ctx.appendText(ch);
+                    next = this;
             }
             return next;
         }
@@ -120,8 +120,8 @@ enum PicaParserState {
         }
     };
 
-    protected abstract PicaParserState parseChar(final char ch, final PicaParserContext ctx, final boolean normalized);
+    protected abstract PicaParserState parseChar(char ch, PicaParserContext ctx, boolean normalized);
 
-    protected abstract void endOfInput(final PicaParserContext ctx);
+    protected abstract void endOfInput(PicaParserContext ctx);
 
 }

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/pica/PicaXmlHandler.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/pica/PicaXmlHandler.java
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.biblio.pica;
 
-import java.text.Normalizer;
+package org.metafacture.biblio.pica;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.StreamReceiver;
@@ -24,8 +23,11 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultXmlPipe;
+
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
+
+import java.text.Normalizer;
 
 /**
  * A pica xml handler.
@@ -48,18 +50,24 @@ public final class PicaXmlHandler extends DefaultXmlPipe<StreamReceiver> {
     private String currentTag = "";
     private StringBuilder builder = new StringBuilder();
 
+    public PicaXmlHandler() {
+    }
+
     @Override
     public void startElement(final String uri, final String localName,
             final String qName, final Attributes attributes) throws SAXException {
         if (SUBFIELD.equals(localName)) {
             builder = new StringBuilder();
             currentTag = attributes.getValue("id");
-        } else if (DATAFIELD.equals(localName)) {
+        }
+        else if (DATAFIELD.equals(localName)) {
             getReceiver().startEntity(
                     attributes.getValue("id") + attributes.getValue("occ"));
-        } else if (RECORD.equals(localName) && NAMESPACE.equals(uri)) {
+        }
+        else if (RECORD.equals(localName) && NAMESPACE.equals(uri)) {
             getReceiver().startRecord("");
-        } else if (LEADER.equals(localName)) {
+        }
+        else if (LEADER.equals(localName)) {
             builder = new StringBuilder();
             currentTag = LEADER;
         }
@@ -71,9 +79,11 @@ public final class PicaXmlHandler extends DefaultXmlPipe<StreamReceiver> {
         if (SUBFIELD.equals(localName)) {
             getReceiver().literal(currentTag,
                     Normalizer.normalize(builder.toString().trim(), Normalizer.Form.NFC));
-        } else if (DATAFIELD.equals(localName)) {
+        }
+        else if (DATAFIELD.equals(localName)) {
             getReceiver().endEntity();
-        } else if (RECORD.equals(localName) && NAMESPACE.equals(uri)) {
+        }
+        else if (RECORD.equals(localName) && NAMESPACE.equals(uri)) {
             getReceiver().endRecord();
         }
     }

--- a/metafacture-biblio/src/test/java/org/metafacture/biblio/AlephMabXmlHandlerTest.java
+++ b/metafacture-biblio/src/test/java/org/metafacture/biblio/AlephMabXmlHandlerTest.java
@@ -13,6 +13,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
 package org.metafacture.biblio;
 
 import org.junit.Before;

--- a/metafacture-biblio/src/test/java/org/metafacture/biblio/AseqDecoderTest.java
+++ b/metafacture-biblio/src/test/java/org/metafacture/biblio/AseqDecoderTest.java
@@ -13,6 +13,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
 package org.metafacture.biblio;
 
 import static org.mockito.Mockito.inOrder;

--- a/metafacture-biblio/src/test/java/org/metafacture/biblio/ComarcXmlHandlerTest.java
+++ b/metafacture-biblio/src/test/java/org/metafacture/biblio/ComarcXmlHandlerTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.biblio;
 
 import static org.mockito.Mockito.verify;

--- a/metafacture-biblio/src/test/java/org/metafacture/biblio/MabDecoderTest.java
+++ b/metafacture-biblio/src/test/java/org/metafacture/biblio/MabDecoderTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.biblio;
 
 import static org.mockito.Mockito.inOrder;

--- a/metafacture-biblio/src/test/java/org/metafacture/biblio/iso2709/DirectoryEntryTest.java
+++ b/metafacture-biblio/src/test/java/org/metafacture/biblio/iso2709/DirectoryEntryTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.biblio.iso2709;
 
 import static org.junit.Assert.assertArrayEquals;

--- a/metafacture-biblio/src/test/java/org/metafacture/biblio/iso2709/Iso646ByteBufferTest.java
+++ b/metafacture-biblio/src/test/java/org/metafacture/biblio/iso2709/Iso646ByteBufferTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.biblio.iso2709;
 
 import static org.junit.Assert.assertArrayEquals;

--- a/metafacture-biblio/src/test/java/org/metafacture/biblio/iso2709/LabelTest.java
+++ b/metafacture-biblio/src/test/java/org/metafacture/biblio/iso2709/LabelTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.biblio.iso2709;
 
 import static org.junit.Assert.assertArrayEquals;

--- a/metafacture-biblio/src/test/java/org/metafacture/biblio/iso2709/RecordBuilderTest.java
+++ b/metafacture-biblio/src/test/java/org/metafacture/biblio/iso2709/RecordBuilderTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.biblio.iso2709;
 
 import static org.junit.Assert.assertEquals;
@@ -544,7 +545,8 @@ public final class RecordBuilderTest {
         builder.appendSubfield(asChars("B"), "Value");
         try {
             builder.endDataField();
-        } catch (final FormatException e) {
+        }
+        catch (final FormatException e) {
             exceptionThrown = true;
         }
 

--- a/metafacture-biblio/src/test/java/org/metafacture/biblio/iso2709/RecordFormatTest.java
+++ b/metafacture-biblio/src/test/java/org/metafacture/biblio/iso2709/RecordFormatTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.biblio.iso2709;
 
 import static org.junit.Assert.assertEquals;

--- a/metafacture-biblio/src/test/java/org/metafacture/biblio/iso2709/RecordTest.java
+++ b/metafacture-biblio/src/test/java/org/metafacture/biblio/iso2709/RecordTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.biblio.iso2709;
 
 import static org.junit.Assert.assertEquals;

--- a/metafacture-biblio/src/test/java/org/metafacture/biblio/marc21/Marc21DecoderTest.java
+++ b/metafacture-biblio/src/test/java/org/metafacture/biblio/marc21/Marc21DecoderTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.biblio.marc21;
 
 import static org.mockito.Mockito.inOrder;

--- a/metafacture-biblio/src/test/java/org/metafacture/biblio/marc21/Marc21EncoderTest.java
+++ b/metafacture-biblio/src/test/java/org/metafacture/biblio/marc21/Marc21EncoderTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.biblio.marc21;
 
 import static org.metafacture.biblio.marc21.Marc21EventNames.LEADER_ENTITY;

--- a/metafacture-biblio/src/test/java/org/metafacture/biblio/marc21/MarcXmlHandlerTest.java
+++ b/metafacture-biblio/src/test/java/org/metafacture/biblio/marc21/MarcXmlHandlerTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.biblio.marc21;
 
 import static org.mockito.Mockito.verify;

--- a/metafacture-biblio/src/test/java/org/metafacture/biblio/pica/PicaEncoderTest.java
+++ b/metafacture-biblio/src/test/java/org/metafacture/biblio/pica/PicaEncoderTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.biblio.pica;
 
 import static org.mockito.Mockito.verify;

--- a/metafacture-biblio/src/test/java/org/metafacture/biblio/pica/PicaMultiscriptRemodelerTest.java
+++ b/metafacture-biblio/src/test/java/org/metafacture/biblio/pica/PicaMultiscriptRemodelerTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.biblio.pica;
 
 import static org.mockito.Mockito.inOrder;
@@ -305,7 +306,8 @@ public class PicaMultiscriptRemodelerTest {
     private String mapScriptToEntityName(final String script) {
         if (SCRIPT_LATIN.equals(script)) {
             return PicaMultiscriptRemodeler.ENTITY_NAME_FOR_LATIN;
-        } else if (SCRIPT_ARABIC.equals(script)
+        }
+        else if (SCRIPT_ARABIC.equals(script)
                 || SCRIPT_HEBREW.equals(script)) {
             return PicaMultiscriptRemodeler.ENTITY_NAME_FOR_NON_LATIN_RL;
         }

--- a/metafacture-commons/src/main/java/org/metafacture/commons/Require.java
+++ b/metafacture-commons/src/main/java/org/metafacture/commons/Require.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.commons;
 
 /**

--- a/metafacture-commons/src/main/java/org/metafacture/commons/ResourceUtil.java
+++ b/metafacture-commons/src/main/java/org/metafacture/commons/ResourceUtil.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.commons;
 
 import java.io.BufferedReader;
@@ -30,7 +31,6 @@ import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Properties;
 
-
 /**
  * Various utility methods for working with files, resources and streams.
  *
@@ -38,7 +38,7 @@ import java.util.Properties;
  * @author Markus Michael Geipel
  *
  */
-public final class ResourceUtil {
+public final class ResourceUtil { // checkstyle-disable-line ClassDataAbstractionCoupling
 
     static final int BUFFER_SIZE = 4096;
 
@@ -67,21 +67,25 @@ public final class ResourceUtil {
 
         InputStream stream = Thread.currentThread().getContextClassLoader()
                 .getResourceAsStream(name);
-        if (stream != null) {
-            return stream;
-        }
-
-        try {
-            stream = new URL(name).openStream();
-        } catch (final IOException e) {
-            throwFileNotFoundException(name, e);
-        }
         if (stream == null) {
-            throwFileNotFoundException(name, null);
+            try {
+                stream = new URL(name).openStream();
+            }
+            catch (final IOException e) {
+                throwFileNotFoundException(name, e);
+            }
+            if (stream == null) {
+                throwFileNotFoundException(name, null);
+            }
         }
 
         return stream;
 
+    }
+
+    public static InputStream getStream(final File file)
+            throws FileNotFoundException {
+        return new FileInputStream(file);
     }
 
     private static void throwFileNotFoundException(final String name,
@@ -92,11 +96,6 @@ public final class ResourceUtil {
             e.initCause(t);
         }
         throw e;
-    }
-
-    public static InputStream getStream(final File file)
-            throws FileNotFoundException {
-        return new FileInputStream(file);
     }
 
     public static Reader getReader(final String name)
@@ -137,11 +136,7 @@ public final class ResourceUtil {
 
         final URL resourceUrl =
                 Thread.currentThread().getContextClassLoader().getResource(name);
-        if (resourceUrl != null) {
-            return resourceUrl;
-        }
-
-        return new URL(name);
+        return resourceUrl != null ? resourceUrl : new URL(name);
     }
 
     public static URL getUrl(final File file) throws MalformedURLException {
@@ -191,14 +186,14 @@ public final class ResourceUtil {
         return list;
     }
 
-    public static String readAll(InputStream inputStream, Charset encoding)
+    public static String readAll(final InputStream inputStream, final Charset encoding)
             throws IOException {
         try (Reader reader = new InputStreamReader(inputStream, encoding)) {
             return readAll(reader);
         }
     }
 
-    public static String readAll(Reader reader) throws IOException {
+    public static String readAll(final Reader reader) throws IOException {
         final StringBuilder loadedText = new StringBuilder();
         try (Reader bufferedReader = new BufferedReader(reader)) {
             final CharBuffer buffer = CharBuffer.allocate(BUFFER_SIZE);

--- a/metafacture-commons/src/main/java/org/metafacture/commons/StringUtil.java
+++ b/metafacture-commons/src/main/java/org/metafacture/commons/StringUtil.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.commons;
 
 import java.nio.CharBuffer;
@@ -85,9 +86,10 @@ public final class StringUtil {
             if (varValue == null) {
                 if (ignoreMissingVars) {
                     varValue = "";
-                } else {
-                    throw new IllegalArgumentException("Variable '" + varName
-                            + "' was not assigned!\nAssigned variables:\n" + variables);
+                }
+                else {
+                    throw new IllegalArgumentException("Variable '" + varName +
+                            "' was not assigned!\nAssigned variables:\n" + variables);
                 }
             }
             builder.append(varValue);
@@ -135,7 +137,7 @@ public final class StringUtil {
         char[] buffer = currentBuffer;
         int bufferLen = buffer.length;
 
-        while(strLen > bufferLen) {
+        while (strLen > bufferLen) {
             bufferLen *= 2;
         }
         if (bufferLen > buffer.length) {

--- a/metafacture-commons/src/main/java/org/metafacture/commons/TimeUtil.java
+++ b/metafacture-commons/src/main/java/org/metafacture/commons/TimeUtil.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.commons;
 
 /**
@@ -22,8 +23,8 @@ package org.metafacture.commons;
  */
 public final class TimeUtil {
 
-    public static final String[] UNIT_SYMBOLS = { "ns", "µs", "ms", "s", "min", "h" };
-    public static final long[] UNIT_FACTORS = { 1L, 1000L, 1000L, 1000L, 60L, 60L };
+    public static final String[] UNIT_SYMBOLS = {"ns", "µs", "ms", "s", "min", "h"};
+    public static final long[] UNIT_FACTORS = {1L, 1000L, 1000L, 1000L, 60L, 60L};
 
     public static final int BASE_UNIT_INDEX = 3;
 

--- a/metafacture-commons/src/main/java/org/metafacture/commons/reflection/ObjectFactory.java
+++ b/metafacture-commons/src/main/java/org/metafacture/commons/reflection/ObjectFactory.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.commons.reflection;
 
 import java.util.Collections;
@@ -36,7 +37,10 @@ public class ObjectFactory<T> {
     private final Map<String, ConfigurableClass<? extends T>> classes =
             new HashMap<>();
 
-    public final void loadClassesFromMap(Map<?, ?> classMap, Class<T> baseType) {
+    public ObjectFactory() {
+    }
+
+    public final void loadClassesFromMap(final Map<?, ?> classMap, final Class<T> baseType) {
         final ClassLoader loader = ReflectionUtil.getContextClassLoader();
         for (final Entry<?, ?> entry : classMap.entrySet()) {
             final String key = entry.getKey().toString();
@@ -45,21 +49,19 @@ public class ObjectFactory<T> {
         }
     }
 
-    public final void registerClass(String key, Class<? extends T> objectClass) {
+    public final void registerClass(final String key, final Class<? extends T> objectClass) {
         registerClass(key, new ConfigurableClass<>(objectClass));
     }
 
-    public final void registerClass(String key,
-            ConfigurableClass<? extends T> objectClass) {
+    public final void registerClass(final String key, final ConfigurableClass<? extends T> objectClass) {
         classes.put(key, objectClass);
     }
 
-    public final T newInstance(String key, Object... constructorArgs) {
+    public final T newInstance(final String key, final Object... constructorArgs) {
         return newInstance(key, Collections.emptyMap(), constructorArgs);
     }
 
-    public final T newInstance(String key, Map<String, String> values,
-            Object... constructorArgs) {
+    public final T newInstance(final String key, final Map<String, String> values, final Object... constructorArgs) {
         if (!classes.containsKey(key)) {
             throw new NoSuchElementException("no registered class for: " + key);
         }
@@ -67,7 +69,7 @@ public class ObjectFactory<T> {
         return instanceClass.newInstance(values, constructorArgs);
     }
 
-    public final boolean containsKey(String key) {
+    public final boolean containsKey(final String key) {
         return classes.containsKey(key);
     }
 
@@ -75,7 +77,7 @@ public class ObjectFactory<T> {
         return Collections.unmodifiableSet(classes.keySet());
     }
 
-    public final ConfigurableClass<? extends T> get(String key) {
+    public final ConfigurableClass<? extends T> get(final String key) {
         return classes.get(key);
     }
 

--- a/metafacture-commons/src/main/java/org/metafacture/commons/reflection/ReflectionException.java
+++ b/metafacture-commons/src/main/java/org/metafacture/commons/reflection/ReflectionException.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.commons.reflection;
 
 /**
@@ -20,11 +21,11 @@ package org.metafacture.commons.reflection;
  */
 public class ReflectionException extends RuntimeException {
 
-    ReflectionException(String message, Throwable cause) {
+    ReflectionException(final String message, final Throwable cause) {
         super(message, cause);
     }
 
-    ReflectionException(String message) {
+    ReflectionException(final String message) {
         super(message);
     }
 

--- a/metafacture-commons/src/main/java/org/metafacture/commons/reflection/ReflectionUtil.java
+++ b/metafacture-commons/src/main/java/org/metafacture/commons/reflection/ReflectionUtil.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.commons.reflection;
 
 /**
@@ -35,22 +36,20 @@ public final class ReflectionUtil {
         return loader;
     }
 
-    public static <T> ConfigurableClass<? extends T> loadClass(String className,
-            Class<T> baseType) {
+    public static <T> ConfigurableClass<? extends T> loadClass(final String className, final Class<T> baseType) {
         return loadClass(getContextClassLoader(), className, baseType);
     }
 
-    public static <T> ConfigurableClass<? extends T> loadClass(ClassLoader loader,
-            String className, Class<T> baseType) {
+    public static <T> ConfigurableClass<? extends T> loadClass(final ClassLoader loader, final String className, final Class<T> baseType) {
         final Class<?> clazz;
         try {
             clazz = loader.loadClass(className);
-        } catch (ClassNotFoundException e) {
+        }
+        catch (final ClassNotFoundException e) {
             throw new ReflectionException("Class not found: " + className, e);
         }
         if (!baseType.isAssignableFrom(clazz)) {
-            throw new ReflectionException(className + " must extend or implement " +
-                    baseType.getName());
+            throw new ReflectionException(className + " must extend or implement " + baseType.getName());
         }
         @SuppressWarnings("unchecked")  // protected by isAssignableFrom check
         final Class<? extends T> castedClass = (Class<? extends T>) clazz;

--- a/metafacture-commons/src/main/java/org/metafacture/commons/tries/ACNode.java
+++ b/metafacture-commons/src/main/java/org/metafacture/commons/tries/ACNode.java
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.commons.tries;
 
 import java.util.Collection;
 import java.util.Map.Entry;
 import java.util.Set;
-
 
 /**
  * Node representing a character in a trie.
@@ -38,12 +38,12 @@ final class ACNode<P> {
         this.depth = depth;
     }
 
-    ACNode<P> addNext(final char key){
+    ACNode<P> addNext(final char key) {
         return addNext(key, null);
     }
 
-    ACNode<P> addNext(final char key, final P value){
-        final ACNode<P> next = new ACNode<P>(value, depth+1);
+    ACNode<P> addNext(final char key, final P currentValue) {
+        final ACNode<P> next = new ACNode<P>(currentValue, depth + 1);
         links.put(key, next);
         return next;
     }
@@ -52,12 +52,16 @@ final class ACNode<P> {
         this.value = value;
     }
 
-    P getValue(){
+    P getValue() {
         return value;
     }
 
-    ACNode<P> getNext(final char key){
+    ACNode<P> getNext(final char key) {
         return links.get(key);
+    }
+
+    Collection<ACNode<P>> getNext() {
+        return links.values();
     }
 
     ACNode<P> getFailure() {
@@ -70,10 +74,6 @@ final class ACNode<P> {
 
     int getDepth() {
         return depth;
-    }
-
-    Collection<ACNode<P>> getNext(){
-        return links.values();
     }
 
     Set<Entry<Character, ACNode<P>>> getLinks() {

--- a/metafacture-commons/src/main/java/org/metafacture/commons/tries/CharMap.java
+++ b/metafacture-commons/src/main/java/org/metafacture/commons/tries/CharMap.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.commons.tries;
 
 import java.util.Collection;
@@ -38,7 +39,7 @@ final class CharMap<V> implements Map<Character, V> {
     private int size;
 
     @SuppressWarnings("unchecked")
-    public CharMap() {
+    CharMap() {
         table = new Entry[INITIAL_CAPACITY];
     }
 
@@ -97,14 +98,15 @@ final class CharMap<V> implements Map<Character, V> {
         ++size;
     }
 
-    public void put(final Entry<V>[] table, final char key, final V value) {
+    public void put(final Entry<V>[] currentTable, final char key, final V value) {
         final Entry<V> newEntry = new Entry<V>(key, value);
 
-        Entry<V> entry = table[key % table.length];
+        Entry<V> entry = currentTable[key % currentTable.length];
 
         if (entry == null) {
-            table[key % table.length] = newEntry;
-        } else {
+            currentTable[key % currentTable.length] = newEntry;
+        }
+        else {
             while (entry.getNext() != null) {
                 if (entry.getKeyChar() == key) {
                     throw new IllegalStateException("Key '" + key + "' already used");
@@ -120,7 +122,7 @@ final class CharMap<V> implements Map<Character, V> {
         @SuppressWarnings("unchecked")
         final Entry<V>[] newTable = new Entry[newSize];
 
-        for (Entry<V> entry : table) {
+        for (final Entry<V> entry : table) {
             Entry<V> temp = entry;
             while (temp != null) {
                 put(newTable, temp.getKeyChar(), temp.getValue());
@@ -174,7 +176,7 @@ final class CharMap<V> implements Map<Character, V> {
 
     @Override
     public Set<java.util.Map.Entry<Character, V>> entrySet() {
-        final Set<java.util.Map.Entry<Character, V>>  entries = new HashSet<java.util.Map.Entry<Character, V>> ();
+        final Set<java.util.Map.Entry<Character, V>> entries = new HashSet<java.util.Map.Entry<Character, V>>();
         for (int i = 0; i < table.length; ++i) {
             Entry<V> entry = table[i];
             while (entry != null) {
@@ -223,9 +225,9 @@ final class CharMap<V> implements Map<Character, V> {
         }
 
         @Override
-        public V setValue(final V value) {
-            final V old = this.value;
-            this.value = value;
+        public V setValue(final V newValue) {
+            final V old = value;
+            value = newValue;
             return old;
         }
 

--- a/metafacture-commons/src/main/java/org/metafacture/commons/tries/SetMatcher.java
+++ b/metafacture-commons/src/main/java/org/metafacture/commons/tries/SetMatcher.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.commons.tries;
 
 import java.io.PrintStream;
@@ -32,6 +33,9 @@ public final class SetMatcher<T> {
     private final ACNode<T> root = new ACNode<>(null, 0);
     private boolean isPrepared;
 
+    public SetMatcher() {
+    }
+
     public void put(final String key, final T value) {
         if (isPrepared) {
             throw new IllegalStateException("keys cannot be added during matching.");
@@ -50,9 +54,11 @@ public final class SetMatcher<T> {
         next = node.getNext(key.charAt(length - 1));
         if (next == null) {
             next = node.addNext(key.charAt(length - 1), value);
-        } else if (next.getValue() == null) {
+        }
+        else if (next.getValue() == null) {
             next.setValue(value);
-        } else {
+        }
+        else {
             throw new IllegalStateException("Key '" + key + "' already in trie");
         }
     }
@@ -72,7 +78,8 @@ public final class SetMatcher<T> {
             final ACNode<T> next = node.getNext(text.charAt(index));
             if (next != null) {
                 node = next;
-            } else if (node != root) {
+            }
+            else if (node != root) {
                 node = node.getFailure();
                 continue;
             }
@@ -85,12 +92,12 @@ public final class SetMatcher<T> {
     private void collectMatches(final ACNode<T> node, final int index, final List<Match<T>> matches) {
         //direct hit or hit in chain of failure links?
         ACNode<T> tempNode = node;
-        do{
+        do {
             if (tempNode.getValue() != null) {
                 matches.add(new Match<T>(tempNode.getValue(), index - tempNode.getDepth(), tempNode.getDepth()));
             }
             tempNode = tempNode.getFailure();
-        }while (tempNode != root);
+        } while (tempNode != root);
     }
 
     private void prepare() {
@@ -98,7 +105,7 @@ public final class SetMatcher<T> {
 
         // prepare root
         root.setFailure(root);
-        for (ACNode<T> child : root.getNext()) {
+        for (final ACNode<T> child : root.getNext()) {
             child.setFailure(root);
             queue.add(child);
         }
@@ -107,7 +114,7 @@ public final class SetMatcher<T> {
             final ACNode<T> parent = queue.poll();
             final ACNode<T> parentFailure = parent.getFailure();
 
-            for (Entry<Character, ACNode<T>> link : parent.getLinks()) {
+            for (final Entry<Character, ACNode<T>> link : parent.getLinks()) {
                 final char key = link.getKey().charValue();
                 final ACNode<T> child = link.getValue();
                 ACNode<T> node = parentFailure;
@@ -118,7 +125,8 @@ public final class SetMatcher<T> {
 
                 if (node.getNext(key) == null) {
                     child.setFailure(root);
-                } else {
+                }
+                else {
                     child.setFailure(node.getNext(key));
                 }
                 queue.add(child);
@@ -141,14 +149,15 @@ public final class SetMatcher<T> {
     private void printDebug(final PrintStream out, final ACNode<T> node) {
         if (node.getValue() == null) {
             out.println(node.hashCode() + " [shape=point label=\"\"]");
-        } else {
+        }
+        else {
             out.println(node.hashCode() + " [shape=circle style=filled label=\"\"]");
         }
 
         if (node.getFailure() != root) {
             out.println(node.hashCode() + " -> " + node.getFailure().hashCode() + "[color=gray]");
         }
-        for (Entry<Character, ACNode<T>> link : node.getLinks()) {
+        for (final Entry<Character, ACNode<T>> link : node.getLinks()) {
             out.println(node.hashCode() + "  -> " + link.getValue().hashCode() + " [label=\"" + link.getKey() + "\"]");
             printDebug(out, link.getValue());
         }
@@ -165,7 +174,6 @@ public final class SetMatcher<T> {
         private final int length;
 
         public Match(final T value, final int start, final int length) {
-            super();
             this.value = value;
             this.start = start;
             this.length = length;

--- a/metafacture-commons/src/main/java/org/metafacture/commons/tries/SetReplacer.java
+++ b/metafacture-commons/src/main/java/org/metafacture/commons/tries/SetReplacer.java
@@ -13,15 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.commons.tries;
+
+import org.metafacture.commons.tries.SetMatcher.Match;
 
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
-
-import org.metafacture.commons.tries.SetMatcher.Match;
+import java.util.Map;
 
 /**
  * @author Markus Michael Geipel
@@ -30,12 +31,15 @@ import org.metafacture.commons.tries.SetMatcher.Match;
 public final class SetReplacer {
     private final SetMatcher<String> matcher = new SetMatcher<String>();
 
+    public SetReplacer() {
+    }
+
     public void addReplacement(final String key, final String with) {
         matcher.put(key, with);
     }
 
     public void addReplacements(final Map<String, String> replacements) {
-        for (Entry<String, String> entry : replacements.entrySet()) {
+        for (final Entry<String, String> entry : replacements.entrySet()) {
             addReplacement(entry.getKey(), entry.getValue());
         }
     }
@@ -49,25 +53,13 @@ public final class SetReplacer {
         Collections.sort(matches, new Comparator<SetMatcher.Match<String>>() {
             @Override
             public int compare(final Match<String> o1, final Match<String> o2) {
-                final int result;
                 final int delta = o1.getStart() - o2.getStart();
-                if (delta < 0) {
-                    result = -1;
-                } else if (delta > 0) {
-                    result = 1;
-                } else {
-                    if (o1.getLength() > o2.getLength()) {
-                        result = -1;
-                    } else {
-                        result = 1;
-                    }
-                }
-                return result;
+                return delta < 0 ? -1 : delta > 0 ? 1 : o1.getLength() > o2.getLength() ? -1 : 1;
             }
 
         });
 
-        for (SetMatcher.Match<String> match : matches) {
+        for (final SetMatcher.Match<String> match : matches) {
 
             if (match.getStart() < lastCut) {
                 continue;

--- a/metafacture-commons/src/main/java/org/metafacture/commons/tries/SimpleRegexTrie.java
+++ b/metafacture-commons/src/main/java/org/metafacture/commons/tries/SimpleRegexTrie.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.commons.tries;
 
 import java.util.List;
@@ -49,14 +50,16 @@ public class SimpleRegexTrie<P> {
         if (keys.matches(SIMPLE_CHARACTER_CLASS)) {
             int charClassStart = keys.indexOf('[', 0);
             final int charClassEnd = keys.indexOf(']', 1);
-            String begin = keys.substring(0, charClassStart);
-            for (; charClassStart < charClassEnd - 1; charClassStart++) {
-                char middle = keys.charAt(charClassStart + 1);
-                String end = keys.substring(charClassEnd + 1, keys.length());
+            final String begin = keys.substring(0, charClassStart);
+            for (; charClassStart < charClassEnd - 1; ++charClassStart) {
+                final char middle = keys.charAt(charClassStart + 1);
+                final String end = keys.substring(charClassEnd + 1, keys.length());
                 put(begin + middle + end, value);
             }
-        } else
+        }
+        else {
             trie.put(keys, value);
+        }
     }
 
     public List<P> get(final String key) {

--- a/metafacture-commons/src/main/java/org/metafacture/commons/tries/SimpleTrie.java
+++ b/metafacture-commons/src/main/java/org/metafacture/commons/tries/SimpleTrie.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.commons.tries;
 
 /**
@@ -24,32 +25,36 @@ package org.metafacture.commons.tries;
 public final class SimpleTrie<P> {
     private final Node<P> root = new Node<>(null);
 
-    public void put(final String key, final P value){
+    public SimpleTrie() {
+    }
+
+    public void put(final String key, final P value) {
 
         Node<P> node = root;
         Node<P> next;
         final int length = key.length();
-        for (int i = 0; i < length-1; ++i) {
+        for (int i = 0; i < length - 1; ++i) {
             next = node.getNext(key.charAt(i));
-            if(next==null){
+            if (next == null) {
                 next = node.addNext(key.charAt(i));
             }
             node = next;
         }
-        next = node.getNext(key.charAt(length-1));
-        if(next==null){
-            next = node.addNext(key.charAt(length-1), value);
-        }else{
+        next = node.getNext(key.charAt(length - 1));
+        if (next == null) {
+            next = node.addNext(key.charAt(length - 1), value);
+        }
+        else {
             throw new IllegalStateException("Value '" + value + "' already in trie");
         }
     }
 
-    public P get(final String key){
+    public P get(final String key) {
         Node<P> node = root;
         final int length = key.length();
         for (int i = 0; i < length; ++i) {
             node = node.getNext(key.charAt(i));
-            if(node==null){
+            if (node == null) {
                 return null;
             }
         }
@@ -65,25 +70,25 @@ public final class SimpleTrie<P> {
         private final P value;
         private final CharMap<Node<P>> links = new CharMap<Node<P>>();
 
-        public Node(final P value) {
+        Node(final P value) {
             this.value = value;
         }
 
-        public Node<P> addNext(final char key){
+        public Node<P> addNext(final char key) {
             return addNext(key, null);
         }
 
-        public Node<P> addNext(final char key, final P value){
-            final Node<P> next = new Node<P>(value);
+        public Node<P> addNext(final char key, final P currentValue) {
+            final Node<P> next = new Node<P>(currentValue);
             links.put(key, next);
             return next;
         }
 
-        public P getValue(){
+        public P getValue() {
             return value;
         }
 
-        public Node<P> getNext(final char key){
+        public Node<P> getNext(final char key) {
             return links.get(key);
         }
     }

--- a/metafacture-commons/src/main/java/org/metafacture/commons/tries/WildcardTrie.java
+++ b/metafacture-commons/src/main/java/org/metafacture/commons/tries/WildcardTrie.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.commons.tries;
 
 import java.util.ArrayList;
@@ -41,6 +42,9 @@ public final class WildcardTrie<P> {
     private Set<Node<P>> nodes = new HashSet<Node<P>>();
     private Set<Node<P>> nextNodes = new HashSet<Node<P>>();
 
+    public WildcardTrie() {
+    }
+
     /**
      * Inserts keys into the try. Use '|' to concatenate. Use '*' (0,inf) and
      * '?' (1,1) to express wildcards.
@@ -51,10 +55,11 @@ public final class WildcardTrie<P> {
     public void put(final String keys, final P value) {
         if (keys.contains(OR_STRING)) {
             final String[] keysSplit = OR_PATTERN.split(keys);
-            for (String string : keysSplit) {
+            for (final String string : keysSplit) {
                 simplyPut(string, value);
             }
-        } else {
+        }
+        else {
             simplyPut(keys, value);
         }
     }
@@ -76,13 +81,11 @@ public final class WildcardTrie<P> {
     }
 
     public List<P> get(final String key) {
-
         nodes.add(root);
         final int length = key.length();
         for (int i = 0; i < length; ++i) {
-            for (Node<P> node : nodes) {
-                Node<P> temp;
-                temp = node.getNext(key.charAt(i));
+            for (final Node<P> node : nodes) {
+                Node<P> temp = node.getNext(key.charAt(i));
                 if (temp != null) {
                     nextNodes.add(temp);
                 }
@@ -108,8 +111,12 @@ public final class WildcardTrie<P> {
             nextNodes = temp;
         }
 
+        return matches();
+    }
+
+    private List<P> matches() {
         List<P> matches = Collections.emptyList();
-        for (Node<P> node : nodes) {
+        for (final Node<P> node : nodes) {
             final Set<P> values = node.getValues();
             if (!values.isEmpty()) {
                 if (matches == Collections.emptyList()) {

--- a/metafacture-commons/src/main/java/org/metafacture/commons/types/ListMap.java
+++ b/metafacture-commons/src/main/java/org/metafacture/commons/types/ListMap.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.commons.types;
 
 import java.util.ArrayList;
@@ -39,12 +40,10 @@ public class ListMap<K, V> implements Map<K, List<V>> {
     private final Map<K, List<V>> map;
 
     public ListMap() {
-        super();
         map = new HashMap<K, List<V>>();
     }
 
     public ListMap(final Map<K, List<V>> map) {
-        super();
         this.map = map;
     }
 
@@ -62,7 +61,6 @@ public class ListMap<K, V> implements Map<K, List<V>> {
         return map.remove(key);
     }
 
-
     public final void clearKey(final K key) {
         final List<V> values = map.get(key);
         if (values != null) {
@@ -71,7 +69,7 @@ public class ListMap<K, V> implements Map<K, List<V>> {
     }
 
     public final void clearAllKeys() {
-        for (Entry<K, List<V>> entry: map.entrySet()) {
+        for (final Entry<K, List<V>> entry: map.entrySet()) {
             entry.getValue().clear();
         }
     }
@@ -86,7 +84,6 @@ public class ListMap<K, V> implements Map<K, List<V>> {
         return map.keySet();
     }
 
-
     public final void add(final K name, final V value) {
 
         List<V> values = map.get(name);
@@ -96,18 +93,6 @@ public class ListMap<K, V> implements Map<K, List<V>> {
         }
 
         values.add(value);
-    }
-
-    //@Override
-    public final void putAll(final K name, final Collection<V> addValues) {
-
-        List<V> values = map.get(name);
-        if (values == null) {
-            values = new ArrayList<V>();
-            map.put(name, values);
-        }
-
-        values.addAll(addValues);
     }
 
     @Override
@@ -136,8 +121,8 @@ public class ListMap<K, V> implements Map<K, List<V>> {
         return map.toString();
     }
 
-    public final void setId(final String identifier) {
-        this.identifier = identifier;
+    public final void setId(final String newIdentifier) {
+        identifier = newIdentifier;
     }
 
     public final String getId() {
@@ -174,10 +159,20 @@ public class ListMap<K, V> implements Map<K, List<V>> {
         return map.remove(key);
     }
 
+    //@Override
+    public final void putAll(final K name, final Collection<V> addValues) {
+        List<V> values = map.get(name);
+        if (values == null) {
+            values = new ArrayList<V>();
+            map.put(name, values);
+        }
+
+        values.addAll(addValues);
+    }
+
     @Override
     public final void putAll(final Map<? extends K, ? extends List<V>> putMap) {
         map.putAll(putMap);
-
     }
 
     @Override

--- a/metafacture-commons/src/main/java/org/metafacture/commons/types/NamedValue.java
+++ b/metafacture-commons/src/main/java/org/metafacture/commons/types/NamedValue.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.commons.types;
 
 /**
@@ -61,9 +62,9 @@ public final class NamedValue  implements Comparable<NamedValue> {
     public boolean equals(final Object obj) {
         if (obj instanceof NamedValue) {
             final NamedValue namedValue = (NamedValue) obj;
-            return namedValue.preCompHashCode == preCompHashCode
-                    && namedValue.name.equals(name)
-                    && namedValue.value.equals(value);
+            return namedValue.preCompHashCode == preCompHashCode &&
+                    namedValue.name.equals(name) &&
+                    namedValue.value.equals(value);
         }
         return false;
     }

--- a/metafacture-commons/src/main/java/org/metafacture/commons/types/ScopedHashMap.java
+++ b/metafacture-commons/src/main/java/org/metafacture/commons/types/ScopedHashMap.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.commons.types;
 
 import java.util.HashMap;
@@ -26,18 +27,16 @@ import java.util.Map;
  * @param <V> type of the values
  * @author Markus Michael Geipel
  */
-public final class ScopedHashMap<K, V> extends HashMap<K, V> {
+public final class ScopedHashMap<K, V> extends HashMap<K, V> { // checkstyle-disable-line IllegalType
 
     private static final long serialVersionUID = -7184066609960144713L;
     private final ScopedHashMap<K, V> outerScope;
 
     public ScopedHashMap(final ScopedHashMap<K, V> outerScope) {
-        super();
         this.outerScope = outerScope;
     }
 
     public ScopedHashMap() {
-        super();
         outerScope = null;
     }
 

--- a/metafacture-commons/src/test/java/org/metafacture/commons/RequireTest.java
+++ b/metafacture-commons/src/test/java/org/metafacture/commons/RequireTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.commons;
 
 import static org.junit.Assert.assertEquals;

--- a/metafacture-commons/src/test/java/org/metafacture/commons/ResourceUtilTest.java
+++ b/metafacture-commons/src/test/java/org/metafacture/commons/ResourceUtilTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.commons;
 
 import static java.util.stream.Collectors.joining;

--- a/metafacture-commons/src/test/java/org/metafacture/commons/StringUtilTest.java
+++ b/metafacture-commons/src/test/java/org/metafacture/commons/StringUtilTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.commons;
 
 import static org.junit.Assert.assertEquals;

--- a/metafacture-commons/src/test/java/org/metafacture/commons/TimeUtilTest.java
+++ b/metafacture-commons/src/test/java/org/metafacture/commons/TimeUtilTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.commons;
 
 import static org.junit.Assert.assertEquals;

--- a/metafacture-commons/src/test/java/org/metafacture/commons/XmlUtilTest.java
+++ b/metafacture-commons/src/test/java/org/metafacture/commons/XmlUtilTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.commons;
 
 import static org.junit.Assert.assertEquals;

--- a/metafacture-commons/src/test/java/org/metafacture/commons/tries/CharMapTest.java
+++ b/metafacture-commons/src/test/java/org/metafacture/commons/tries/CharMapTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.commons.tries;
 
 import static org.junit.Assert.assertEquals;

--- a/metafacture-commons/src/test/java/org/metafacture/commons/tries/SetMatchTest.java
+++ b/metafacture-commons/src/test/java/org/metafacture/commons/tries/SetMatchTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.commons.tries;
 
 import static org.junit.Assert.assertEquals;

--- a/metafacture-commons/src/test/java/org/metafacture/commons/tries/SetReplaceTest.java
+++ b/metafacture-commons/src/test/java/org/metafacture/commons/tries/SetReplaceTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.commons.tries;
 
 import static org.junit.Assert.assertEquals;

--- a/metafacture-commons/src/test/java/org/metafacture/commons/tries/SimpleRegexTrieTest.java
+++ b/metafacture-commons/src/test/java/org/metafacture/commons/tries/SimpleRegexTrieTest.java
@@ -12,6 +12,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
 package org.metafacture.commons.tries;
 
 import static org.junit.Assert.assertTrue;

--- a/metafacture-commons/src/test/java/org/metafacture/commons/tries/SimpleTrieTest.java
+++ b/metafacture-commons/src/test/java/org/metafacture/commons/tries/SimpleTrieTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.commons.tries;
 
 import static org.junit.Assert.assertEquals;

--- a/metafacture-commons/src/test/java/org/metafacture/commons/tries/WildcardTrieTest.java
+++ b/metafacture-commons/src/test/java/org/metafacture/commons/tries/WildcardTrieTest.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.commons.tries;
 
 import static org.junit.Assert.assertEquals;

--- a/metafacture-commons/src/test/java/org/metafacture/commons/types/ListMapTest.java
+++ b/metafacture-commons/src/test/java/org/metafacture/commons/types/ListMapTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.commons.types;
 
 import static org.junit.Assert.assertEquals;

--- a/metafacture-commons/src/test/java/org/metafacture/commons/types/NamedValueTest.java
+++ b/metafacture-commons/src/test/java/org/metafacture/commons/types/NamedValueTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.commons.types;
 
 import org.junit.Assert;

--- a/metafacture-csv/src/main/java/org/metafacture/csv/CsvDecoder.java
+++ b/metafacture-csv/src/main/java/org/metafacture/csv/CsvDecoder.java
@@ -13,11 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.csv;
 
-import java.io.IOException;
-import java.io.StringReader;
-import java.util.List;
+package org.metafacture.csv;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.StreamReceiver;
@@ -27,6 +24,10 @@ import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
 
 import com.opencsv.CSVReader;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.List;
 
 /**
  * Decodes lines of CSV files. First line is interpreted as header.
@@ -52,7 +53,6 @@ public final class CsvDecoder extends DefaultObjectPipe<String, StreamReceiver> 
      * @param separator to split lines
      */
     public CsvDecoder(final String separator) {
-        super();
         this.separator = separator.charAt(0);
     }
 
@@ -60,12 +60,10 @@ public final class CsvDecoder extends DefaultObjectPipe<String, StreamReceiver> 
      * @param separator to split lines
      */
     public CsvDecoder(final char separator) {
-        super();
         this.separator = separator;
     }
 
     public CsvDecoder() {
-        super();
         this.separator = DEFAULT_SEP;
     }
 
@@ -73,22 +71,25 @@ public final class CsvDecoder extends DefaultObjectPipe<String, StreamReceiver> 
     public void process(final String string) {
         assert !isClosed();
         final String[] parts = parseCsv(string);
-        if(hasHeader){
-            if(header.length==0){
+        if (hasHeader) {
+            if (header.length == 0) {
                 header = parts;
-            }else if(parts.length==header.length){
+            }
+            else if (parts.length == header.length) {
                 getReceiver().startRecord(String.valueOf(++count));
                 for (int i = 0; i < parts.length; ++i) {
                     getReceiver().literal(header[i], parts[i]);
                 }
                 getReceiver().endRecord();
-            }else{
+            }
+            else {
                 throw new IllegalArgumentException(
                         String.format(
                                 "wrong number of columns (expected %s, was %s) in input line: %s",
                                 header.length, parts.length, string));
             }
-        }else{
+        }
+        else {
             getReceiver().startRecord(String.valueOf(++count));
             for (int i = 0; i < parts.length; ++i) {
                 getReceiver().literal(String.valueOf(i), parts[i]);
@@ -107,7 +108,8 @@ public final class CsvDecoder extends DefaultObjectPipe<String, StreamReceiver> 
                 parts = lines.get(0);
             }
             reader.close();
-        } catch (IOException e) {
+        }
+        catch (final IOException e) {
             e.printStackTrace();
         }
         return parts;
@@ -117,5 +119,7 @@ public final class CsvDecoder extends DefaultObjectPipe<String, StreamReceiver> 
         this.hasHeader = hasHeader;
     }
 
-    public void setSeparator(final String separator) { this.separator = separator.charAt(0); }
+    public void setSeparator(final String separator) {
+        this.separator = separator.charAt(0);
+    }
 }

--- a/metafacture-csv/src/test/java/org/metafacture/csv/CsvDecoderTest.java
+++ b/metafacture-csv/src/test/java/org/metafacture/csv/CsvDecoderTest.java
@@ -13,6 +13,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
 package org.metafacture.csv;
 
 import static org.mockito.Mockito.inOrder;

--- a/metafacture-elasticsearch/src/main/java/org/metafacture/elasticsearch/JsonToElasticsearchBulk.java
+++ b/metafacture-elasticsearch/src/main/java/org/metafacture/elasticsearch/JsonToElasticsearchBulk.java
@@ -13,7 +13,16 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
 package org.metafacture.elasticsearch;
+
+import org.metafacture.framework.FluxCommand;
+import org.metafacture.framework.ObjectReceiver;
+import org.metafacture.framework.annotations.In;
+import org.metafacture.framework.annotations.Out;
+import org.metafacture.framework.helpers.DefaultObjectPipe;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -23,14 +32,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
-
-import org.metafacture.framework.FluxCommand;
-import org.metafacture.framework.ObjectReceiver;
-import org.metafacture.framework.annotations.In;
-import org.metafacture.framework.annotations.Out;
-import org.metafacture.framework.helpers.DefaultObjectPipe;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Add Elasticsearch bulk indexing metadata to JSON input.
@@ -42,56 +43,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @In(String.class)
 @Out(String.class)
 @FluxCommand("json-to-elasticsearch-bulk")
-public class JsonToElasticsearchBulk extends
-        DefaultObjectPipe<String, ObjectReceiver<String>> {
-
-    /**
-     * Use a MultiMap with Jackson to collect values from multiple fields with
-     * identical names under a single key.
-     */
-    static class MultiMap extends HashMap<String, Object> {
-        private static final long serialVersionUID = 490682490432334605L;
-
-        MultiMap() {
-            // default constructor for Jackson
-        }
-
-        @Override
-        public Object put(String key, Object value) {
-            if (containsKey(key)) {
-                Object oldValue = get(key);
-                if (oldValue instanceof Set) {
-                    @SuppressWarnings("unchecked")
-                    Set<Object> vals = ((Set<Object>) oldValue);
-                    vals.add(value);
-                    return super.put(key, vals);
-                }
-                HashSet<Object> set = new HashSet<>(Arrays.asList(oldValue, value));
-                return super.put(key, set.size() == 1 ? value : set);
-            }
-            return super.put(key, value);
-        }
-    }
+public class JsonToElasticsearchBulk extends DefaultObjectPipe<String, ObjectReceiver<String>> {
 
     private ObjectMapper mapper = new ObjectMapper();
     private String[] idPath;
     private String type;
     private String index;
 
-    public void setIdKey(String idKey) {
-        this.idPath = new String[]{idKey};
-    }
-
-    public void setType(String type) {
-        this.type = type;
-    }
-
-    public void setIndex(String index) {
-        this.index = index;
-    }
-
     public JsonToElasticsearchBulk() {
-        super();
         this.idPath = new String[]{};
         this.type = null;
         this.index = null;
@@ -103,8 +62,8 @@ public class JsonToElasticsearchBulk extends
      * @param type The Elasticsearch index type
      * @param index The Elasticsearch index name
      */
-    public JsonToElasticsearchBulk(String type, String index) {
-        this(new String[] { }, type, index);
+    public JsonToElasticsearchBulk(final String type, final String index) {
+        this(new String[] {}, type, index);
     }
 
     /**
@@ -112,7 +71,7 @@ public class JsonToElasticsearchBulk extends
      * @param type The Elasticsearch index type
      * @param index The Elasticsearch index name
      */
-    public JsonToElasticsearchBulk(String[] idPath, String type, String index) {
+    public JsonToElasticsearchBulk(final String[] idPath, final String type, final String index) {
         this.idPath = idPath;
         this.type = type;
         this.index = index;
@@ -123,7 +82,7 @@ public class JsonToElasticsearchBulk extends
      * @param type The Elasticsearch index type
      * @param index The Elasticsearch index name
      */
-    public JsonToElasticsearchBulk(String idKey, String type, String index) {
+    public JsonToElasticsearchBulk(final String idKey, final String type, final String index) {
         this(new String[]{idKey}, type, index);
     }
 
@@ -133,42 +92,96 @@ public class JsonToElasticsearchBulk extends
      * @param index The Elasticsearch index name
      * @param entitySeparator The separator between entity names in idKey
      */
-    public JsonToElasticsearchBulk(String idKey, String type, String index, String entitySeparator) {
+    public JsonToElasticsearchBulk(final String idKey, final String type, final String index, final String entitySeparator) {
         this(idKey.split(Pattern.quote(entitySeparator)), type, index);
     }
 
+    public void setIdKey(final String idKey) {
+        this.idPath = new String[]{idKey};
+    }
+
+    public void setType(final String type) {
+        this.type = type;
+    }
+
+    public void setIndex(final String index) {
+        this.index = index;
+    }
+
     @Override
-    public void process(String obj) {
-        StringWriter stringWriter = new StringWriter();
+    public void process(final String obj) {
+        final StringWriter stringWriter = new StringWriter();
         try {
-            Map<String, Object> json = mapper.readValue(obj, MultiMap.class);
-            Map<String, Object> detailsMap = new HashMap<String, Object>();
-            Map<String, Object> indexMap = new HashMap<String, Object>();
+            final Map<String, Object> json = mapper.readValue(obj, MultiMap.class);
+            final Map<String, Object> detailsMap = new HashMap<String, Object>();
+            final Map<String, Object> indexMap = new HashMap<String, Object>();
             indexMap.put("index", detailsMap);
-            if (idPath.length > 0) detailsMap.put("_id", findId(json));
+            if (idPath.length > 0) {
+                detailsMap.put("_id", findId(json));
+            }
             detailsMap.put("_type", type);
             detailsMap.put("_index", index);
             mapper.writeValue(stringWriter, indexMap);
             stringWriter.write("\n");
             mapper.writeValue(stringWriter, json);
-        } catch (IOException e) {
+        }
+        catch (final IOException e) {
             e.printStackTrace();
         }
         getReceiver().process(stringWriter.toString());
     }
 
-    private Object findId(Object value) {
+    private Object findId(final Object value) {
+        Object newValue = value;
+
         for (final String key : idPath) {
-            if (value instanceof Map) {
+            if (newValue instanceof Map) {
                 @SuppressWarnings("unchecked")
-                final Map<String, Object> nestedMap = (Map<String, Object>) value;
-                value = nestedMap.get(key);
+                final Map<String, Object> nestedMap = (Map<String, Object>) newValue;
+                newValue = nestedMap.get(key);
             }
             else {
                 return null;
             }
         }
 
-        return value;
+        return newValue;
     }
+
+    /**
+     * Use a MultiMap with Jackson to collect values from multiple fields with
+     * identical names under a single key.
+     */
+    static class MultiMap extends HashMap<String, Object> { // checkstyle-disable-line IllegalType
+        private static final long serialVersionUID = 490682490432334605L;
+
+        MultiMap() {
+            // default constructor for Jackson
+        }
+
+        @Override
+        public Object put(final String key, final Object value) {
+            final Object newValue;
+
+            if (containsKey(key)) {
+                final Object oldValue = get(key);
+                if (oldValue instanceof Set) {
+                    @SuppressWarnings("unchecked")
+                    final Set<Object> vals = (Set<Object>) oldValue;
+                    vals.add(value);
+                    newValue = vals;
+                }
+                else {
+                    final Set<Object> set = new HashSet<>(Arrays.asList(oldValue, value));
+                    newValue = set.size() == 1 ? value : set;
+                }
+            }
+            else {
+                newValue = value;
+            }
+
+            return super.put(key, newValue);
+        }
+    }
+
 }

--- a/metafacture-elasticsearch/src/test/java/org/metafacture/elasticsearch/JsonToElasticsearchBulkTest.java
+++ b/metafacture-elasticsearch/src/test/java/org/metafacture/elasticsearch/JsonToElasticsearchBulkTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.elasticsearch;
 
 import static org.mockito.Mockito.verify;

--- a/metafacture-files/src/main/java/org/metafacture/files/DirReader.java
+++ b/metafacture-files/src/main/java/org/metafacture/files/DirReader.java
@@ -13,11 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.files;
 
-import java.io.File;
-import java.io.FilenameFilter;
-import java.util.Arrays;
+package org.metafacture.files;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.ObjectReceiver;
@@ -25,6 +22,10 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.util.Arrays;
 
 /**
  * Reads a directory and emits all filenames found.
@@ -40,14 +41,17 @@ public final class DirReader extends DefaultObjectPipe<String, ObjectReceiver<St
 
     private boolean recursive;
 
-    private String filenameFilterPattern = null;
+    private String filenameFilterPattern;
+
+    public DirReader() {
+    }
 
     public void setRecursive(final boolean recursive) {
         this.recursive = recursive;
     }
 
-    public void setFilenamePattern(final String filenameFilterPattern) {
-        this.filenameFilterPattern = filenameFilterPattern;
+    public void setFilenamePattern(final String newFilenameFilterPattern) {
+        filenameFilterPattern = newFilenameFilterPattern;
     }
 
     @Override
@@ -55,27 +59,29 @@ public final class DirReader extends DefaultObjectPipe<String, ObjectReceiver<St
         final File file = new File(dir);
         if (file.isDirectory()) {
             dir(file);
-        } else {
+        }
+        else {
             getReceiver().process(dir);
         }
     }
 
     private void dir(final File dir) {
         final ObjectReceiver<String> receiver = getReceiver();
-        final File[] files = filenameFilterPattern == null ? dir.listFiles()
-                : dir.listFiles(new FilenameFilter() {
+        final File[] files = filenameFilterPattern == null ? dir.listFiles() :
+                dir.listFiles(new FilenameFilter() {
                     @Override
                     public boolean accept(final File dir, final String name) {
                         return name.matches(filenameFilterPattern);
                     }
                 });
         Arrays.sort(files);
-        for (File file : files) {
+        for (final File file : files) {
             if (file.isDirectory()) {
                 if (recursive) {
                     dir(file);
                 }
-            } else {
+            }
+            else {
                 receiver.process(file.getAbsolutePath());
             }
         }

--- a/metafacture-files/src/main/java/org/metafacture/files/FileDigestCalculator.java
+++ b/metafacture-files/src/main/java/org/metafacture/files/FileDigestCalculator.java
@@ -13,13 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.files;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
+package org.metafacture.files;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.MetafactureException;
@@ -29,6 +24,12 @@ import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
 import org.metafacture.framework.objects.Triple;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 
 /**
  * Interprets the input string as a file name and computes a cryptographic hash
@@ -48,12 +49,12 @@ public final class FileDigestCalculator extends
 
     private static final int HIGH_NIBBLE = 0xf0;
     private static final int LOW_NIBBLE = 0x0f;
-    private static final char[] NIBBLE_TO_HEX =
-            { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
+    private static final char[] NIBBLE_TO_HEX = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+
+    private static final int NIBBLE_TO_HEX_SHIFT_WIDTH = 4;
 
     private final DigestAlgorithm algorithm;
     private final MessageDigest messageDigest;
-
 
     public FileDigestCalculator(final DigestAlgorithm algorithm) {
         this.algorithm = algorithm;
@@ -72,12 +73,17 @@ public final class FileDigestCalculator extends
         try {
             stream = new FileInputStream(file);
             digest = bytesToHex(getDigest(stream, messageDigest));
-        } catch (IOException e) {
+        }
+        catch (final IOException e) {
             throw new MetafactureException(e);
-        } finally {
+        }
+        finally {
             if (stream != null) {
-                try { stream.close(); }
-                catch (final IOException e) { }
+                try {
+                    stream.close();
+                }
+                catch (final IOException e) {
+                }
             }
         }
         getReceiver().process(new Triple(file, algorithm.name(), digest));
@@ -96,8 +102,8 @@ public final class FileDigestCalculator extends
 
     private static String bytesToHex(final byte[] bytes) {
         final char[] hex = new char[bytes.length * 2];
-        for (int i=0; i < bytes.length; ++i) {
-            hex[i * 2] = NIBBLE_TO_HEX[(bytes[i] & HIGH_NIBBLE) >>> 4];
+        for (int i = 0; i < bytes.length; ++i) {
+            hex[i * 2] = NIBBLE_TO_HEX[(bytes[i] & HIGH_NIBBLE) >>> NIBBLE_TO_HEX_SHIFT_WIDTH];
             hex[i * 2 + 1] = NIBBLE_TO_HEX[bytes[i] & LOW_NIBBLE];
         }
         return new String(hex);
@@ -115,19 +121,20 @@ public final class FileDigestCalculator extends
         SHA1("SHA-1"),
         SHA256("SHA-256"),
         SHA384("SHA-384"),
-        SHA512 ("SHA-512");
+        SHA512("SHA-512");
 
         private final String identifier;
 
-        private DigestAlgorithm(final String identifier) {
+        DigestAlgorithm(final String identifier) {
             this.identifier = identifier;
         }
 
         public MessageDigest getInstance() {
             try {
                 return MessageDigest.getInstance(identifier);
-            } catch (NoSuchAlgorithmException e) {
-                throw new MetafactureException (e);
+            }
+            catch (final NoSuchAlgorithmException e) {
+                throw new MetafactureException(e);
             }
         }
 

--- a/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/CloseSuppressor.java
+++ b/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/CloseSuppressor.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.flowcontrol;
 
 import org.metafacture.framework.FluxCommand;
@@ -59,9 +60,9 @@ public final class CloseSuppressor<T>
     }
 
     @Override
-    public <R extends ObjectReceiver<T>> R setReceiver(final R receiver) {
-        this.receiver = receiver;
-        return receiver;
+    public <R extends ObjectReceiver<T>> R setReceiver(final R newReceiver) {
+        receiver = newReceiver;
+        return newReceiver;
     }
 
     @Override

--- a/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/ObjectBatchResetter.java
+++ b/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/ObjectBatchResetter.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.flowcontrol;
 
 import org.metafacture.framework.FluxCommand;
@@ -41,6 +42,9 @@ public class ObjectBatchResetter<T> extends DefaultObjectPipe<T, ObjectReceiver<
     private long batchCount;
     private int objectCount;
 
+    public ObjectBatchResetter() {
+    }
+
     /**
      * Number of objects after which a <i>reset-stream</i> event is triggered.
      * <p>
@@ -53,8 +57,7 @@ public class ObjectBatchResetter<T> extends DefaultObjectPipe<T, ObjectReceiver<
      * @param batchSize number of objects before a <i>reset-stream</i> event is
      *                  triggered
      */
-    public void setBatchSize(int batchSize) {
-
+    public void setBatchSize(final int batchSize) {
         this.batchSize = batchSize;
     }
 

--- a/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/ObjectExceptionCatcher.java
+++ b/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/ObjectExceptionCatcher.java
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.flowcontrol;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
+package org.metafacture.flowcontrol;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.ObjectReceiver;
@@ -24,9 +22,12 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 
 /**
  * Wraps the call to the process method of the downstream module
@@ -57,7 +58,6 @@ public final class ObjectExceptionCatcher<T> extends
     }
 
     public ObjectExceptionCatcher(final String logPrefix) {
-        super();
         this.logPrefix = logPrefix;
     }
 
@@ -81,7 +81,8 @@ public final class ObjectExceptionCatcher<T> extends
     public void process(final T obj) {
         try {
             getReceiver().process(obj);
-        } catch(final Exception e) {
+        }
+        catch (final Exception e) { // checkstyle-disable-line IllegalCatch
             LOG.error("{}'{}' while processing object: {}", logPrefix, e.getMessage(), obj);
 
             if (logStackTrace) {

--- a/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/ObjectPipeDecoupler.java
+++ b/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/ObjectPipeDecoupler.java
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.flowcontrol;
 
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
+package org.metafacture.flowcontrol;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.ObjectPipe;
@@ -24,8 +22,12 @@ import org.metafacture.framework.ObjectReceiver;
 import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 
 /**
  * Creates a new thread in which subsequent flow elements run.
@@ -76,7 +78,8 @@ public final class ObjectPipeDecoupler<T> implements ObjectPipe<T, ObjectReceive
             if (debug) {
                 LOG.info("Current buffer size: {}", queue.size());
             }
-        } catch (InterruptedException e) {
+        }
+        catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
         }
     }
@@ -87,20 +90,21 @@ public final class ObjectPipeDecoupler<T> implements ObjectPipe<T, ObjectReceive
     }
 
     @Override
-    public <R extends ObjectReceiver<T>> R setReceiver(final R receiver) {
+    public <R extends ObjectReceiver<T>> R setReceiver(final R newReceiver) {
         if (null != thread) {
             throw new IllegalStateException("Receiver cannot be changed while processing thread is running.");
         }
 
-        this.receiver = receiver;
-        return receiver;
+        receiver = newReceiver;
+        return newReceiver;
     }
 
     @Override
     public void resetStream() {
         try {
             queue.put(Feeder.BLUE_PILL);
-        } catch (InterruptedException e) {
+        }
+        catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
         }
     }
@@ -110,7 +114,8 @@ public final class ObjectPipeDecoupler<T> implements ObjectPipe<T, ObjectReceive
         try {
             queue.put(Feeder.RED_PILL);
             thread.join();
-        } catch (InterruptedException e) {
+        }
+        catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
         }
         thread = null;
@@ -128,7 +133,7 @@ public final class ObjectPipeDecoupler<T> implements ObjectPipe<T, ObjectReceive
         private final ObjectReceiver<T> receiver;
         private final BlockingQueue<Object> queue;
 
-        public Feeder(final ObjectReceiver<T> receiver, final BlockingQueue<Object> queue) {
+        Feeder(final ObjectReceiver<T> receiver, final BlockingQueue<Object> queue) {
             this.receiver = receiver;
             this.queue = queue;
         }
@@ -150,7 +155,8 @@ public final class ObjectPipeDecoupler<T> implements ObjectPipe<T, ObjectReceive
                     }
                     receiver.process((T) object);
                 }
-            } catch (InterruptedException e) {
+            }
+            catch (final InterruptedException e) {
                 Thread.currentThread().interrupt();
                 return;
             }

--- a/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/ObjectThreader.java
+++ b/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/ObjectThreader.java
@@ -15,9 +15,6 @@
 
 package org.metafacture.flowcontrol;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.ObjectPipe;
 import org.metafacture.framework.ObjectReceiver;
@@ -25,8 +22,12 @@ import org.metafacture.framework.Tee;
 import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Divides incoming objects and distributes them to added receivers. These
@@ -48,22 +49,26 @@ public class ObjectThreader<T> implements Tee<ObjectReceiver<T>>, ObjectPipe<T, 
 
     private static final Logger LOG = LoggerFactory.getLogger(ObjectThreader.class);
     private final List<ObjectReceiver<T>> receivers = new ArrayList<ObjectReceiver<T>>();
-    private int objectNumber = 0;
+    private int objectNumber;
+
+    public ObjectThreader() {
+    }
 
     @Override
     public void process(final T obj) {
         receivers.get(objectNumber).process(obj);
         if (objectNumber == receivers.size() - 1) {
             objectNumber = 0;
-        } else {
-            objectNumber++;
+        }
+        else {
+            ++objectNumber;
         }
     }
 
     @Override
     public Tee<ObjectReceiver<T>> addReceiver(final ObjectReceiver<T> receiver) {
-        LOG.info("Adding thread {}", (receivers.size() + 1));
-        ObjectPipeDecoupler<T> opd = new ObjectPipeDecoupler<>();
+        LOG.info("Adding thread {}", receivers.size() + 1);
+        final ObjectPipeDecoupler<T> opd = new ObjectPipeDecoupler<>();
         opd.setReceiver(receiver);
         receivers.add(opd);
         return this;
@@ -77,7 +82,7 @@ public class ObjectThreader<T> implements Tee<ObjectReceiver<T>>, ObjectPipe<T, 
     }
 
     @Override
-    public <R extends ObjectReceiver<T>> R setReceivers(R receiver, ObjectReceiver<T> lateralReceiver) {
+    public <R extends ObjectReceiver<T>> R setReceivers(final R receiver, final ObjectReceiver<T> lateralReceiver) {
         receivers.clear();
         addReceiver(receiver);
         addReceiver(lateralReceiver);
@@ -95,7 +100,7 @@ public class ObjectThreader<T> implements Tee<ObjectReceiver<T>>, ObjectPipe<T, 
     }
 
     @Override
-    public Tee<ObjectReceiver<T>> removeReceiver(ObjectReceiver<T> receiver) {
+    public Tee<ObjectReceiver<T>> removeReceiver(final ObjectReceiver<T> receiver) {
         receivers.remove(receiver);
         return this;
     }

--- a/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/StreamBatchResetter.java
+++ b/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/StreamBatchResetter.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.flowcontrol;
 
 import org.metafacture.framework.FluxCommand;
@@ -40,35 +41,38 @@ public final class StreamBatchResetter extends ForwardingStreamPipe {
     private long recordCount;
     private long batchCount;
 
-    public final void setBatchSize(final int batchSize) {
+    public StreamBatchResetter() {
+    }
+
+    public void setBatchSize(final int batchSize) {
         this.batchSize = batchSize;
     }
 
-    public final long getBatchSize() {
+    public long getBatchSize() {
         return batchSize;
     }
 
-    public final long getBatchCount() {
+    public long getBatchCount() {
         return batchCount;
     }
 
-    public final long getRecordCount() {
+    public long getRecordCount() {
         return recordCount;
     }
 
     @Override
-    public final void endRecord() {
+    public void endRecord() {
         getReceiver().endRecord();
-        recordCount++;
+        ++recordCount;
         recordCount %= batchSize;
         if (recordCount == 0) {
-            batchCount++;
+            ++batchCount;
             getReceiver().resetStream();
         }
     }
 
     @Override
-    protected final void onResetStream() {
+    protected void onResetStream() {
         recordCount = 0;
         batchCount = 0;
     }

--- a/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/StreamBuffer.java
+++ b/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/StreamBuffer.java
@@ -13,15 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.flowcontrol;
 
-import java.util.ArrayList;
-import java.util.List;
+package org.metafacture.flowcontrol;
 
 import org.metafacture.framework.StreamPipe;
 import org.metafacture.framework.StreamReceiver;
 import org.metafacture.framework.helpers.DefaultStreamPipe;
 
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * {@link StreamPipe} which buffers incoming records and replays them upon
@@ -30,8 +30,7 @@ import org.metafacture.framework.helpers.DefaultStreamPipe;
  * @author Markus Michael Geipel
  *
  */
-public final class StreamBuffer
-        extends DefaultStreamPipe<StreamReceiver> {
+public final class StreamBuffer extends DefaultStreamPipe<StreamReceiver> {
 
     /**
      * Defines entity and literal message types.
@@ -43,8 +42,10 @@ public final class StreamBuffer
     private final List<MessageType> typeBuffer = new ArrayList<StreamBuffer.MessageType>();
     private final List<String> valueBuffer = new ArrayList<String>();
 
+    public StreamBuffer() {
+    }
 
-    public boolean isEmpty(){
+    public boolean isEmpty() {
         return typeBuffer.isEmpty();
     }
 
@@ -54,27 +55,27 @@ public final class StreamBuffer
     public void replay() {
 
         int index = 0;
-        for (MessageType type : typeBuffer) {
+        for (final MessageType type : typeBuffer) {
             switch (type) {
-            case RECORD_START:
-                getReceiver().startRecord(valueBuffer.get(index));
-                ++index;
-                break;
-            case RECORD_END:
-                getReceiver().endRecord();
-                break;
+                case RECORD_START:
+                    getReceiver().startRecord(valueBuffer.get(index));
+                    ++index;
+                    break;
+                case RECORD_END:
+                    getReceiver().endRecord();
+                    break;
 
-            case ENTITY_START:
-                getReceiver().startEntity(valueBuffer.get(index));
-                ++index;
-                break;
-            case ENTITY_END:
-                getReceiver().endEntity();
-                break;
-            default:
-                getReceiver().literal(valueBuffer.get(index), valueBuffer.get(index+1));
-                index +=2;
-                break;
+                case ENTITY_START:
+                    getReceiver().startEntity(valueBuffer.get(index));
+                    ++index;
+                    break;
+                case ENTITY_END:
+                    getReceiver().endEntity();
+                    break;
+                default:
+                    getReceiver().literal(valueBuffer.get(index), valueBuffer.get(index + 1));
+                    index += 2;
+                    break;
             }
         }
     }

--- a/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/StreamDeferrer.java
+++ b/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/StreamDeferrer.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.flowcontrol;
 
 import org.metafacture.framework.FluxCommand;
@@ -43,6 +44,9 @@ import org.metafacture.framework.helpers.DefaultStreamPipe;
 public class StreamDeferrer extends DefaultStreamPipe<StreamReceiver> {
 
     private final StreamBuffer buffer = new StreamBuffer();
+
+    public StreamDeferrer() {
+    }
 
     @Override
     public void startRecord(final String identifier) {

--- a/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/StreamExceptionCatcher.java
+++ b/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/StreamExceptionCatcher.java
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-/**
- *
- */
 package org.metafacture.flowcontrol;
 
 import org.metafacture.framework.FluxCommand;
@@ -25,6 +22,7 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultStreamPipe;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,7 +49,6 @@ public final class StreamExceptionCatcher extends
     }
 
     public StreamExceptionCatcher(final String logPrefix) {
-        super();
         this.logPrefix = logPrefix;
     }
 
@@ -59,7 +56,8 @@ public final class StreamExceptionCatcher extends
     public void startRecord(final String identifier) {
         try {
             getReceiver().startRecord(identifier);
-        } catch(final Exception e) {
+        }
+        catch (final Exception e) { // checkstyle-disable-line IllegalCatch
             LOG.error(MSG_PATTERN, logPrefix, "StartRecord" + identifier);
             LOG.error(MSG_PATTERN, logPrefix, e);
         }
@@ -69,7 +67,8 @@ public final class StreamExceptionCatcher extends
     public void endRecord() {
         try {
             getReceiver().endRecord();
-        } catch(final Exception e) {
+        }
+        catch (final Exception e) { // checkstyle-disable-line IllegalCatch
             LOG.error(MSG_PATTERN, logPrefix, "endRecord");
             LOG.error(MSG_PATTERN, logPrefix, e);
         }
@@ -79,7 +78,8 @@ public final class StreamExceptionCatcher extends
     public void startEntity(final String name) {
         try {
             getReceiver().startEntity(name);
-        } catch(final Exception e) {
+        }
+        catch (final Exception e) { // checkstyle-disable-line IllegalCatch
             LOG.error(MSG_PATTERN, logPrefix, "startEntity" + name);
             LOG.error(MSG_PATTERN, logPrefix, e);
         }
@@ -89,7 +89,8 @@ public final class StreamExceptionCatcher extends
     public void endEntity() {
         try {
             getReceiver().endEntity();
-        } catch(final Exception e) {
+        }
+        catch (final Exception e) { // checkstyle-disable-line IllegalCatch
             LOG.error(MSG_PATTERN, logPrefix, "endEntity");
             LOG.error(MSG_PATTERN, logPrefix, e);
         }
@@ -99,8 +100,9 @@ public final class StreamExceptionCatcher extends
     public void literal(final String name, final String value) {
         try {
             getReceiver().literal(name, value);
-        } catch(final Exception e) {
-            LOG.error(MSG_PATTERN, logPrefix, "literal " + name +" " + value);
+        }
+        catch (final Exception e) { // checkstyle-disable-line IllegalCatch
+            LOG.error(MSG_PATTERN, logPrefix, "literal " + name + " " + value);
             LOG.error(MSG_PATTERN, logPrefix, e);
         }
     }

--- a/metafacture-flowcontrol/src/test/java/org/metafacture/flowcontrol/CloseSuppressorTest.java
+++ b/metafacture-flowcontrol/src/test/java/org/metafacture/flowcontrol/CloseSuppressorTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.flowcontrol;
 
 import org.junit.Test;

--- a/metafacture-flowcontrol/src/test/java/org/metafacture/flowcontrol/ObjectBatchResetterTest.java
+++ b/metafacture-flowcontrol/src/test/java/org/metafacture/flowcontrol/ObjectBatchResetterTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.flowcontrol;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/metafacture-flowcontrol/src/test/java/org/metafacture/flowcontrol/ObjectExceptionCatcherTest.java
+++ b/metafacture-flowcontrol/src/test/java/org/metafacture/flowcontrol/ObjectExceptionCatcherTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.flowcontrol;
 
 import static org.mockito.ArgumentMatchers.anyString;

--- a/metafacture-flowcontrol/src/test/java/org/metafacture/flowcontrol/ObjectThreaderTest.java
+++ b/metafacture-flowcontrol/src/test/java/org/metafacture/flowcontrol/ObjectThreaderTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.flowcontrol;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/metafacture-flowcontrol/src/test/java/org/metafacture/flowcontrol/StreamBufferTest.java
+++ b/metafacture-flowcontrol/src/test/java/org/metafacture/flowcontrol/StreamBufferTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.flowcontrol;
 
 import static org.mockito.Mockito.inOrder;

--- a/metafacture-flowcontrol/src/test/java/org/metafacture/flowcontrol/StreamDeferrerTest.java
+++ b/metafacture-flowcontrol/src/test/java/org/metafacture/flowcontrol/StreamDeferrerTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.flowcontrol;
 
 import static org.mockito.Mockito.inOrder;

--- a/metafacture-flux/src/main/java/org/metafacture/flux/FluxCompiler.java
+++ b/metafacture-flux/src/main/java/org/metafacture/flux/FluxCompiler.java
@@ -13,20 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.flux;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Map;
+import org.metafacture.flux.parser.FlowBuilder;
+import org.metafacture.flux.parser.FluxLexer;
+import org.metafacture.flux.parser.FluxParser;
+import org.metafacture.flux.parser.FluxProgramm;
 
 import org.antlr.runtime.ANTLRInputStream;
 import org.antlr.runtime.CommonTokenStream;
 import org.antlr.runtime.RecognitionException;
 import org.antlr.runtime.tree.CommonTreeNodeStream;
-import org.metafacture.flux.parser.FlowBuilder;
-import org.metafacture.flux.parser.FluxLexer;
-import org.metafacture.flux.parser.FluxParser;
-import org.metafacture.flux.parser.FluxProgramm;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
 
 /**
  * Creates a flow based on a flux script.
@@ -38,7 +40,7 @@ public final class FluxCompiler {
         // no instances
     }
 
-    public static FluxProgramm compile(final InputStream flux, final Map<String,String> vars ) throws RecognitionException, IOException{
+    public static FluxProgramm compile(final InputStream flux, final Map<String, String> vars) throws RecognitionException, IOException {
         return compileFlow(compileAst(flux), vars);
     }
 

--- a/metafacture-flux/src/main/java/org/metafacture/flux/FluxParseException.java
+++ b/metafacture-flux/src/main/java/org/metafacture/flux/FluxParseException.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.flux;
 
 import org.metafacture.framework.MetafactureException;

--- a/metafacture-flux/src/main/java/org/metafacture/flux/HelpPrinter.java
+++ b/metafacture-flux/src/main/java/org/metafacture/flux/HelpPrinter.java
@@ -13,7 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.flux;
+
+import org.metafacture.commons.ResourceUtil;
+import org.metafacture.commons.reflection.ObjectFactory;
+import org.metafacture.framework.MetafactureException;
+import org.metafacture.framework.annotations.Description;
+import org.metafacture.framework.annotations.In;
+import org.metafacture.framework.annotations.Out;
+import org.metafacture.framework.annotations.ReturnsAvailableArguments;
 
 import java.io.IOException;
 import java.io.PrintStream;
@@ -24,16 +33,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
-
-import org.metafacture.commons.ResourceUtil;
-import org.metafacture.commons.reflection.ObjectFactory;
-import org.metafacture.framework.MetafactureException;
-import org.metafacture.framework.annotations.Description;
-import org.metafacture.framework.annotations.In;
-import org.metafacture.framework.annotations.Out;
-import org.metafacture.framework.annotations.ReturnsAvailableArguments;
+import java.util.Map;
 
 /**
  * prints Flux help for a given {@link ObjectFactory}
@@ -58,7 +59,7 @@ public final class HelpPrinter {
         final List<String> keyWords = new ArrayList<String>();
         keyWords.addAll(factory.keySet());
         Collections.sort(keyWords);
-        for (String name : keyWords) {
+        for (final String name : keyWords) {
             describe(name, factory, out);
         }
     }
@@ -66,20 +67,18 @@ public final class HelpPrinter {
     private static String getVersionInfo() {
         try {
             return ResourceUtil.loadProperties("build.properties").toString();
-        } catch (IOException e) {
+        }
+        catch (final IOException e) {
             throw new MetafactureException("Failed to load build infos", e);
         }
     }
 
-    private static <T> void describe(String name, ObjectFactory<T> factory,
-            PrintStream out) {
+    private static <T> void describe(final String name, final ObjectFactory<T> factory, final PrintStream out) {
         final Class<? extends T> moduleClass = factory.get(name).getPlainClass();
         final Description desc = moduleClass.getAnnotation(Description.class);
 
         out.println(name);
-        name.chars().forEach(c-> {
-            out.print("-");
-        });
+        name.chars().forEach(c -> out.print("-"));
         out.println();
 
         if (desc != null) {
@@ -95,13 +94,14 @@ public final class HelpPrinter {
         if (!attributes.isEmpty()) {
             out.print("- options:\t");
             final StringBuilder builder = new StringBuilder();
-            for (Entry<String, Class<?>> entry : attributes.entrySet()) {
+            for (final Entry<String, Class<?>> entry : attributes.entrySet()) {
                 if (entry.getValue().isEnum()) {
                     builder.append(entry.getKey())
                             .append(" ")
                             .append(Arrays.asList(entry.getValue().getEnumConstants()))
                             .append(", ");
-                } else {
+                }
+                else {
                     builder.append(entry.getKey())
                             .append(" (")
                             .append(entry.getValue().getSimpleName())
@@ -128,14 +128,13 @@ public final class HelpPrinter {
     }
 
     @SuppressWarnings("unchecked")
-    private static Collection<String> getAvailableArguments(
-            Class<?> moduleClass) {
-        for (Method method : moduleClass.getMethods()) {
+    private static Collection<String> getAvailableArguments(final Class<?> moduleClass) {
+        for (final Method method : moduleClass.getMethods()) {
             if (method.getAnnotation(ReturnsAvailableArguments.class) != null) {
                 try {
                     return (Collection<String>) method.invoke(moduleClass);
-                } catch (IllegalAccessException | InvocationTargetException |
-                        IllegalArgumentException e) {
+                }
+                catch (final IllegalAccessException | InvocationTargetException | IllegalArgumentException e) {
                     // silently ignore
                 }
             }

--- a/metafacture-flux/src/main/java/org/metafacture/flux/parser/Flow.java
+++ b/metafacture-flux/src/main/java/org/metafacture/flux/parser/Flow.java
@@ -13,12 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.flux.parser;
 
-import java.util.ArrayList;
-import java.util.Deque;
-import java.util.LinkedList;
-import java.util.List;
+package org.metafacture.flux.parser;
 
 import org.metafacture.flux.FluxParseException;
 import org.metafacture.framework.LifeCycle;
@@ -28,6 +24,10 @@ import org.metafacture.framework.Sender;
 import org.metafacture.framework.Tee;
 import org.metafacture.io.StdInOpener;
 
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * @author Markus Michael Geipel
@@ -42,9 +42,12 @@ final class Flow {
     private ObjectReceiver<? extends Object> start;
     private boolean joinLooseEnds;
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+    Flow() {
+    }
+
+    @SuppressWarnings("unchecked")
     public void addElement(final Receiver nextElement) {
-        if(element==null){
+        if (element == null) {
             setStart((ObjectReceiver<? extends Object>) nextElement);
             return;
         }
@@ -55,19 +58,23 @@ final class Flow {
                 for (final LifeCycle looseEnd : looseEndsStack.pop()) {
                     if (looseEnd instanceof Tee) {
                         ((Tee) looseEnd).addReceiver(nextElement);
-                    } else {
+                    }
+                    else {
                         ((Sender) looseEnd).setReceiver(nextElement);
                     }
                 }
                 joinLooseEnds = false;
-            } else {
+            }
+            else {
                 if (sender instanceof Tee) {
                     ((Tee) sender).addReceiver(nextElement);
-                } else {
+                }
+                else {
                     sender.setReceiver(nextElement);
                 }
             }
-        } else {
+        }
+        else {
             throw new FluxParseException(element.getClass().getCanonicalName() + "is not a sender");
         }
         element = nextElement;
@@ -78,7 +85,8 @@ final class Flow {
             final Tee<?> tee = (Tee<?>) element;
             teeStack.push(tee);
             looseEndsStack.push(new ArrayList<LifeCycle>());
-        } else {
+        }
+        else {
             throw new FluxParseException("Flow cannot be split without a tee-element.");
         }
     }
@@ -93,7 +101,7 @@ final class Flow {
         element = teeStack.peek();
     }
 
-    private void setStart(final ObjectReceiver<? extends Object> start){
+    private void setStart(final ObjectReceiver<? extends Object> start) {
         this.start = start;
         element = start;
     }

--- a/metafacture-flux/src/main/java/org/metafacture/flux/parser/FluxProgramm.java
+++ b/metafacture-flux/src/main/java/org/metafacture/flux/parser/FluxProgramm.java
@@ -13,7 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.flux.parser;
+
+import org.metafacture.commons.ResourceUtil;
+import org.metafacture.commons.reflection.ConfigurableClass;
+import org.metafacture.commons.reflection.ObjectFactory;
+import org.metafacture.commons.reflection.ReflectionUtil;
+import org.metafacture.flux.FluxParseException;
+import org.metafacture.flux.HelpPrinter;
+import org.metafacture.framework.Receiver;
 
 import java.io.IOException;
 import java.io.PrintStream;
@@ -26,14 +35,6 @@ import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import org.metafacture.commons.ResourceUtil;
-import org.metafacture.commons.reflection.ConfigurableClass;
-import org.metafacture.commons.reflection.ObjectFactory;
-import org.metafacture.commons.reflection.ReflectionUtil;
-import org.metafacture.flux.FluxParseException;
-import org.metafacture.flux.HelpPrinter;
-import org.metafacture.framework.Receiver;
 
 /**
  * @author Markus Michael Geipel
@@ -52,7 +53,8 @@ public final class FluxProgramm {
                 final URL url = enumeration.nextElement();
                 COMMAND_FACTORY.loadClassesFromMap(ResourceUtil.loadProperties(url), Receiver.class);
             }
-        } catch (final IOException e) {
+        }
+        catch (final IOException e) {
             throw new FluxParseException("unable to load properties.", e);
         }
     }
@@ -62,6 +64,9 @@ public final class FluxProgramm {
     private final Map<String, Wormhole> wormholeNameMapping = new HashMap<String, Wormhole>();
     private final Map<Flow, Wormhole> wormholeInFlowMapping = new Hashtable<Flow, Wormhole>();
 
+    public FluxProgramm() {
+    }
+
     private static Receiver createElement(final String name, final Map<String, String> namedArgs,
             final List<Object> cArgs) {
 
@@ -69,7 +74,8 @@ public final class FluxProgramm {
         if (COMMAND_FACTORY.containsKey(name)) {
             newElement = COMMAND_FACTORY.newInstance(name, namedArgs, cArgs.toArray());
 
-        } else {
+        }
+        else {
             final ConfigurableClass<? extends Receiver> elementClass =
                     ReflectionUtil.loadClass(name, Receiver.class);
             newElement = elementClass.newInstance(namedArgs, cArgs.toArray());
@@ -156,7 +162,8 @@ public final class FluxProgramm {
             flow.start();
             if (!wormholeInFlowMapping.containsKey(flow)) {
                 flow.close();
-            } else {
+            }
+            else {
                 wormholeInFlowMapping.get(flow).finished(flow);
             }
         }
@@ -172,7 +179,7 @@ public final class FluxProgramm {
         private Flow out;
         private final String name;
 
-        public Wormhole(final String name) {
+        Wormhole(final String name) {
             this.name = name;
         }
 

--- a/metafacture-flux/src/main/java/org/metafacture/flux/parser/StringSender.java
+++ b/metafacture-flux/src/main/java/org/metafacture/flux/parser/StringSender.java
@@ -13,18 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.flux.parser;
 
 import org.metafacture.framework.ObjectReceiver;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
-
 
 /**
  * Helper class to start a pipe with a {@link String}
  *
  * @author Markus Michael Geipel
  */
-public final class StringSender extends DefaultObjectPipe<Object, ObjectReceiver<String>>{
+public final class StringSender extends DefaultObjectPipe<Object, ObjectReceiver<String>> {
 
     private final String string;
 
@@ -34,9 +34,10 @@ public final class StringSender extends DefaultObjectPipe<Object, ObjectReceiver
 
     @Override
     public void process(final Object notUsed) {
-        if(notUsed==null){
-        getReceiver().process(string);
-        }else{
+        if (notUsed == null) {
+            getReceiver().process(string);
+        }
+        else {
             throw new IllegalArgumentException("Parameter not used. Must be null");
         }
     }

--- a/metafacture-flux/src/test/java/org/metafacture/flux/FluxGrammarTest.java
+++ b/metafacture-flux/src/test/java/org/metafacture/flux/FluxGrammarTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.flux;
 
 import static java.util.Collections.emptyMap;

--- a/metafacture-flux/src/test/java/org/metafacture/flux/FluxProgrammTest.java
+++ b/metafacture-flux/src/test/java/org/metafacture/flux/FluxProgrammTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.flux;
 
 import java.io.IOException;

--- a/metafacture-formatting/src/main/java/org/metafacture/formatting/ObjectTemplate.java
+++ b/metafacture-formatting/src/main/java/org/metafacture/formatting/ObjectTemplate.java
@@ -13,12 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.formatting;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+package org.metafacture.formatting;
 
 import org.metafacture.commons.StringUtil;
 import org.metafacture.framework.FluxCommand;
@@ -29,6 +25,10 @@ import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
 import org.metafacture.framework.objects.Triple;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Builds a {@link String} from a template and an {@link Object}. ${o} marks
@@ -54,19 +54,19 @@ public final class ObjectTemplate<T> extends DefaultObjectPipe<T, ObjectReceiver
     private final String template;
 
     public ObjectTemplate(final String template) {
-        super();
         this.template = template;
     }
 
     @Override
     public void process(final T obj) {
-        if(obj instanceof Triple){
-            final Triple triple = (Triple)obj;
+        if (obj instanceof Triple) {
+            final Triple triple = (Triple) obj;
             vars.put("s", triple.getSubject());
             vars.put("p", triple.getPredicate());
             vars.put("o", triple.getObject());
             getReceiver().process(StringUtil.format(template, vars));
-        }else{
+        }
+        else {
             final Matcher matcher = OBJ_PATTERN.matcher(template);
             getReceiver().process(matcher.replaceAll(obj.toString()));
         }

--- a/metafacture-formatting/src/main/java/org/metafacture/formatting/PreambleEpilogueAdder.java
+++ b/metafacture-formatting/src/main/java/org/metafacture/formatting/PreambleEpilogueAdder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.formatting;
 
 import org.metafacture.framework.FluxCommand;
@@ -21,7 +22,6 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
-
 
 /**
  * Emits a <i>preamble</i> string before the first string object in the
@@ -44,7 +44,10 @@ public final class PreambleEpilogueAdder extends DefaultObjectPipe<String, Objec
     private String preamble = "";
     private String epilogue = "";
 
-    private boolean objectsReceived = false;
+    private boolean objectsReceived;
+
+    public PreambleEpilogueAdder() {
+    }
 
     /**
      * Sets the <i>preamble</i> string which is emitted before the first object.
@@ -86,7 +89,7 @@ public final class PreambleEpilogueAdder extends DefaultObjectPipe<String, Objec
 
     @Override
     public void process(final String obj) {
-        if(!objectsReceived && !preamble.isEmpty()) {
+        if (!objectsReceived && !preamble.isEmpty()) {
             getReceiver().process(preamble);
         }
         objectsReceived = true;
@@ -95,7 +98,7 @@ public final class PreambleEpilogueAdder extends DefaultObjectPipe<String, Objec
 
     @Override
     protected void onCloseStream() {
-        if(objectsReceived && !epilogue.isEmpty()) {
+        if (objectsReceived && !epilogue.isEmpty()) {
             getReceiver().process(epilogue);
         }
     }

--- a/metafacture-formatting/src/main/java/org/metafacture/formatting/StreamLiteralFormatter.java
+++ b/metafacture-formatting/src/main/java/org/metafacture/formatting/StreamLiteralFormatter.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.formatting;
 
 import org.metafacture.framework.FluxCommand;
@@ -45,8 +46,7 @@ import org.metafacture.framework.helpers.DefaultStreamPipe;
 @In(StreamReceiver.class)
 @Out(String.class)
 @FluxCommand("encode-literals")
-public final class StreamLiteralFormatter
-        extends DefaultStreamPipe<ObjectReceiver<String>> {
+public final class StreamLiteralFormatter extends DefaultStreamPipe<ObjectReceiver<String>> {
 
     /**
      * The default value for {@link #setSeparator(String)}.
@@ -54,6 +54,9 @@ public final class StreamLiteralFormatter
     public static final String DEFAULT_SEPARATOR = "\t";
 
     private String separator = DEFAULT_SEPARATOR;
+
+    public StreamLiteralFormatter() {
+    }
 
     /**
      * Sets the separator between the literal name and value. The separator is
@@ -78,7 +81,8 @@ public final class StreamLiteralFormatter
     public void literal(final String name, final String value) {
         if (name == null || name.isEmpty()) {
             getReceiver().process(value);
-        } else {
+        }
+        else {
             getReceiver().process(name + separator + value);
         }
     }

--- a/metafacture-formeta/src/main/java/org/metafacture/formeta/Formeta.java
+++ b/metafacture-formeta/src/main/java/org/metafacture/formeta/Formeta.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.formeta;
 
 /**

--- a/metafacture-formeta/src/main/java/org/metafacture/formeta/FormetaDecoder.java
+++ b/metafacture-formeta/src/main/java/org/metafacture/formeta/FormetaDecoder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.formeta;
 
 import org.metafacture.formeta.parser.Emitter;

--- a/metafacture-formeta/src/main/java/org/metafacture/formeta/FormetaEncoder.java
+++ b/metafacture-formeta/src/main/java/org/metafacture/formeta/FormetaEncoder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.formeta;
 
 import org.metafacture.formeta.formatter.Formatter;
@@ -35,11 +36,13 @@ import org.metafacture.framework.helpers.DefaultStreamPipe;
 @In(StreamReceiver.class)
 @Out(String.class)
 @FluxCommand("encode-formeta")
-public final class FormetaEncoder extends
-        DefaultStreamPipe<ObjectReceiver<String>> {
+public final class FormetaEncoder extends DefaultStreamPipe<ObjectReceiver<String>> {
 
     private FormatterStyle style = FormatterStyle.CONCISE;
     private Formatter formatter = style.createFormatter();
+
+    public FormetaEncoder() {
+    }
 
     public FormatterStyle getStyle() {
         return style;
@@ -49,7 +52,6 @@ public final class FormetaEncoder extends
         this.style = formatterStyle;
         formatter = formatterStyle.createFormatter();
     }
-
 
     @Override
     public void startRecord(final String identifier) {

--- a/metafacture-formeta/src/main/java/org/metafacture/formeta/FormetaRecordsReader.java
+++ b/metafacture-formeta/src/main/java/org/metafacture/formeta/FormetaRecordsReader.java
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.formeta;
 
-import java.io.IOException;
-import java.io.Reader;
+package org.metafacture.formeta;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.MetafactureException;
@@ -25,6 +23,9 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
+
+import java.io.IOException;
+import java.io.Reader;
 
 /**
  * Reads a stream of formeta data and splits between each top-level element.
@@ -36,15 +37,17 @@ import org.metafacture.framework.helpers.DefaultObjectPipe;
 @Out(String.class)
 @Description("Reads a stream of formeta data and splits between each top-level element")
 @FluxCommand("as-formeta-records")
-public final class FormetaRecordsReader extends
-        DefaultObjectPipe<Reader, ObjectReceiver<String>> {
+public final class FormetaRecordsReader extends DefaultObjectPipe<Reader, ObjectReceiver<String>> {
 
     private static final int BUFFER_SIZE = 1024 * 1024 * 16;
 
     private final StringBuilder builder = new StringBuilder();
     private final char[] buffer = new char[BUFFER_SIZE];
 
-    @Override
+    public FormetaRecordsReader() {
+    }
+
+    @Override // checkstyle-disable-line CyclomaticComplexity
     public void process(final Reader reader) {
         assert !isClosed();
 
@@ -58,29 +61,32 @@ public final class FormetaRecordsReader extends
                 int offset = 0;
                 for (int i = 0; i < size; ++i) {
                     switch (buffer[i]) {
-                    case Formeta.ESCAPE_CHAR:
-                        i += 1; // Skip next character
-                        break;
-                    case Formeta.GROUP_START:
-                        if (!inQuotedText) {
-                            groupLevel += 1;
-                        }
-                        break;
-                    case Formeta.GROUP_END:
-                        if (!inQuotedText) {
-                            groupLevel -= 1;
-                        }
-                        // Fall through
-                    case Formeta.ITEM_SEPARATOR:
-                        if (!inQuotedText && groupLevel == 0) {
-                            builder.append(buffer, offset, i - offset + 1);
-                            offset = i + 1;
-                            emitRecord();
-                        }
-                        break;
-                    case Formeta.QUOT_CHAR:
-                        inQuotedText = !inQuotedText;
-                        break;
+                        case Formeta.ESCAPE_CHAR:
+                            // Skip next character
+                            i += 1; // checkstyle-disable-line ModifiedControlVariable
+                            break;
+                        case Formeta.GROUP_START:
+                            if (!inQuotedText) {
+                                groupLevel += 1;
+                            }
+                            break;
+                        case Formeta.GROUP_END:
+                            if (!inQuotedText) {
+                                groupLevel -= 1;
+                            }
+                            // fall through
+                        case Formeta.ITEM_SEPARATOR:
+                            if (!inQuotedText && groupLevel == 0) {
+                                builder.append(buffer, offset, i - offset + 1);
+                                offset = i + 1;
+                                emitRecord();
+                            }
+                            break;
+                        case Formeta.QUOT_CHAR:
+                            inQuotedText = !inQuotedText;
+                            break;
+                        default:
+                            // ignore
                     }
                 }
                 builder.append(buffer, offset, size - offset);
@@ -89,7 +95,8 @@ public final class FormetaRecordsReader extends
                 emitRecord();
             }
 
-        } catch (final IOException e) {
+        }
+        catch (final IOException e) {
             throw new MetafactureException(e);
         }
     }

--- a/metafacture-formeta/src/main/java/org/metafacture/formeta/formatter/AbstractFormatter.java
+++ b/metafacture-formeta/src/main/java/org/metafacture/formeta/formatter/AbstractFormatter.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.formeta.formatter;
 
 import org.metafacture.commons.StringUtil;
@@ -26,15 +27,15 @@ import org.metafacture.formeta.Formeta;
  */
 public abstract class AbstractFormatter implements Formatter {
 
-    public static final String CHARS_TO_ESCAPE_QUOTED = "\n\r"
-            + Formeta.QUOT_CHAR
-            + Formeta.ESCAPE_CHAR;
+    public static final String CHARS_TO_ESCAPE_QUOTED = "\n\r" +
+            Formeta.QUOT_CHAR +
+            Formeta.ESCAPE_CHAR;
 
-    public static final String CHARS_TO_ESCAPE = CHARS_TO_ESCAPE_QUOTED
-            + Formeta.GROUP_START
-            + Formeta.GROUP_END
-            + Formeta.ITEM_SEPARATOR
-            + Formeta.NAME_VALUE_SEPARATOR;
+    public static final String CHARS_TO_ESCAPE = CHARS_TO_ESCAPE_QUOTED +
+            Formeta.GROUP_START +
+            Formeta.GROUP_END +
+            Formeta.ITEM_SEPARATOR +
+            Formeta.NAME_VALUE_SEPARATOR;
 
     protected static final int BUFFER_SIZE = 1024;
 
@@ -73,16 +74,17 @@ public abstract class AbstractFormatter implements Formatter {
                 escapeAndAppendChar(buffer[i], CHARS_TO_ESCAPE_QUOTED);
             }
             builder.append(Formeta.QUOT_CHAR);
-        } else {
+        }
+        else {
             if (bufferLen > 0) {
                 escapeAndAppendChar(buffer[0],
                         CHARS_TO_ESCAPE + Formeta.WHITESPACE);
             }
-            for (int i = 1; i < bufferLen-1; ++i) {
+            for (int i = 1; i < bufferLen - 1; ++i) {
                 escapeAndAppendChar(buffer[i], CHARS_TO_ESCAPE);
             }
             if (bufferLen > 1) {
-                escapeAndAppendChar(buffer[bufferLen-1],
+                escapeAndAppendChar(buffer[bufferLen - 1],
                         CHARS_TO_ESCAPE + Formeta.WHITESPACE);
             }
         }
@@ -92,12 +94,13 @@ public abstract class AbstractFormatter implements Formatter {
         // Default implementation does nothing
     }
 
-    protected abstract boolean shouldQuoteText(final char[] buffer, final int len);
+    protected abstract boolean shouldQuoteText(char[] currentBuffer, int len);
 
     private void escapeAndAppendChar(final char ch, final String charsToEscape) {
         if (charsToEscape.indexOf(ch) > -1) {
             appendEscapedChar(ch);
-        } else {
+        }
+        else {
             builder.append(ch);
         }
     }
@@ -105,14 +108,14 @@ public abstract class AbstractFormatter implements Formatter {
     private void appendEscapedChar(final char ch) {
         builder.append(Formeta.ESCAPE_CHAR);
         switch (ch) {
-        case '\n':
-            builder.append(Formeta.NEWLINE_ESC_SEQ);
-            break;
-        case '\r':
-            builder.append(Formeta.CARRIAGE_RETURN_ESC_SEQ);
-            break;
-        default:
-            builder.append(ch);
+            case '\n':
+                builder.append(Formeta.NEWLINE_ESC_SEQ);
+                break;
+            case '\r':
+                builder.append(Formeta.CARRIAGE_RETURN_ESC_SEQ);
+                break;
+            default:
+                builder.append(ch);
         }
     }
 

--- a/metafacture-formeta/src/main/java/org/metafacture/formeta/formatter/ConciseFormatter.java
+++ b/metafacture-formeta/src/main/java/org/metafacture/formeta/formatter/ConciseFormatter.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.formeta.formatter;
 
 import org.metafacture.formeta.Formeta;
@@ -26,6 +27,9 @@ import org.metafacture.formeta.Formeta;
 public final class ConciseFormatter extends AbstractFormatter {
 
     private boolean appendItemSeparator;
+
+    public ConciseFormatter() {
+    }
 
     @Override
     public void startGroup(final String name) {

--- a/metafacture-formeta/src/main/java/org/metafacture/formeta/formatter/Formatter.java
+++ b/metafacture-formeta/src/main/java/org/metafacture/formeta/formatter/Formatter.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.formeta.formatter;
 
 /**
@@ -25,10 +26,10 @@ public interface Formatter {
 
     void reset();
 
-    void startGroup(final String name);
+    void startGroup(String name);
 
     void endGroup();
 
-    void literal(final String name, final String value);
+    void literal(String name, String value);
 
 }

--- a/metafacture-formeta/src/main/java/org/metafacture/formeta/formatter/FormatterStyle.java
+++ b/metafacture-formeta/src/main/java/org/metafacture/formeta/formatter/FormatterStyle.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.formeta.formatter;
 
 /**

--- a/metafacture-formeta/src/main/java/org/metafacture/formeta/formatter/MultilineFormatter.java
+++ b/metafacture-formeta/src/main/java/org/metafacture/formeta/formatter/MultilineFormatter.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.formeta.formatter;
 
 import org.metafacture.formeta.Formeta;
@@ -36,7 +37,6 @@ public final class MultilineFormatter extends AbstractFormatter {
     private boolean firstItem;
 
     public MultilineFormatter() {
-        super();
         onReset();
     }
 

--- a/metafacture-formeta/src/main/java/org/metafacture/formeta/formatter/VerboseFormatter.java
+++ b/metafacture-formeta/src/main/java/org/metafacture/formeta/formatter/VerboseFormatter.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.formeta.formatter;
 
 import org.metafacture.formeta.Formeta;
@@ -31,6 +32,9 @@ public final class VerboseFormatter extends AbstractFormatter {
     private static final String NAME_VALUE_SEPARATOR = Formeta.NAME_VALUE_SEPARATOR + " ";
 
     private boolean appendItemSeparator;
+
+    public VerboseFormatter() {
+    }
 
     @Override
     public void startGroup(final String name) {

--- a/metafacture-formeta/src/main/java/org/metafacture/formeta/parser/Emitter.java
+++ b/metafacture-formeta/src/main/java/org/metafacture/formeta/parser/Emitter.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.formeta.parser;
 
 import org.metafacture.framework.StreamReceiver;
@@ -25,12 +26,12 @@ import org.metafacture.framework.StreamReceiver;
  */
 public interface Emitter {
 
-    void setReceiver(final StreamReceiver receiver);
+    void setReceiver(StreamReceiver receiver);
 
-    void startGroup(final String name, final int nestingLevel);
+    void startGroup(String name, int nestingLevel);
 
-    void endGroup(final int nestingLevel);
+    void endGroup(int nestingLevel);
 
-    void literal(final String name, final String value, final int nestingLevel);
+    void literal(String name, String value, int nestingLevel);
 
 }

--- a/metafacture-formeta/src/main/java/org/metafacture/formeta/parser/FormetaParser.java
+++ b/metafacture-formeta/src/main/java/org/metafacture/formeta/parser/FormetaParser.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.formeta.parser;
 
 import org.metafacture.commons.StringUtil;
@@ -36,6 +37,9 @@ public final class FormetaParser {
     private char[] buffer = new char[BUFFER_SIZE];
     private final StructureParserContext structureParserContext = new StructureParserContext();
 
+    public FormetaParser() {
+    }
+
     public void setEmitter(final Emitter emitter) {
         structureParserContext.setEmitter(emitter);
     }
@@ -45,7 +49,7 @@ public final class FormetaParser {
     }
 
     public void parse(final String data) {
-        assert structureParserContext.getEmitter() != null: "No emitter set";
+        assert structureParserContext.getEmitter() != null : "No emitter set";
 
         // According to http://stackoverflow.com/a/11876086 it is faster to copy
         // a string into a char array then to use charAt():
@@ -59,16 +63,16 @@ public final class FormetaParser {
             for (; i < bufferLen; ++i) {
                 state = state.processChar(buffer[i], structureParserContext);
             }
-        } catch (final FormatException e) {
-            final String errorMsg = "Parsing error at position "
-                    + (i + 1) + ": "
-                    + getErrorSnippet(data, i) + ", "
-                    + e.getMessage();
+        }
+        catch (final FormatException e) {
+            final String errorMsg = "Parsing error at position " +
+                (i + 1) + ": " + getErrorSnippet(data, i) + ", " + e.getMessage();
             throw new FormatException(errorMsg, e);
         }
         try {
             state.endOfInput(structureParserContext);
-        } catch (final FormatException e) {
+        }
+        catch (final FormatException e) {
             throw new FormatException("Parsing error: " + e.getMessage(), e);
         }
     }
@@ -88,7 +92,8 @@ public final class FormetaParser {
         final int start = pos - SNIPPET_SIZE / 2;
         if (start < 0) {
             snippet.append(record.substring(0, pos));
-        } else {
+        }
+        else {
             snippet.append(SNIPPET_ELLIPSIS);
             snippet.append(record.substring(start, pos));
         }
@@ -101,7 +106,8 @@ public final class FormetaParser {
             final int end = pos + SNIPPET_SIZE / 2;
             if (end > record.length()) {
                 snippet.append(record.substring(pos + 1));
-            } else {
+            }
+            else {
                 snippet.append(record.substring(pos + 1, end));
                 snippet.append(SNIPPET_ELLIPSIS);
             }

--- a/metafacture-formeta/src/main/java/org/metafacture/formeta/parser/FullRecordEmitter.java
+++ b/metafacture-formeta/src/main/java/org/metafacture/formeta/parser/FullRecordEmitter.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.formeta.parser;
 
 import org.metafacture.framework.FormatException;
@@ -28,6 +29,9 @@ public final class FullRecordEmitter implements Emitter {
 
     private StreamReceiver receiver;
 
+    public FullRecordEmitter() {
+    }
+
     @Override
     public void setReceiver(final StreamReceiver receiver) {
         this.receiver = receiver;
@@ -37,7 +41,8 @@ public final class FullRecordEmitter implements Emitter {
     public void startGroup(final String name, final int nestingLevel) {
         if (nestingLevel == 0) {
             receiver.startRecord(name);
-        } else {
+        }
+        else {
             receiver.startEntity(name);
         }
     }
@@ -46,7 +51,8 @@ public final class FullRecordEmitter implements Emitter {
     public void endGroup(final int nestingLevel) {
         if (nestingLevel == 0) {
             receiver.endRecord();
-        } else {
+        }
+        else {
             receiver.endEntity();
         }
     }

--- a/metafacture-formeta/src/main/java/org/metafacture/formeta/parser/PartialRecordEmitter.java
+++ b/metafacture-formeta/src/main/java/org/metafacture/formeta/parser/PartialRecordEmitter.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.formeta.parser;
 
 import org.metafacture.framework.StreamReceiver;
@@ -25,7 +26,8 @@ public final class PartialRecordEmitter implements Emitter {
     private StreamReceiver receiver;
     private String defaultName;
 
-
+    public PartialRecordEmitter() {
+    }
 
     public void setDefaultName(final String defaultName) {
         this.defaultName = defaultName;
@@ -44,7 +46,8 @@ public final class PartialRecordEmitter implements Emitter {
     public void startGroup(final String name, final int nestingLevel) {
         if (nestingLevel == 0 && defaultName != null && name.isEmpty()) {
             receiver.startEntity(defaultName);
-        } else {
+        }
+        else {
             receiver.startEntity(name);
         }
     }
@@ -58,7 +61,8 @@ public final class PartialRecordEmitter implements Emitter {
     public void literal(final String name, final String value, final int nestingLevel) {
         if (nestingLevel == 0 && defaultName != null && name.isEmpty()) {
             receiver.literal(defaultName, value);
-        } else {
+        }
+        else {
             receiver.literal(name, value);
         }
     }

--- a/metafacture-formeta/src/main/java/org/metafacture/formeta/parser/StructureParserContext.java
+++ b/metafacture-formeta/src/main/java/org/metafacture/formeta/parser/StructureParserContext.java
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.formeta.parser;
 
+package org.metafacture.formeta.parser;
 
 /**
  * Context of the record parser. It manages the text parser and the generation of
@@ -30,6 +30,9 @@ class StructureParserContext {
 
     private String literalName;
     private int nestingLevel;
+
+    StructureParserContext() {
+    }
 
     public void setEmitter(final Emitter emitter) {
         this.emitter = emitter;

--- a/metafacture-formeta/src/main/java/org/metafacture/formeta/parser/StructureParserState.java
+++ b/metafacture-formeta/src/main/java/org/metafacture/formeta/parser/StructureParserState.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.formeta.parser;
 
 import org.metafacture.formeta.Formeta;
@@ -30,29 +31,29 @@ enum StructureParserState {
         protected StructureParserState delimiterReached(final char ch, final StructureParserContext ctx) {
             final StructureParserState newState;
             switch (ch) {
-            case Formeta.GROUP_START:
-                ctx.startGroup();
-                newState = ITEM_NAME;
-                break;
-            case Formeta.NAME_VALUE_SEPARATOR:
-                ctx.startLiteral();
-                newState =  LITERAL_VALUE;
-                break;
-            case Formeta.ITEM_SEPARATOR:
-                if (!ctx.isTextEmpty()) {
+                case Formeta.GROUP_START:
+                    ctx.startGroup();
+                    newState = ITEM_NAME;
+                    break;
+                case Formeta.NAME_VALUE_SEPARATOR:
+                    ctx.startLiteral();
+                    newState =  LITERAL_VALUE;
+                    break;
+                case Formeta.ITEM_SEPARATOR:
+                    if (!ctx.isTextEmpty()) {
+                        throw new FormatException(getUnexpectedCharMsg(NAME_DELIMITER_EXPECTED, ch));
+                    }
+                    newState = ITEM_NAME;
+                    break;
+                case Formeta.GROUP_END:
+                    if (!ctx.isTextEmpty() || !ctx.isNested()) {
+                        throw new FormatException(getUnexpectedCharMsg(NAME_DELIMITER_EXPECTED, ch));
+                    }
+                    ctx.endGroup();
+                    newState = ITEM_NAME;
+                    break;
+                default:
                     throw new FormatException(getUnexpectedCharMsg(NAME_DELIMITER_EXPECTED, ch));
-                }
-                newState = ITEM_NAME;
-                break;
-            case Formeta.GROUP_END:
-                if (!ctx.isTextEmpty() || !ctx.isNested()) {
-                    throw new FormatException(getUnexpectedCharMsg(NAME_DELIMITER_EXPECTED, ch));
-                }
-                ctx.endGroup();
-                newState = ITEM_NAME;
-                break;
-            default:
-                throw new FormatException(getUnexpectedCharMsg(NAME_DELIMITER_EXPECTED, ch));
             }
             return newState;
         }
@@ -68,20 +69,20 @@ enum StructureParserState {
         protected StructureParserState delimiterReached(final char ch, final StructureParserContext ctx) {
             final StructureParserState newState;
             switch (ch) {
-            case Formeta.ITEM_SEPARATOR:
-                ctx.endLiteral();
-                newState = ITEM_NAME;
-                break;
-            case Formeta.GROUP_END:
-                if (!ctx.isNested()) {
-                    throw new FormatException(getUnexpectedCharMsg(ITEM_SEPARATOR_EXPECTED, ch));
-                }
-                ctx.endLiteral();
-                ctx.endGroup();
-                newState = ITEM_NAME;
-                break;
-            default:
-                throw new FormatException(getUnexpectedCharMsg(VALUE_DELIMITER_EXPECTED, ch));
+                case Formeta.ITEM_SEPARATOR:
+                    ctx.endLiteral();
+                    newState = ITEM_NAME;
+                    break;
+                case Formeta.GROUP_END:
+                    if (!ctx.isNested()) {
+                        throw new FormatException(getUnexpectedCharMsg(ITEM_SEPARATOR_EXPECTED, ch));
+                    }
+                    ctx.endLiteral();
+                    ctx.endGroup();
+                    newState = ITEM_NAME;
+                    break;
+                default:
+                    throw new FormatException(getUnexpectedCharMsg(VALUE_DELIMITER_EXPECTED, ch));
             }
             return newState;
         }
@@ -107,9 +108,9 @@ enum StructureParserState {
         return this;
     }
 
-    public abstract void endOfInput(final StructureParserContext ctx);
+    public abstract void endOfInput(StructureParserContext ctx);
 
-    protected abstract StructureParserState delimiterReached(final char ch, final StructureParserContext ctx);
+    protected abstract StructureParserState delimiterReached(char ch, StructureParserContext ctx);
 
     private static String getUnexpectedCharMsg(final String expected, final char actual) {
         return expected + " expected but got '" + actual + "'";

--- a/metafacture-formeta/src/main/java/org/metafacture/formeta/parser/TextParserContext.java
+++ b/metafacture-formeta/src/main/java/org/metafacture/formeta/parser/TextParserContext.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.formeta.parser;
 
 import org.metafacture.formeta.Formeta;
@@ -25,18 +26,21 @@ import org.metafacture.framework.FormatException;
  */
 class TextParserContext {
 
-    private static final String ESCAPABLE_CHARS = Formeta.WHITESPACE
-            + Formeta.QUOT_CHAR
-            + Formeta.ESCAPE_CHAR
-            + Formeta.GROUP_START
-            + Formeta.GROUP_END
-            + Formeta.ITEM_SEPARATOR
-            + Formeta.NAME_VALUE_SEPARATOR;
+    private static final String ESCAPABLE_CHARS = Formeta.WHITESPACE +
+        Formeta.QUOT_CHAR +
+        Formeta.ESCAPE_CHAR +
+        Formeta.GROUP_START +
+        Formeta.GROUP_END +
+        Formeta.ITEM_SEPARATOR +
+        Formeta.NAME_VALUE_SEPARATOR;
 
     private final StringBuilder text = new StringBuilder();
 
     private int lengthWithoutTrailingWs;
     private boolean quoted;
+
+    TextParserContext() {
+    }
 
     public String getText() {
         return text.substring(0, lengthWithoutTrailingWs);
@@ -56,11 +60,14 @@ class TextParserContext {
     public void appendEscapedChar(final char ch) {
         if (Formeta.NEWLINE_ESC_SEQ == ch) {
             text.append('\n');
-        } else if (Formeta.CARRIAGE_RETURN_ESC_SEQ == ch) {
+        }
+        else if (Formeta.CARRIAGE_RETURN_ESC_SEQ == ch) {
             text.append('\r');
-        } else if (ESCAPABLE_CHARS.indexOf(ch) > -1) {
+        }
+        else if (ESCAPABLE_CHARS.indexOf(ch) > -1) {
             text.append(ch);
-        } else {
+        }
+        else {
             throw new FormatException("invalid escape sequence: " + ch);
         }
         lengthWithoutTrailingWs = text.length();

--- a/metafacture-formeta/src/main/java/org/metafacture/formeta/parser/TextParserState.java
+++ b/metafacture-formeta/src/main/java/org/metafacture/formeta/parser/TextParserState.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.formeta.parser;
 
 import org.metafacture.formeta.Formeta;
@@ -28,30 +29,31 @@ enum TextParserState {
     LEADING_WHITESPACE {
         public TextParserState processChar(final char ch, final TextParserContext ctx) {
             final TextParserState newState;
-            switch(ch) {
-            case Formeta.ESCAPE_CHAR:
-                ctx.setQuoted(false);
-                newState = ESCAPE_SEQ;
-                break;
-            case Formeta.QUOT_CHAR:
-                ctx.setQuoted(true);
-                newState = QUOTED_TEXT;
-                break;
-            case Formeta.GROUP_START:
-            case Formeta.GROUP_END:
-            case Formeta.ITEM_SEPARATOR:
-            case Formeta.NAME_VALUE_SEPARATOR:
-                ctx.setQuoted(false);
-                newState = DELIMITER_REACHED;
-                break;
-            default:
-                if (Formeta.isWhitespace(ch)) {
-                    newState = LEADING_WHITESPACE;
-                } else {
+            switch (ch) {
+                case Formeta.ESCAPE_CHAR:
                     ctx.setQuoted(false);
-                    ctx.appendChar(ch);
-                    newState = TEXT;
-                }
+                    newState = ESCAPE_SEQ;
+                    break;
+                case Formeta.QUOT_CHAR:
+                    ctx.setQuoted(true);
+                    newState = QUOTED_TEXT;
+                    break;
+                case Formeta.GROUP_START:
+                case Formeta.GROUP_END:
+                case Formeta.ITEM_SEPARATOR:
+                case Formeta.NAME_VALUE_SEPARATOR:
+                    ctx.setQuoted(false);
+                    newState = DELIMITER_REACHED;
+                    break;
+                default:
+                    if (Formeta.isWhitespace(ch)) {
+                        newState = LEADING_WHITESPACE;
+                    }
+                    else {
+                        ctx.setQuoted(false);
+                        ctx.appendChar(ch);
+                        newState = TEXT;
+                    }
             }
             return newState;
         }
@@ -59,19 +61,19 @@ enum TextParserState {
     TEXT {
         public TextParserState processChar(final char ch, final TextParserContext ctx) {
             final TextParserState newState;
-            switch(ch) {
-            case Formeta.ESCAPE_CHAR:
-                newState = ESCAPE_SEQ;
-                break;
-            case Formeta.GROUP_START:
-            case Formeta.GROUP_END:
-            case Formeta.ITEM_SEPARATOR:
-            case Formeta.NAME_VALUE_SEPARATOR:
-                newState = DELIMITER_REACHED;
-                break;
-            default:
-                ctx.appendChar(ch);
-                newState = TEXT;
+            switch (ch) {
+                case Formeta.ESCAPE_CHAR:
+                    newState = ESCAPE_SEQ;
+                    break;
+                case Formeta.GROUP_START:
+                case Formeta.GROUP_END:
+                case Formeta.ITEM_SEPARATOR:
+                case Formeta.NAME_VALUE_SEPARATOR:
+                    newState = DELIMITER_REACHED;
+                    break;
+                default:
+                    ctx.appendChar(ch);
+                    newState = TEXT;
             }
             return newState;
         }
@@ -89,16 +91,16 @@ enum TextParserState {
     QUOTED_TEXT {
         public TextParserState processChar(final char ch, final TextParserContext ctx) {
             final TextParserState newState;
-            switch(ch) {
-            case Formeta.ESCAPE_CHAR:
-                newState = QUOTED_ESCAPE_SEQ;
-                break;
-            case Formeta.QUOT_CHAR:
-                newState = TRAILING_WHITESPACE;
-                break;
-            default:
-                ctx.appendChar(ch);
-                newState = QUOTED_TEXT;
+            switch (ch) {
+                case Formeta.ESCAPE_CHAR:
+                    newState = QUOTED_ESCAPE_SEQ;
+                    break;
+                case Formeta.QUOT_CHAR:
+                    newState = TRAILING_WHITESPACE;
+                    break;
+                default:
+                    ctx.appendChar(ch);
+                    newState = QUOTED_TEXT;
             }
             return newState;
         }
@@ -120,25 +122,26 @@ enum TextParserState {
     TRAILING_WHITESPACE {
         public TextParserState processChar(final char ch, final TextParserContext ctx) {
             final TextParserState newState;
-            switch(ch) {
-            case Formeta.GROUP_START:
-            case Formeta.GROUP_END:
-            case Formeta.ITEM_SEPARATOR:
-            case Formeta.NAME_VALUE_SEPARATOR:
-                newState = DELIMITER_REACHED;
-                break;
-            default:
-                if (Formeta.isWhitespace(ch)) {
-                    newState = TRAILING_WHITESPACE;
-                } else {
-                    final String sep = "', '";
-                    final String expected = "whitespace or one of '"
-                            + Formeta.GROUP_START + sep
-                            + Formeta.GROUP_END + sep
-                            + Formeta.ITEM_SEPARATOR + sep
-                            + Formeta.NAME_VALUE_SEPARATOR + "'";
-                    throw new FormatException(getUnexpectedCharMsg(expected, ch));
-                }
+            switch (ch) {
+                case Formeta.GROUP_START:
+                case Formeta.GROUP_END:
+                case Formeta.ITEM_SEPARATOR:
+                case Formeta.NAME_VALUE_SEPARATOR:
+                    newState = DELIMITER_REACHED;
+                    break;
+                default:
+                    if (Formeta.isWhitespace(ch)) {
+                        newState = TRAILING_WHITESPACE;
+                    }
+                    else {
+                        final String sep = "', '";
+                        final String expected = "whitespace or one of '" +
+                            Formeta.GROUP_START + sep +
+                            Formeta.GROUP_END + sep +
+                            Formeta.ITEM_SEPARATOR + sep +
+                            Formeta.NAME_VALUE_SEPARATOR + "'";
+                        throw new FormatException(getUnexpectedCharMsg(expected, ch));
+                    }
             }
             return newState;
         }
@@ -149,7 +152,7 @@ enum TextParserState {
         }
     };
 
-    public abstract TextParserState processChar(final char ch, final TextParserContext ctx);
+    public abstract TextParserState processChar(char ch, TextParserContext ctx);
 
     public void endOfInput(final TextParserContext ctx) {
         // Default implementation does nothing

--- a/metafacture-formeta/src/test/java/org/metafacture/formeta/FormetaDecoderTest.java
+++ b/metafacture-formeta/src/test/java/org/metafacture/formeta/FormetaDecoderTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.formeta;
 
 import static org.mockito.Mockito.inOrder;

--- a/metafacture-formeta/src/test/java/org/metafacture/formeta/FormetaEncoderTest.java
+++ b/metafacture-formeta/src/test/java/org/metafacture/formeta/FormetaEncoderTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.formeta;
 
 import static org.mockito.Mockito.verify;

--- a/metafacture-formeta/src/test/java/org/metafacture/formeta/FormetaRecordsReaderTest.java
+++ b/metafacture-formeta/src/test/java/org/metafacture/formeta/FormetaRecordsReaderTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.formeta;
 
 import static org.mockito.Mockito.verify;

--- a/metafacture-formeta/src/test/java/org/metafacture/formeta/formatter/AbstactFormatterTest.java
+++ b/metafacture-formeta/src/test/java/org/metafacture/formeta/formatter/AbstactFormatterTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.formeta.formatter;
 
 import static org.junit.Assert.assertEquals;

--- a/metafacture-formeta/src/test/java/org/metafacture/formeta/formatter/ConciseFormatterTest.java
+++ b/metafacture-formeta/src/test/java/org/metafacture/formeta/formatter/ConciseFormatterTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.formeta.formatter;
 
 import static org.junit.Assert.assertEquals;

--- a/metafacture-formeta/src/test/java/org/metafacture/formeta/formatter/MultilineFormatterTest.java
+++ b/metafacture-formeta/src/test/java/org/metafacture/formeta/formatter/MultilineFormatterTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.formeta.formatter;
 
 import static org.junit.Assert.assertEquals;

--- a/metafacture-formeta/src/test/java/org/metafacture/formeta/formatter/VerboseFormatterTest.java
+++ b/metafacture-formeta/src/test/java/org/metafacture/formeta/formatter/VerboseFormatterTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.formeta.formatter;
 
 import static org.junit.Assert.assertEquals;

--- a/metafacture-formeta/src/test/java/org/metafacture/formeta/parser/FormetaParserTest.java
+++ b/metafacture-formeta/src/test/java/org/metafacture/formeta/parser/FormetaParserTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.formeta.parser;
 
 import static org.mockito.Mockito.inOrder;
@@ -141,7 +142,8 @@ public final class FormetaParserTest {
         // Try processing an incomplete record:
         try {
             parser.parse(BROKEN_RECORD);
-        } catch (FormatException e) {
+        }
+        catch (FormatException e) {
             // The decoder should recover automatically
         }
 

--- a/metafacture-framework/src/main/java/org/metafacture/framework/FluxCommand.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/FluxCommand.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.framework;
 
 import java.lang.annotation.Documented;

--- a/metafacture-framework/src/main/java/org/metafacture/framework/FormatException.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/FormatException.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.framework;
 
 /**

--- a/metafacture-framework/src/main/java/org/metafacture/framework/LifeCycle.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/LifeCycle.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.framework;
 
 /**

--- a/metafacture-framework/src/main/java/org/metafacture/framework/MetafactureException.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/MetafactureException.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.framework;
 
 /**

--- a/metafacture-framework/src/main/java/org/metafacture/framework/MissingIdException.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/MissingIdException.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.framework;
 
 /**

--- a/metafacture-framework/src/main/java/org/metafacture/framework/ObjectPipe.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/ObjectPipe.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.framework;
 
 import org.metafacture.framework.helpers.DefaultObjectPipe;

--- a/metafacture-framework/src/main/java/org/metafacture/framework/ObjectReceiver.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/ObjectReceiver.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.framework;
 
 import org.metafacture.framework.helpers.DefaultObjectReceiver;

--- a/metafacture-framework/src/main/java/org/metafacture/framework/Receiver.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/Receiver.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.framework;
 
 /**

--- a/metafacture-framework/src/main/java/org/metafacture/framework/Sender.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/Sender.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.framework;
 
 import org.metafacture.framework.helpers.DefaultSender;

--- a/metafacture-framework/src/main/java/org/metafacture/framework/StandardEventNames.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/StandardEventNames.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.framework;
 
 /**

--- a/metafacture-framework/src/main/java/org/metafacture/framework/StreamPipe.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/StreamPipe.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.framework;
 
 import org.metafacture.framework.helpers.DefaultStreamPipe;

--- a/metafacture-framework/src/main/java/org/metafacture/framework/StreamReceiver.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/StreamReceiver.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.framework;
 
 import org.metafacture.framework.helpers.DefaultStreamReceiver;

--- a/metafacture-framework/src/main/java/org/metafacture/framework/Tee.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/Tee.java
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.framework;
 
+package org.metafacture.framework;
 
 import org.metafacture.framework.helpers.DefaultTee;
 
@@ -75,6 +75,6 @@ public interface Tee<T extends Receiver> extends Sender<T> {
      *
      * @return reference to the tee for method chaining
      */
-     Tee<T> clearReceivers();
+    Tee<T> clearReceivers();
 
 }

--- a/metafacture-framework/src/main/java/org/metafacture/framework/XmlPipe.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/XmlPipe.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.framework;
 
 import org.metafacture.framework.helpers.DefaultXmlPipe;

--- a/metafacture-framework/src/main/java/org/metafacture/framework/XmlReceiver.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/XmlReceiver.java
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.framework;
 
 import org.metafacture.framework.helpers.DefaultXmlReceiver;
+
 import org.xml.sax.ContentHandler;
 import org.xml.sax.DTDHandler;
 import org.xml.sax.EntityResolver;

--- a/metafacture-framework/src/main/java/org/metafacture/framework/annotations/Description.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/annotations/Description.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.framework.annotations;
 
 import java.lang.annotation.Documented;

--- a/metafacture-framework/src/main/java/org/metafacture/framework/annotations/In.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/annotations/In.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.framework.annotations;
 
 import java.lang.annotation.Documented;

--- a/metafacture-framework/src/main/java/org/metafacture/framework/annotations/Out.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/annotations/Out.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.framework.annotations;
 
 import java.lang.annotation.Documented;

--- a/metafacture-framework/src/main/java/org/metafacture/framework/annotations/ReturnsAvailableArguments.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/annotations/ReturnsAvailableArguments.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.framework.annotations;
 
 import java.lang.annotation.Documented;

--- a/metafacture-framework/src/main/java/org/metafacture/framework/helpers/DefaultLifeCycle.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/helpers/DefaultLifeCycle.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.framework.helpers;
 
 import org.metafacture.framework.LifeCycle;
@@ -25,6 +26,9 @@ import org.metafacture.framework.LifeCycle;
  *
  */
 public class DefaultLifeCycle implements LifeCycle {
+
+    public DefaultLifeCycle() {
+    }
 
     @Override
     public void resetStream() {

--- a/metafacture-framework/src/main/java/org/metafacture/framework/helpers/DefaultObjectPipe.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/helpers/DefaultObjectPipe.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.framework.helpers;
 
 import org.metafacture.framework.ObjectPipe;
@@ -28,8 +29,10 @@ import org.metafacture.framework.Receiver;
  * @author Christoph Böhme
  *
  */
-public class DefaultObjectPipe<T, R extends Receiver>
-        extends DefaultSender<R> implements ObjectPipe<T, R> {
+public class DefaultObjectPipe<T, R extends Receiver> extends DefaultSender<R> implements ObjectPipe<T, R> {
+
+    public DefaultObjectPipe() {
+    }
 
     @Override
     public void process(final T obj) {

--- a/metafacture-framework/src/main/java/org/metafacture/framework/helpers/DefaultObjectReceiver.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/helpers/DefaultObjectReceiver.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.framework.helpers;
 
 import org.metafacture.framework.ObjectPipe;
@@ -32,6 +33,9 @@ import org.metafacture.framework.ObjectReceiver;
  *
  */
 public class DefaultObjectReceiver<T> extends DefaultLifeCycle implements ObjectReceiver<T> {
+
+    public DefaultObjectReceiver() {
+    }
 
     @Override
     public void process(final T obj) {

--- a/metafacture-framework/src/main/java/org/metafacture/framework/helpers/DefaultSender.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/helpers/DefaultSender.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.framework.helpers;
 
 import org.metafacture.framework.Receiver;
@@ -38,15 +39,18 @@ public class DefaultSender<T extends Receiver> implements Sender<T> {
     private T receiver;
     private boolean isClosed;
 
+    public DefaultSender() {
+    }
+
     public final boolean isClosed() {
         return isClosed;
     }
 
     @Override
-    public final <R extends T> R setReceiver(final R receiver) {
-        this.receiver = receiver;
+    public final <R extends T> R setReceiver(final R newReceiver) {
+        receiver = newReceiver;
         onSetReceiver();
-        return receiver;
+        return newReceiver;
     }
 
     @Override

--- a/metafacture-framework/src/main/java/org/metafacture/framework/helpers/DefaultStreamPipe.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/helpers/DefaultStreamPipe.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.framework.helpers;
 
 import org.metafacture.framework.Receiver;
@@ -27,8 +28,10 @@ import org.metafacture.framework.StreamPipe;
  * @author Christoph Böhme
  * @see ForwardingStreamPipe
  */
-public class DefaultStreamPipe<R extends Receiver>
-        extends DefaultSender<R> implements StreamPipe<R> {
+public class DefaultStreamPipe<R extends Receiver> extends DefaultSender<R> implements StreamPipe<R> {
+
+    public DefaultStreamPipe() {
+    }
 
     @Override
     public void startRecord(final String identifier) {

--- a/metafacture-framework/src/main/java/org/metafacture/framework/helpers/DefaultStreamReceiver.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/helpers/DefaultStreamReceiver.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.framework.helpers;
 
 import org.metafacture.framework.StreamPipe;
@@ -31,13 +32,16 @@ import org.metafacture.framework.StreamReceiver;
  */
 public class DefaultStreamReceiver extends DefaultLifeCycle implements StreamReceiver {
 
+    public DefaultStreamReceiver() {
+    }
+
     @Override
     public void startRecord(final String identifier) {
         // Default implementation does nothing
     }
 
     @Override
-    public void endRecord(){
+    public void endRecord() {
         // Default implementation does nothing
     }
 

--- a/metafacture-framework/src/main/java/org/metafacture/framework/helpers/DefaultTee.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/helpers/DefaultTee.java
@@ -13,15 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.framework.helpers;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+package org.metafacture.framework.helpers;
 
 import org.metafacture.framework.Receiver;
 import org.metafacture.framework.Tee;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Default implementation for tee modules.
@@ -33,6 +33,9 @@ import org.metafacture.framework.Tee;
 public class DefaultTee<T extends Receiver> implements Tee<T> {
 
     private final List<T> receivers = new ArrayList<T>();
+
+    public DefaultTee() {
+    }
 
     @Override
     public final <R extends T> R setReceiver(final R receiver) {

--- a/metafacture-framework/src/main/java/org/metafacture/framework/helpers/DefaultXmlPipe.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/helpers/DefaultXmlPipe.java
@@ -13,17 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.framework.helpers;
 
-import java.io.IOException;
+package org.metafacture.framework.helpers;
 
 import org.metafacture.framework.Receiver;
 import org.metafacture.framework.XmlPipe;
+
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.Locator;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
+
+import java.io.IOException;
 
 /**
  * Default implementation for {@link XmlPipe}s which simply
@@ -34,8 +36,10 @@ import org.xml.sax.SAXParseException;
  * @author Christoph Böhme
  *
  */
-public class DefaultXmlPipe <R extends Receiver>
-        extends DefaultSender<R> implements XmlPipe<R> {
+public class DefaultXmlPipe<R extends Receiver> extends DefaultSender<R> implements XmlPipe<R> {
+
+    public DefaultXmlPipe() {
+    }
 
     @Override
     public void setDocumentLocator(final Locator locator) {

--- a/metafacture-framework/src/main/java/org/metafacture/framework/helpers/DefaultXmlReceiver.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/helpers/DefaultXmlReceiver.java
@@ -13,17 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.framework.helpers;
 
-import java.io.IOException;
+package org.metafacture.framework.helpers;
 
 import org.metafacture.framework.XmlPipe;
 import org.metafacture.framework.XmlReceiver;
+
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.Locator;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
+
+import java.io.IOException;
 
 /**
  * Default implementation of {@link XmlReceiver} which
@@ -37,6 +39,9 @@ import org.xml.sax.SAXParseException;
  *
  */
 public class DefaultXmlReceiver extends DefaultLifeCycle implements XmlReceiver {
+
+    public DefaultXmlReceiver() {
+    }
 
     @Override
     public void setDocumentLocator(final Locator locator) {

--- a/metafacture-framework/src/main/java/org/metafacture/framework/helpers/ForwardingStreamPipe.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/helpers/ForwardingStreamPipe.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.framework.helpers;
 
 import org.metafacture.framework.StreamPipe;
@@ -27,6 +28,9 @@ import org.metafacture.framework.StreamReceiver;
  * @see DefaultStreamPipe
  */
 public class ForwardingStreamPipe extends DefaultStreamPipe<StreamReceiver> {
+
+    public ForwardingStreamPipe() {
+    }
 
     @Override
     public void startRecord(final String identifier) {

--- a/metafacture-framework/src/main/java/org/metafacture/framework/objects/Triple.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/objects/Triple.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.framework.objects;
 
 import java.io.IOException;
@@ -72,7 +73,8 @@ public final class Triple implements Comparable<Triple> {
         try {
             return new Triple(in.readUTF(), in.readUTF(), in.readUTF(),
                     (ObjectType) in.readObject());
-        } catch (final ClassNotFoundException e) {
+        }
+        catch (final ClassNotFoundException e) {
             throw new IOException("Cannot read triple", e);
         }
     }
@@ -98,11 +100,11 @@ public final class Triple implements Comparable<Triple> {
             return false;
         }
         final Triple other = (Triple) obj;
-        return other.preCompHashCode == preCompHashCode
-                && other.predicate.equals(predicate)
-                && other.object.equals(object)
-                && other.subject.equals(subject)
-                && other.objectType == objectType;
+        return other.preCompHashCode == preCompHashCode &&
+                other.predicate.equals(predicate) &&
+                other.object.equals(object) &&
+                other.subject.equals(subject) &&
+                other.objectType == objectType;
     }
 
     @Override
@@ -112,7 +114,7 @@ public final class Triple implements Comparable<Triple> {
             result = predicate.compareTo(triple.predicate);
             if (result == 0) {
                 result = object.compareTo(triple.object);
-                if(result == 0) {
+                if (result == 0) {
                     return objectType.compareTo(triple.objectType);
                 }
             }

--- a/metafacture-framework/src/test/java/org/metafacture/framework/helpers/DefaultSenderTest.java
+++ b/metafacture-framework/src/test/java/org/metafacture/framework/helpers/DefaultSenderTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.framework.helpers;
 
 import static org.junit.Assert.assertFalse;

--- a/metafacture-html/src/main/java/org/metafacture/html/ElementExtractor.java
+++ b/metafacture-html/src/main/java/org/metafacture/html/ElementExtractor.java
@@ -13,21 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.html;
 
-import java.io.IOException;
-import java.io.Reader;
-
-import org.apache.commons.io.IOUtils;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.ObjectReceiver;
 import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
+
+import org.apache.commons.io.IOUtils;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+import java.io.IOException;
+import java.io.Reader;
 
 /**
  * Extracts the the specified element from an HTML document
@@ -51,10 +53,11 @@ public class ElementExtractor extends DefaultObjectPipe<Reader, ObjectReceiver<S
     @Override
     public void process(final Reader reader) {
         try {
-            Document document = Jsoup.parse(IOUtils.toString(reader));
-            Element firstElement = document.select(selector).first();
+            final Document document = Jsoup.parse(IOUtils.toString(reader));
+            final Element firstElement = document.select(selector).first();
             getReceiver().process(firstElement.data());
-        } catch (IOException e) {
+        }
+        catch (final IOException e) {
             e.printStackTrace();
         }
     }

--- a/metafacture-html/src/main/java/org/metafacture/html/HtmlDecoder.java
+++ b/metafacture-html/src/main/java/org/metafacture/html/HtmlDecoder.java
@@ -13,7 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.html;
+
+import org.metafacture.framework.FluxCommand;
+import org.metafacture.framework.StreamReceiver;
+import org.metafacture.framework.annotations.Description;
+import org.metafacture.framework.annotations.In;
+import org.metafacture.framework.annotations.Out;
+import org.metafacture.framework.helpers.DefaultObjectPipe;
+
+import org.apache.commons.io.IOUtils;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Attribute;
+import org.jsoup.nodes.Attributes;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -24,46 +41,32 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-import org.apache.commons.io.IOUtils;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Attribute;
-import org.jsoup.nodes.Attributes;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
-import org.metafacture.framework.FluxCommand;
-import org.metafacture.framework.StreamReceiver;
-import org.metafacture.framework.annotations.Description;
-import org.metafacture.framework.annotations.In;
-import org.metafacture.framework.annotations.Out;
-import org.metafacture.framework.helpers.DefaultObjectPipe;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Decode HTML to metadata events. Each input document represents one record.
  *
  * @author Fabian Steeg (fsteeg)
  *
  */
-@Description("Decode HTML to metadata events. The attrValsAsSubfields option can be used to override "
-        + "the default attribute values to be used as subfields (e.g. by default "
-        + "`link rel=\"canonical\" href=\"http://example.org\"` becomes `link.canonical`). "
-        + "It expects an HTTP-style query string specifying as key the attributes whose value should "
-        + "be used as a subfield, and as value the attribute whose value should be the subfield value, "
-        + "e.g. the default contains `link.rel=href`. To use the HTML element text as the value "
-        + "(instead of another attribute), omit the value of the query-string key-value pair, "
-        + "e.g. `title.lang`. To add to the defaults, instead of replacing them, start with an `&`, "
-        + "e.g. `&h3.class`")
+@Description("Decode HTML to metadata events. The attrValsAsSubfields option can be used to override " +
+        "the default attribute values to be used as subfields (e.g. by default " +
+        "`link rel=\"canonical\" href=\"http://example.org\"` becomes `link.canonical`). " +
+        "It expects an HTTP-style query string specifying as key the attributes whose value should " +
+        "be used as a subfield, and as value the attribute whose value should be the subfield value, " +
+        "e.g. the default contains `link.rel=href`. To use the HTML element text as the value " +
+        "(instead of another attribute), omit the value of the query-string key-value pair, " +
+        "e.g. `title.lang`. To add to the defaults, instead of replacing them, start with an `&`, " +
+        "e.g. `&h3.class`")
 @In(Reader.class)
 @Out(StreamReceiver.class)
 @FluxCommand("decode-html")
 public class HtmlDecoder extends DefaultObjectPipe<Reader, StreamReceiver> {
 
+    private static final Logger LOG = LoggerFactory.getLogger(HtmlDecoder.class);
+
     private static final String DEFAULT_ATTR_VALS_AS_SUBFIELDS = //
             "meta.name=content&meta.property=content&link.rel=href&a.rel=href";
+
     private Map<String, String> attrValsAsSubfields;
-    private static final Logger LOG =
-            LoggerFactory.getLogger(HtmlDecoder.class);
 
     public HtmlDecoder() {
         setAttrValsAsSubfields(DEFAULT_ATTR_VALS_AS_SUBFIELDS);
@@ -72,28 +75,29 @@ public class HtmlDecoder extends DefaultObjectPipe<Reader, StreamReceiver> {
     @Override
     public void process(final Reader reader) {
         try {
-            StreamReceiver receiver = getReceiver();
+            final StreamReceiver receiver = getReceiver();
             receiver.startRecord(UUID.randomUUID().toString());
-            Document document = Jsoup.parse(IOUtils.toString(reader));
+            final Document document = Jsoup.parse(IOUtils.toString(reader));
             process(document, receiver);
             receiver.endRecord();
-        } catch (IOException e) {
+        }
+        catch (final IOException e) {
             LOG.error(e.getMessage(), e);
         }
     }
 
-    private void process(Element parent, StreamReceiver receiver) {
-        for (Element element : parent.children()) {
+    private void process(final Element parent, final StreamReceiver receiver) {
+        for (final Element element : parent.children()) {
             receiver.startEntity(element.nodeName());
-            Attributes attributes = element.attributes();
+            final Attributes attributes = element.attributes();
             boolean addedValueAsSubfield = false;
-            for (Attribute attribute : attributes) {
+            for (final Attribute attribute : attributes) {
                 addedValueAsSubfield = handleAttributeValuesAsSubfields(receiver, element, attributes, attribute);
                 receiver.literal(attribute.getKey(), attribute.getValue());
             }
             if (element.children().isEmpty()) {
-                String text = element.text().trim();
-                String value = text.isEmpty() ? element.data() : text;
+                final String text = element.text().trim();
+                final String value = text.isEmpty() ? element.data() : text;
                 if (!value.isEmpty() && !addedValueAsSubfield) {
                     receiver.literal("value", value);
                 }
@@ -103,34 +107,34 @@ public class HtmlDecoder extends DefaultObjectPipe<Reader, StreamReceiver> {
         }
     }
 
-    private boolean handleAttributeValuesAsSubfields(StreamReceiver receiver, Element element,
-            Attributes attributes, Attribute attribute) {
-        String fullFieldKey = element.nodeName() + "." + attribute.getKey();
+    private boolean handleAttributeValuesAsSubfields(final StreamReceiver receiver, final Element element, final Attributes attributes, final Attribute attribute) {
+        final String fullFieldKey = element.nodeName() + "." + attribute.getKey();
         if (attrValsAsSubfields.containsKey(fullFieldKey)) {
-            String configValue = attrValsAsSubfields.get(fullFieldKey);
+            final String configValue = attrValsAsSubfields.get(fullFieldKey);
             if (configValue.trim().isEmpty()) {
                 receiver.literal(attribute.getValue(), element.text().trim());
                 return true;
-            } else {
-                String value = attributes.get(configValue);
+            }
+            else {
+                final String value = attributes.get(configValue);
                 receiver.literal(attribute.getValue(), value);
             }
         }
         return false;
     }
 
-    public void setAttrValsAsSubfields(String mapString) {
+    public void setAttrValsAsSubfields(final String mapString) {
         this.attrValsAsSubfields = new HashMap<String, String>();
-        String input = mapString.startsWith("&") ? DEFAULT_ATTR_VALS_AS_SUBFIELDS + mapString
-                : mapString;
-        for (String nameValuePair : input.split("&")) {
-            String[] nameValue = nameValuePair.split("=");
+        final String input = mapString.startsWith("&") ? DEFAULT_ATTR_VALS_AS_SUBFIELDS + mapString : mapString;
+        for (final String nameValuePair : input.split("&")) {
+            final String[] nameValue = nameValuePair.split("=");
             try {
-                String utf8 = StandardCharsets.UTF_8.name();
-                String key = URLDecoder.decode(nameValue[0], utf8);
-                String val = nameValue.length > 1 ? URLDecoder.decode(nameValue[1], utf8) : "";
+                final String utf8 = StandardCharsets.UTF_8.name();
+                final String key = URLDecoder.decode(nameValue[0], utf8);
+                final String val = nameValue.length > 1 ? URLDecoder.decode(nameValue[1], utf8) : "";
                 attrValsAsSubfields.put(key, val);
-            } catch (UnsupportedEncodingException e) {
+            }
+            catch (final UnsupportedEncodingException e) {
                 LOG.error(e.getMessage(), e);
             }
         }

--- a/metafacture-html/src/test/java/org/metafacture/html/ElementExtractorTest.java
+++ b/metafacture-html/src/test/java/org/metafacture/html/ElementExtractorTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.html;
 
 import static org.mockito.Mockito.verify;

--- a/metafacture-html/src/test/java/org/metafacture/html/HtmlDecoderTest.java
+++ b/metafacture-html/src/test/java/org/metafacture/html/HtmlDecoderTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.html;
 
 import static org.mockito.Mockito.inOrder;

--- a/metafacture-io/src/main/java/org/metafacture/io/AbstractObjectWriter.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/AbstractObjectWriter.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.io;
 
 /**

--- a/metafacture-io/src/main/java/org/metafacture/io/ByteStreamFileWriter.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/ByteStreamFileWriter.java
@@ -1,15 +1,14 @@
 package org.metafacture.io;
 
-import static java.util.Objects.requireNonNull;
+import org.metafacture.framework.helpers.DefaultObjectReceiver;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Objects;
 import java.util.function.Supplier;
-
-import org.metafacture.framework.helpers.DefaultObjectReceiver;
 
 /**
  * Writes byte arrays to regular output files.
@@ -28,6 +27,9 @@ public class ByteStreamFileWriter extends DefaultObjectReceiver<byte[]> {
 
     private OutputStream outputStream;
 
+    public ByteStreamFileWriter() {
+    }
+
     /**
      * Supplier for file names.
      * <p>
@@ -42,9 +44,8 @@ public class ByteStreamFileWriter extends DefaultObjectReceiver<byte[]> {
      *
      * @param fileNameSupplier a supplier that returns file names.
      */
-    public void setFileNameSupplier(Supplier<File> fileNameSupplier) {
-
-        this.fileNameSupplier = requireNonNull(fileNameSupplier);
+    public void setFileNameSupplier(final Supplier<File> fileNameSupplier) {
+        this.fileNameSupplier = Objects.requireNonNull(fileNameSupplier);
     }
 
     /**
@@ -58,8 +59,7 @@ public class ByteStreamFileWriter extends DefaultObjectReceiver<byte[]> {
      * @param appendIfFileExists true if new data should be appended,
      *                           false to overwrite the existing file.
      */
-    public void setAppendIfFileExists(boolean appendIfFileExists) {
-
+    public void setAppendIfFileExists(final boolean appendIfFileExists) {
         this.appendIfFileExists = appendIfFileExists;
     }
 
@@ -75,8 +75,7 @@ public class ByteStreamFileWriter extends DefaultObjectReceiver<byte[]> {
      * @param flushAfterWrite true if the output stream should be flushed
      *                        after every write.
      */
-    public void setFlushAfterWrite(boolean flushAfterWrite) {
-
+    public void setFlushAfterWrite(final boolean flushAfterWrite) {
         this.flushAfterWrite = flushAfterWrite;
     }
 
@@ -88,7 +87,6 @@ public class ByteStreamFileWriter extends DefaultObjectReceiver<byte[]> {
      */
     @Override
     public void process(final byte[] bytes) {
-
         ensureOpenStream();
         try {
             outputStream.write(bytes);
@@ -96,7 +94,8 @@ public class ByteStreamFileWriter extends DefaultObjectReceiver<byte[]> {
                 outputStream.flush();
             }
 
-        } catch (IOException e) {
+        }
+        catch (final IOException e) {
             throw new WriteFailed("Error while writing bytes to output stream", e);
         }
     }
@@ -109,7 +108,6 @@ public class ByteStreamFileWriter extends DefaultObjectReceiver<byte[]> {
      */
     @Override
     public void resetStream() {
-
         closeStream();
         ensureOpenStream();
     }
@@ -121,12 +119,12 @@ public class ByteStreamFileWriter extends DefaultObjectReceiver<byte[]> {
      */
     @Override
     public void closeStream() {
-
         if (outputStream != null) {
             try {
                 outputStream.close();
 
-            } catch (IOException e) {
+            }
+            catch (final IOException e) {
                 throw new CloseFailed("Error while closing output stream", e);
             }
             outputStream = null;
@@ -134,14 +132,14 @@ public class ByteStreamFileWriter extends DefaultObjectReceiver<byte[]> {
     }
 
     private void ensureOpenStream() {
-
         if (outputStream != null) {
             return;
         }
         try {
             outputStream = new FileOutputStream(fileNameSupplier.get(), appendIfFileExists);
 
-        } catch (FileNotFoundException e) {
+        }
+        catch (final FileNotFoundException e) {
             throw new OpenFailed("Cannot open output stream. File not found.", e);
         }
     }

--- a/metafacture-io/src/main/java/org/metafacture/io/CloseFailed.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/CloseFailed.java
@@ -2,15 +2,15 @@ package org.metafacture.io;
 
 public class CloseFailed extends IoFailed {
 
-    public CloseFailed(String message) {
+    public CloseFailed(final String message) {
         super(message);
     }
 
-    public CloseFailed(Throwable cause) {
+    public CloseFailed(final Throwable cause) {
         super(cause);
     }
 
-    public CloseFailed(String message, Throwable cause) {
+    public CloseFailed(final String message, final Throwable cause) {
         super(message, cause);
     }
 

--- a/metafacture-io/src/main/java/org/metafacture/io/ConfigurableObjectWriter.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/ConfigurableObjectWriter.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.io;
 
 import org.metafacture.framework.ObjectReceiver;
@@ -58,14 +59,14 @@ public interface ConfigurableObjectWriter<T> extends ObjectReceiver<T> {
      *
      * @param compression type of compression
      */
-    void setCompression(final FileCompression compression);
+    void setCompression(FileCompression compression);
 
     /**
      * Sets the compression mode.
      *
      * @param compression type of compression
      */
-    void setCompression(final String compression);
+    void setCompression(String compression);
 
     /**
      * Returns the header which is output before the first object.
@@ -79,7 +80,7 @@ public interface ConfigurableObjectWriter<T> extends ObjectReceiver<T> {
      *
      * @param header new header string
      */
-    void setHeader(final String header);
+    void setHeader(String header);
 
     /**
      * Returns the footer which is output after the last object.
@@ -93,7 +94,7 @@ public interface ConfigurableObjectWriter<T> extends ObjectReceiver<T> {
      *
      * @param footer new footer string
      */
-    void setFooter(final String footer);
+    void setFooter(String footer);
 
     /**
      * Returns the separator which is output between objects.
@@ -107,6 +108,6 @@ public interface ConfigurableObjectWriter<T> extends ObjectReceiver<T> {
      *
      * @param separator new separator string
      */
-    void setSeparator(final String separator);
+    void setSeparator(String separator);
 
 }

--- a/metafacture-io/src/main/java/org/metafacture/io/FileCompression.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/FileCompression.java
@@ -13,19 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.io;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
-import java.io.InputStream;
-import java.io.OutputStream;
+import org.metafacture.framework.MetafactureException;
 
 import org.apache.commons.compress.compressors.CompressorException;
 import org.apache.commons.compress.compressors.CompressorStreamFactory;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.input.ProxyInputStream;
 import org.apache.commons.io.output.ProxyOutputStream;
-import org.metafacture.framework.MetafactureException;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 /**
  * Provides a convenient interface for using stream compressors
@@ -61,15 +63,20 @@ public enum FileCompression {
             final FileCompression compressor;
             if ("gz".equalsIgnoreCase(extension)) {
                 compressor = GZIP;
-            } else if ("gzip".equalsIgnoreCase(extension)) {
+            }
+            else if ("gzip".equalsIgnoreCase(extension)) {
                 compressor = GZIP;
-            } else if ("bz2".equalsIgnoreCase(extension)) {
+            }
+            else if ("bz2".equalsIgnoreCase(extension)) {
                 compressor = BZIP2;
-            } else if ("bzip2".equalsIgnoreCase(extension)) {
+            }
+            else if ("bzip2".equalsIgnoreCase(extension)) {
                 compressor = BZIP2;
-            } else if ("xz".equalsIgnoreCase(extension)) {
+            }
+            else if ("xz".equalsIgnoreCase(extension)) {
                 compressor = XZ;
-            } else {
+            }
+            else {
                 compressor = NONE;
             }
 
@@ -83,7 +90,8 @@ public enum FileCompression {
                 return decompressConcatenated ?
                     APACHE_COMPRESSOR_FACTORY_DECOMPRESS_CONCATENATED.createCompressorInputStream(bufferedStream) :
                     APACHE_COMPRESSOR_FACTORY_NO_DECOMPRESS_CONCATENATED.createCompressorInputStream(bufferedStream);
-            } catch (CompressorException e) {
+            }
+            catch (final CompressorException e) {
                 return NONE.createDecompressor(bufferedStream, decompressConcatenated);
             }
         }
@@ -95,7 +103,8 @@ public enum FileCompression {
             try {
                 return APACHE_COMPRESSOR_FACTORY.createCompressorOutputStream(
                         CompressorStreamFactory.BZIP2, bufferStream(writeTo));
-            } catch (CompressorException e) {
+            }
+            catch (final CompressorException e) {
                 throw new MetafactureException(e);
             }
         }
@@ -105,7 +114,8 @@ public enum FileCompression {
             try {
                 return APACHE_COMPRESSOR_FACTORY.createCompressorInputStream(
                         CompressorStreamFactory.BZIP2, bufferStream(readFrom), decompressConcatenated);
-            } catch (CompressorException e) {
+            }
+            catch (final CompressorException e) {
                 throw new MetafactureException(e);
             }
         }
@@ -117,7 +127,8 @@ public enum FileCompression {
             try {
                 return APACHE_COMPRESSOR_FACTORY.createCompressorOutputStream(
                         CompressorStreamFactory.GZIP, bufferStream(writeTo));
-            } catch (CompressorException e) {
+            }
+            catch (final CompressorException e) {
                 throw new MetafactureException(e);
             }
         }
@@ -127,7 +138,8 @@ public enum FileCompression {
             try {
                 return APACHE_COMPRESSOR_FACTORY.createCompressorInputStream(
                         CompressorStreamFactory.GZIP, bufferStream(readFrom), decompressConcatenated);
-            } catch (CompressorException e) {
+            }
+            catch (final CompressorException e) {
                 throw new MetafactureException(e);
             }
         }
@@ -139,7 +151,8 @@ public enum FileCompression {
             try {
                 return APACHE_COMPRESSOR_FACTORY.createCompressorOutputStream(
                         CompressorStreamFactory.PACK200, bufferStream(writeTo));
-            } catch (CompressorException e) {
+            }
+            catch (final CompressorException e) {
                 throw new MetafactureException(e);
             }
         }
@@ -149,7 +162,8 @@ public enum FileCompression {
             try {
                 return APACHE_COMPRESSOR_FACTORY.createCompressorInputStream(
                         CompressorStreamFactory.PACK200, bufferStream(readFrom), decompressConcatenated);
-            } catch (CompressorException e) {
+            }
+            catch (final CompressorException e) {
                 throw new MetafactureException(e);
             }
         }
@@ -161,7 +175,8 @@ public enum FileCompression {
             try {
                 return APACHE_COMPRESSOR_FACTORY.createCompressorOutputStream(
                         CompressorStreamFactory.XZ, bufferStream(writeTo));
-            } catch (CompressorException e) {
+            }
+            catch (final CompressorException e) {
                 throw new MetafactureException(e);
             }
         }
@@ -171,7 +186,8 @@ public enum FileCompression {
             try {
                 return APACHE_COMPRESSOR_FACTORY.createCompressorInputStream(
                         CompressorStreamFactory.XZ, bufferStream(readFrom), decompressConcatenated);
-            } catch (CompressorException e) {
+            }
+            catch (final CompressorException e) {
                 throw new MetafactureException(e);
             }
         }
@@ -186,9 +202,9 @@ public enum FileCompression {
 
     private static final int BUFFER_SIZE = 8 * 1024 * 1024;
 
-    public abstract OutputStream createCompressor(final OutputStream writeTo, final String fileName);
+    public abstract OutputStream createCompressor(OutputStream writeTo, String fileName);
 
-    public abstract InputStream createDecompressor(final InputStream readFrom, final boolean decompressConcatenated);
+    public abstract InputStream createDecompressor(InputStream readFrom, boolean decompressConcatenated);
 
     public InputStream createDecompressor(final InputStream readFrom) {
         return createDecompressor(readFrom, DEFAULT_DECOMPRESS_CONCATENATED);

--- a/metafacture-io/src/main/java/org/metafacture/io/FileOpener.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/FileOpener.java
@@ -13,15 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.io;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-
-import org.apache.commons.io.input.BOMInputStream;
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.MetafactureException;
 import org.metafacture.framework.ObjectReceiver;
@@ -30,6 +24,13 @@ import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
 
+import org.apache.commons.io.input.BOMInputStream;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
 
 /**
  * Opens a file and passes a reader for it to the receiver.
@@ -41,12 +42,14 @@ import org.metafacture.framework.helpers.DefaultObjectPipe;
 @In(String.class)
 @Out(java.io.Reader.class)
 @FluxCommand("open-file")
-public final class FileOpener
-        extends DefaultObjectPipe<String, ObjectReceiver<Reader>> {
+public final class FileOpener extends DefaultObjectPipe<String, ObjectReceiver<Reader>> {
 
     private String encoding = "UTF-8";
     private FileCompression compression = FileCompression.AUTO;
     private boolean decompressConcatenated = FileCompression.DEFAULT_DECOMPRESS_CONCATENATED;
+
+    public FileOpener() {
+    }
 
     /**
      * Returns the encoding used to open the resource.
@@ -98,15 +101,18 @@ public final class FileOpener
                     final Reader reader = new InputStreamReader(new BOMInputStream(
                             decompressor), encoding);
                     getReceiver().process(reader);
-                } catch (final IOException | MetafactureException e) {
+                }
+                catch (final IOException | MetafactureException e) {
                     decompressor.close();
                     throw e;
                 }
-            } catch (final IOException | MetafactureException e) {
+            }
+            catch (final IOException | MetafactureException e) {
                 fileStream.close();
                 throw e;
             }
-        } catch (final IOException e) {
+        }
+        catch (final IOException e) {
             throw new MetafactureException(e);
         }
     }

--- a/metafacture-io/src/main/java/org/metafacture/io/HttpOpener.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/HttpOpener.java
@@ -13,13 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.io;
 
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.net.URL;
-import java.net.URLConnection;
+package org.metafacture.io;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.MetafactureException;
@@ -29,6 +24,11 @@ import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
 
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.URL;
+import java.net.URLConnection;
 
 /**
  * Opens a {@link URLConnection} and passes a reader to the receiver.
@@ -40,11 +40,13 @@ import org.metafacture.framework.helpers.DefaultObjectPipe;
 @In(String.class)
 @Out(java.io.Reader.class)
 @FluxCommand("open-http")
-public final class HttpOpener
-        extends DefaultObjectPipe<String, ObjectReceiver<Reader>> {
+public final class HttpOpener extends DefaultObjectPipe<String, ObjectReceiver<Reader>> {
 
     private String encoding = "UTF-8";
     private String accept = "*/*";
+
+    public HttpOpener() {
+    }
 
     /**
      * Sets the HTTP accept header value. This is a mime-type such as text/plain
@@ -82,7 +84,8 @@ public final class HttpOpener
                 enc = encoding;
             }
             getReceiver().process(new InputStreamReader(con.getInputStream(), enc));
-        } catch (IOException e) {
+        }
+        catch (final IOException e) {
             throw new MetafactureException(e);
         }
     }

--- a/metafacture-io/src/main/java/org/metafacture/io/IoFailed.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/IoFailed.java
@@ -4,15 +4,15 @@ import org.metafacture.framework.MetafactureException;
 
 public class IoFailed extends MetafactureException {
 
-    public IoFailed(String message) {
+    public IoFailed(final String message) {
         super(message);
     }
 
-    public IoFailed(Throwable cause) {
+    public IoFailed(final Throwable cause) {
         super(cause);
     }
 
-    public IoFailed(String message, Throwable cause) {
+    public IoFailed(final String message, final Throwable cause) {
         super(message, cause);
     }
 

--- a/metafacture-io/src/main/java/org/metafacture/io/IoWriterFactory.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/IoWriterFactory.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.io;
 
 import java.io.Writer;

--- a/metafacture-io/src/main/java/org/metafacture/io/LineReader.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/LineReader.java
@@ -13,11 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.io;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.Reader;
+package org.metafacture.io;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.MetafactureException;
@@ -26,6 +23,10 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
 
 /**
  * Processes input from a reader line by line.
@@ -37,14 +38,17 @@ import org.metafacture.framework.helpers.DefaultObjectPipe;
 @In(Reader.class)
 @Out(String.class)
 @FluxCommand("as-lines")
-public final class LineReader
-        extends DefaultObjectPipe<Reader, ObjectReceiver<String>> {
+public final class LineReader extends DefaultObjectPipe<Reader, ObjectReceiver<String>> {
+
     private static final int BUFFER_SIZE = 1024 * 1024 * 16;
+
+    public LineReader() {
+    }
 
     @Override
     public void process(final Reader reader) {
         assert !isClosed();
-        assert null!=reader;
+        assert null != reader;
         process(reader, getReceiver());
     }
 
@@ -56,7 +60,8 @@ public final class LineReader
                 receiver.process(line);
                 line = lineReader.readLine();
             }
-        } catch (IOException e) {
+        }
+        catch (final IOException e) {
             throw new MetafactureException(e);
         }
     }

--- a/metafacture-io/src/main/java/org/metafacture/io/ObjectFileWriter.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/ObjectFileWriter.java
@@ -13,7 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.io;
+
+import org.metafacture.framework.FluxCommand;
+import org.metafacture.framework.MetafactureException;
+import org.metafacture.framework.annotations.In;
 
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -22,10 +27,6 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import org.metafacture.framework.FluxCommand;
-import org.metafacture.framework.MetafactureException;
-import org.metafacture.framework.annotations.In;
 
 /**
  * @param <T>
@@ -52,8 +53,6 @@ public final class ObjectFileWriter<T> extends AbstractObjectWriter<T>  {
     private FileCompression compression = FileCompression.AUTO;
 
     public ObjectFileWriter(final String path) {
-        super();
-
         this.path = path;
         startNewFile();
 
@@ -95,11 +94,13 @@ public final class ObjectFileWriter<T> extends AbstractObjectWriter<T>  {
             if (firstObject) {
                 writer.write(getHeader());
                 firstObject = false;
-            } else {
+            }
+            else {
                 writer.write(getSeparator());
             }
             writer.write(obj.toString());
-        } catch (final IOException e) {
+        }
+        catch (final IOException e) {
             throw new MetafactureException(e);
         }
     }
@@ -112,9 +113,11 @@ public final class ObjectFileWriter<T> extends AbstractObjectWriter<T>  {
                     writer.write(getFooter());
                 }
                 writer.close();
-            } catch (final IOException e) {
+            }
+            catch (final IOException e) {
                 throw new MetafactureException(e);
-            } finally {
+            }
+            finally {
                 closed = true;
             }
         }
@@ -130,9 +133,11 @@ public final class ObjectFileWriter<T> extends AbstractObjectWriter<T>  {
                     writer.write(getFooter());
                 }
                 writer.close();
-            } catch (final IOException e) {
+            }
+            catch (final IOException e) {
                 throw new MetafactureException(e);
-            } finally {
+            }
+            finally {
                 closed = true;
             }
         }
@@ -140,25 +145,28 @@ public final class ObjectFileWriter<T> extends AbstractObjectWriter<T>  {
 
     private void startNewFile() {
         final Matcher matcher = VAR_PATTERN.matcher(this.path);
-        final String path = matcher.replaceAll(String.valueOf(count));
+        final String currentPath = matcher.replaceAll(String.valueOf(count));
         try {
-            final OutputStream file = new FileOutputStream(path);
+            final OutputStream file = new FileOutputStream(currentPath);
             try {
-                final OutputStream compressor = compression.createCompressor(file, path);
+                final OutputStream compressor = compression.createCompressor(file, currentPath);
                 try {
                     writer = new OutputStreamWriter(compressor, encoding);
                     firstObject = true;
                     closed = false;
-                } catch (final IOException e) {
+                }
+                catch (final IOException e) {
                     compressor.close();
                     throw e;
                 }
-            } catch (final IOException e) {
+            }
+            catch (final IOException e) {
                 file.close();
                 throw e;
             }
-        } catch (final IOException e) {
-            throw new MetafactureException("Error creating file '" + path + "'.", e);
+        }
+        catch (final IOException e) {
+            throw new MetafactureException("Error creating file '" + currentPath + "'.", e);
         }
     }
 

--- a/metafacture-io/src/main/java/org/metafacture/io/ObjectJavaIoWriter.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/ObjectJavaIoWriter.java
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.io;
 
-import java.io.IOException;
-import java.io.Writer;
+package org.metafacture.io;
 
 import org.metafacture.framework.MetafactureException;
 import org.metafacture.framework.ObjectReceiver;
+
+import java.io.IOException;
+import java.io.Writer;
 
 /**
  * @param <T>
@@ -51,14 +52,15 @@ public final class ObjectJavaIoWriter<T> implements ObjectReceiver<T> {
         try {
             writer.write(obj.toString());
             writer.append('\n');
-        } catch (IOException e) {
+        }
+        catch (final IOException e) {
             throw new MetafactureException(e);
         }
     }
 
     @Override
     public void resetStream() {
-        if(writerFactory==null){
+        if (writerFactory == null) {
             throw new UnsupportedOperationException("Cannot reset ObjectJavaIoWriter. No IOWriterFactory set.");
         }
         writer = writerFactory.createWriter();
@@ -70,10 +72,12 @@ public final class ObjectJavaIoWriter<T> implements ObjectReceiver<T> {
         if (!closed) {
             try {
                 writer.close();
-            } catch (IOException e) {
+            }
+            catch (final IOException e) {
                 throw new MetafactureException(e);
-            }finally{
-                closed=true;
+            }
+            finally {
+                closed = true;
             }
 
         }

--- a/metafacture-io/src/main/java/org/metafacture/io/ObjectStdoutWriter.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/ObjectStdoutWriter.java
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.io;
 
-import java.nio.charset.Charset;
+package org.metafacture.io;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
+
+import java.nio.charset.Charset;
 
 /**
  * @param <T> object type
@@ -37,6 +38,9 @@ public final class ObjectStdoutWriter<T> extends AbstractObjectWriter<T>  {
 
     private boolean firstObject = true;
     private boolean closed;
+
+    public ObjectStdoutWriter() {
+    }
 
     @Override
     public String getEncoding() {
@@ -70,7 +74,8 @@ public final class ObjectStdoutWriter<T> extends AbstractObjectWriter<T>  {
         if (firstObject) {
             System.out.print(getHeader());
             firstObject = false;
-        } else {
+        }
+        else {
             System.out.print(getSeparator());
         }
         System.out.print(obj);

--- a/metafacture-io/src/main/java/org/metafacture/io/ObjectWriter.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/ObjectWriter.java
@@ -13,12 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.io;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+package org.metafacture.io;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.annotations.Description;
@@ -26,6 +22,10 @@ import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.annotations.ReturnsAvailableArguments;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Writes objects to stdout or a file
@@ -34,7 +34,6 @@ import org.metafacture.framework.annotations.ReturnsAvailableArguments;
  * @author Christoph Böhme
  *
  */
-
 @Description("Writes objects to stdout or a file")
 @In(Object.class)
 @Out(Void.class)
@@ -49,7 +48,8 @@ public final class ObjectWriter<T> implements ConfigurableObjectWriter<T> {
     public ObjectWriter(final String destination) {
         if (STDOUT.equals(destination)) {
             objectWriter = new ObjectStdoutWriter<T>();
-        } else {
+        }
+        else {
             objectWriter = new ObjectFileWriter<T>(destination);
         }
     }
@@ -58,6 +58,7 @@ public final class ObjectWriter<T> implements ConfigurableObjectWriter<T> {
     public static Collection<String> getArguments() {
         return ARGUMENTS;
     }
+
     @Override
     public String getEncoding() {
         return objectWriter.getEncoding();
@@ -82,7 +83,6 @@ public final class ObjectWriter<T> implements ConfigurableObjectWriter<T> {
     public void setCompression(final String compression) {
         objectWriter.setCompression(compression);
     }
-
 
     @Override
     public String getHeader() {

--- a/metafacture-io/src/main/java/org/metafacture/io/OpenFailed.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/OpenFailed.java
@@ -2,15 +2,15 @@ package org.metafacture.io;
 
 public class OpenFailed extends IoFailed {
 
-    public OpenFailed(String message) {
+    public OpenFailed(final String message) {
         super(message);
     }
 
-    public OpenFailed(Throwable cause) {
+    public OpenFailed(final Throwable cause) {
         super(cause);
     }
 
-    public OpenFailed(String message, Throwable cause) {
+    public OpenFailed(final String message, final Throwable cause) {
         super(message, cause);
     }
 

--- a/metafacture-io/src/main/java/org/metafacture/io/RecordReader.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/RecordReader.java
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.io;
 
-import java.io.IOException;
-import java.io.Reader;
+package org.metafacture.io;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.MetafactureException;
@@ -25,6 +23,9 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
+
+import java.io.IOException;
+import java.io.Reader;
 
 /**
  * <p>Reads data from a {@code Reader} and splits it into individual
@@ -40,8 +41,7 @@ import org.metafacture.framework.helpers.DefaultObjectPipe;
 @In(Reader.class)
 @Out(String.class)
 @FluxCommand("as-records")
-public final class RecordReader extends
-        DefaultObjectPipe<Reader, ObjectReceiver<String>> {
+public final class RecordReader extends DefaultObjectPipe<Reader, ObjectReceiver<String>> {
 
     public static final char DEFAULT_SEPARATOR = '\u001d';
 
@@ -53,10 +53,14 @@ public final class RecordReader extends
     private char separator = DEFAULT_SEPARATOR;
     private boolean skipEmptyRecords = true;
 
+    public RecordReader() {
+    }
+
     public void setSeparator(final String separator) {
         if (separator.length() >= 1) {
             this.separator = separator.charAt(0);
-        } else {
+        }
+        else {
             this.separator = DEFAULT_SEPARATOR;
         }
     }
@@ -100,7 +104,8 @@ public final class RecordReader extends
                 emitRecord();
             }
 
-        } catch (final IOException e) {
+        }
+        catch (final IOException e) {
             throw new MetafactureException(e);
         }
     }

--- a/metafacture-io/src/main/java/org/metafacture/io/ResourceOpener.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/ResourceOpener.java
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.io;
 
-import java.io.Reader;
+package org.metafacture.io;
 
 import org.metafacture.commons.ResourceUtil;
 import org.metafacture.framework.FluxCommand;
@@ -26,7 +25,8 @@ import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
 
-
+import java.io.IOException;
+import java.io.Reader;
 
 /**
  * Opens a resource or file and passes a reader for it to the receiver.
@@ -38,10 +38,12 @@ import org.metafacture.framework.helpers.DefaultObjectPipe;
 @In(String.class)
 @Out(java.io.Reader.class)
 @FluxCommand("open-resource")
-public final class ResourceOpener
-        extends DefaultObjectPipe<String, ObjectReceiver<Reader>> {
+public final class ResourceOpener extends DefaultObjectPipe<String, ObjectReceiver<Reader>> {
 
     private String encoding = "UTF-8";
+
+    public ResourceOpener() {
+    }
 
     /**
      * Returns the encoding used to open the resource.
@@ -65,7 +67,8 @@ public final class ResourceOpener
     public void process(final String file) {
         try {
             getReceiver().process(ResourceUtil.getReader(file, encoding));
-        } catch (java.io.IOException e) {
+        }
+        catch (final IOException e) {
             throw new MetafactureException(e);
         }
     }

--- a/metafacture-io/src/main/java/org/metafacture/io/StdInOpener.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/StdInOpener.java
@@ -13,11 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.io;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
+package org.metafacture.io;
 
 import org.metafacture.framework.ObjectReceiver;
 import org.metafacture.framework.annotations.Description;
@@ -25,6 +22,9 @@ import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
 
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
 
 /**
  * Helper class to open stdin
@@ -37,17 +37,22 @@ import org.metafacture.framework.helpers.DefaultObjectPipe;
 @Out(java.io.Reader.class)
 public final class StdInOpener extends DefaultObjectPipe<Object, ObjectReceiver<java.io.Reader>> {
 
+    public StdInOpener() {
+    }
+
     @Override
     public void process(final Object notUsed) {
         if (notUsed == null) {
-            BufferedReader stdin;
+            final BufferedReader stdin;
             try {
                 stdin = new BufferedReader(new InputStreamReader(System.in, "UTF-8"));
-            } catch (UnsupportedEncodingException e) {
+            }
+            catch (final UnsupportedEncodingException e) {
                 throw new IllegalStateException("UTF-8 not supported", e);
             }
             getReceiver().process(stdin);
-        } else {
+        }
+        else {
             throw new IllegalArgumentException("Parameter not used. Must be null");
         }
     }

--- a/metafacture-io/src/main/java/org/metafacture/io/TarReader.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/TarReader.java
@@ -13,18 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.io;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.nio.charset.Charset;
-
-import org.apache.commons.compress.archivers.ArchiveEntry;
-import org.apache.commons.compress.archivers.ArchiveInputStream;
-import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
-import org.apache.commons.io.input.ReaderInputStream;
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.MetafactureException;
 import org.metafacture.framework.ObjectReceiver;
@@ -32,6 +23,17 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
+
+import org.apache.commons.compress.archivers.ArchiveEntry;
+import org.apache.commons.compress.archivers.ArchiveInputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.io.input.ReaderInputStream;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.Charset;
 
 /**
  * Opens (aka 'untar') a tar archive and passes every entry.
@@ -43,15 +45,16 @@ import org.metafacture.framework.helpers.DefaultObjectPipe;
 @In(Reader.class)
 @Out(Reader.class)
 @FluxCommand("open-tar")
-public class TarReader
-        extends DefaultObjectPipe<Reader, ObjectReceiver<Reader>> {
+public class TarReader extends DefaultObjectPipe<Reader, ObjectReceiver<Reader>> {
+
+    public TarReader() {
+    }
 
     @Override
     public void process(final Reader reader) {
         try (
-                InputStream stream = new ReaderInputStream(reader,
-                        Charset.defaultCharset());
-                ArchiveInputStream tarStream = new TarArchiveInputStream(stream);
+                InputStream stream = new ReaderInputStream(reader, Charset.defaultCharset());
+                ArchiveInputStream tarStream = new TarArchiveInputStream(stream)
         ) {
             ArchiveEntry entry;
             while ((entry = tarStream.getNextEntry()) != null) {
@@ -59,16 +62,16 @@ public class TarReader
                     processFileEntry(tarStream);
                 }
             }
-        } catch (IOException e) {
+        }
+        catch (final IOException e) {
             throw new MetafactureException(e);
         }
     }
 
-    private void processFileEntry(ArchiveInputStream archiveStream)
-            throws IOException {
+    private void processFileEntry(final ArchiveInputStream archiveStream) throws IOException {
         try (
                 InputStream entryStream = new ArchiveEntryInputStream(archiveStream);
-                Reader entryReader = new InputStreamReader(entryStream);
+                Reader entryReader = new InputStreamReader(entryStream)
         ) {
             getReceiver().process(entryReader);
         }
@@ -96,7 +99,7 @@ public class TarReader
 
         private final ArchiveInputStream archiveStream;
 
-        ArchiveEntryInputStream(ArchiveInputStream archiveStream) {
+        ArchiveEntryInputStream(final ArchiveInputStream archiveStream) {
             this.archiveStream = archiveStream;
         }
 
@@ -106,17 +109,17 @@ public class TarReader
         }
 
         @Override
-        public int read(byte[] b) throws IOException {
+        public int read(final byte[] b) throws IOException {
             return archiveStream.read(b);
         }
 
         @Override
-        public int read(byte[] b, int off, int len) throws IOException {
+        public int read(final byte[] b, final int off, final int len) throws IOException {
             return archiveStream.read(b, off, len);
         }
 
         @Override
-        public long skip(long n) throws IOException {
+        public long skip(final long n) throws IOException {
             return archiveStream.skip(n);
         }
 
@@ -131,7 +134,7 @@ public class TarReader
         }
 
         @Override
-        public void mark(int readlimit) {
+        public void mark(final int readlimit) {
             archiveStream.mark(readlimit);
         }
 

--- a/metafacture-io/src/main/java/org/metafacture/io/WriteFailed.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/WriteFailed.java
@@ -2,15 +2,15 @@ package org.metafacture.io;
 
 public class WriteFailed extends IoFailed {
 
-    public WriteFailed(String message) {
+    public WriteFailed(final String message) {
         super(message);
     }
 
-    public WriteFailed(Throwable cause) {
+    public WriteFailed(final Throwable cause) {
         super(cause);
     }
 
-    public WriteFailed(String message, Throwable cause) {
+    public WriteFailed(final String message, final Throwable cause) {
         super(message, cause);
     }
 

--- a/metafacture-io/src/test/java/org/metafacture/io/AbstractConfigurableObjectWriterTest.java
+++ b/metafacture-io/src/test/java/org/metafacture/io/AbstractConfigurableObjectWriterTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.io;
 
 import static org.junit.Assert.assertEquals;

--- a/metafacture-io/src/test/java/org/metafacture/io/FileOpenerCompressionTest.java
+++ b/metafacture-io/src/test/java/org/metafacture/io/FileOpenerCompressionTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.io;
 
 import static org.junit.Assert.assertEquals;

--- a/metafacture-io/src/test/java/org/metafacture/io/FileOpenerTest.java
+++ b/metafacture-io/src/test/java/org/metafacture/io/FileOpenerTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.io;
 
 import static org.junit.Assert.assertEquals;

--- a/metafacture-io/src/test/java/org/metafacture/io/ObjectFileWriterCompressionTest.java
+++ b/metafacture-io/src/test/java/org/metafacture/io/ObjectFileWriterCompressionTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.io;
 
 import static org.junit.Assert.assertArrayEquals;

--- a/metafacture-io/src/test/java/org/metafacture/io/ObjectFileWriterTest.java
+++ b/metafacture-io/src/test/java/org/metafacture/io/ObjectFileWriterTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.io;
 
 import static org.junit.Assert.assertArrayEquals;

--- a/metafacture-io/src/test/java/org/metafacture/io/ObjectStdoutWriterTest.java
+++ b/metafacture-io/src/test/java/org/metafacture/io/ObjectStdoutWriterTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.io;
 
 import java.io.ByteArrayOutputStream;

--- a/metafacture-io/src/test/java/org/metafacture/io/RecordReaderTest.java
+++ b/metafacture-io/src/test/java/org/metafacture/io/RecordReaderTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.io;
 
 import static org.mockito.Mockito.inOrder;

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/Collector.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/Collector.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration;
 
 import java.util.Collection;
@@ -25,7 +26,7 @@ import java.util.Collection;
  * @author Markus Michael Geipel
  *
  */
-public interface Collector <V> {
+public interface Collector<V> {
 
     Collection<V> getCollection();
 

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/EventList.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/EventList.java
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration;
+
+import org.metafacture.framework.StreamReceiver;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import org.metafacture.framework.StreamReceiver;
 
 /**
  * Stores the received stream events in a list.
@@ -32,6 +33,9 @@ public final class EventList implements StreamReceiver {
     private final List<Event> events = new ArrayList<Event>();
 
     private boolean closed;
+
+    public EventList() {
+    }
 
     public List<Event> getEvents() {
         return Collections.unmodifiableList(events);
@@ -131,7 +135,7 @@ public final class EventList implements StreamReceiver {
             final StringBuilder builder = new StringBuilder();
             builder.append(type);
             if (name != null) {
-                builder.append("(" );
+                builder.append("(");
                 builder.append(name);
                 if (value != null) {
                     builder.append("=");

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/MapToStream.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/MapToStream.java
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.javaintegration;
 
-import java.util.Map;
+package org.metafacture.javaintegration;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.StandardEventNames;
@@ -23,6 +22,8 @@ import org.metafacture.framework.StreamReceiver;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
+
+import java.util.Map;
 
 /**
  * Emits a {@link Map} as a record with a literal for each entry in the map.
@@ -59,10 +60,12 @@ import org.metafacture.framework.helpers.DefaultObjectPipe;
 @In(Map.class)
 @Out(StreamReceiver.class)
 @FluxCommand("map-to-stream")
-public final class MapToStream extends
-        DefaultObjectPipe<Map<?, ?>, StreamReceiver> {
+public final class MapToStream extends DefaultObjectPipe<Map<?, ?>, StreamReceiver> {
 
     private Object idKey = StandardEventNames.ID;
+
+    public MapToStream() {
+    }
 
     /**
      * Sets the key of the map entry that is used for the record id.
@@ -88,7 +91,8 @@ public final class MapToStream extends
         final Object id = map.get(idKey);
         if (id == null) {
             getReceiver().startRecord("");
-        } else {
+        }
+        else {
             getReceiver().startRecord(id.toString());
         }
         for (final Map.Entry<?, ?> entry: map.entrySet()) {

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/NamedValueList.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/NamedValueList.java
@@ -13,7 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration;
+
+import org.metafacture.commons.types.NamedValue;
+import org.metafacture.framework.helpers.DefaultStreamReceiver;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -21,29 +25,22 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 
-import org.metafacture.commons.types.NamedValue;
-import org.metafacture.framework.helpers.DefaultStreamReceiver;
-
-
 /**
  * Collects the received results in a {@link List}.
  *
  * @author Markus Michael Geipel
  *
  */
-public final class NamedValueList extends DefaultStreamReceiver
-        implements List<NamedValue>, Collector<List<NamedValue>> {
+public final class NamedValueList extends DefaultStreamReceiver implements List<NamedValue>, Collector<List<NamedValue>> {
 
     private Collection<List<NamedValue>> collection;
     private List<NamedValue> list;
 
     public NamedValueList() {
-        super();
         list = new ArrayList<NamedValue>();
     }
 
     public NamedValueList(final Collection<List<NamedValue>> collection) {
-        super();
         list = new ArrayList<NamedValue>();
         this.collection = collection;
     }
@@ -84,35 +81,43 @@ public final class NamedValueList extends DefaultStreamReceiver
     }
 
     @Override
+    public void add(final int index, final NamedValue element) {
+        list.add(index, element);
+    }
+
+    @Override
     public boolean remove(final Object object) {
         return list.remove(object);
     }
 
     @Override
-    public boolean containsAll(final Collection<?> collection) {
-        return list.containsAll(collection);
+    public NamedValue remove(final int index) {
+        return list.remove(index);
     }
 
     @Override
-    public boolean addAll(final Collection<? extends NamedValue> collection) {
-        return list.addAll(collection);
+    public boolean containsAll(final Collection<?> currentCollection) {
+        return list.containsAll(currentCollection);
     }
 
     @Override
-    public boolean addAll(final int index, final Collection<? extends NamedValue> collection) {
-        return list.addAll(index, collection);
+    public boolean addAll(final Collection<? extends NamedValue> currentCollection) {
+        return list.addAll(currentCollection);
     }
 
     @Override
-    public boolean removeAll(final Collection<?> collection) {
-
-        return list.removeAll(collection);
+    public boolean addAll(final int index, final Collection<? extends NamedValue> currentCollection) {
+        return list.addAll(index, currentCollection);
     }
 
     @Override
-    public boolean retainAll(final Collection<?> collection) {
+    public boolean removeAll(final Collection<?> currentCollection) {
+        return list.removeAll(currentCollection);
+    }
 
-        return list.retainAll(collection);
+    @Override
+    public boolean retainAll(final Collection<?> currentCollection) {
+        return list.retainAll(currentCollection);
     }
 
     @Override
@@ -128,16 +133,6 @@ public final class NamedValueList extends DefaultStreamReceiver
     @Override
     public NamedValue set(final int index, final NamedValue element) {
         return list.set(index, element);
-    }
-
-    @Override
-    public void add(final int index, final NamedValue element) {
-        list.add(index, element);
-    }
-
-    @Override
-    public NamedValue remove(final int index) {
-        return list.remove(index);
     }
 
     @Override
@@ -166,7 +161,7 @@ public final class NamedValueList extends DefaultStreamReceiver
     }
 
     @Override
-    public void startRecord(final String identifier){
+    public void startRecord(final String identifier) {
         list.clear();
     }
 

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/NamedValueSet.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/NamedValueSet.java
@@ -13,16 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration;
+
+import org.metafacture.commons.types.NamedValue;
+import org.metafacture.framework.helpers.DefaultStreamReceiver;
 
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
-
-import org.metafacture.commons.types.NamedValue;
-import org.metafacture.framework.helpers.DefaultStreamReceiver;
-
 
 /**
  * Collects {@link NamedValue}s in a {@link Set}. So there will not be
@@ -30,14 +30,12 @@ import org.metafacture.framework.helpers.DefaultStreamReceiver;
  *
  * @author Markus Michael Geipel
  */
-public final class NamedValueSet extends DefaultStreamReceiver
-        implements Set<NamedValue>, Collector<Set<NamedValue>> {
+public final class NamedValueSet extends DefaultStreamReceiver implements Set<NamedValue>, Collector<Set<NamedValue>> {
 
     private Collection<Set<NamedValue>> collection;
     private Set<NamedValue> set;
 
     public NamedValueSet() {
-        super();
         set = new HashSet<>();
         this.collection = null;
 
@@ -50,7 +48,6 @@ public final class NamedValueSet extends DefaultStreamReceiver
      * @param collection is filled with the received results.
      */
     public NamedValueSet(final Collection<Set<NamedValue>> collection) {
-        super();
         set = new HashSet<>();
         this.collection = collection;
     }

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/ObjectCollector.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/ObjectCollector.java
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration;
+
+import org.metafacture.framework.ObjectReceiver;
 
 import java.util.LinkedList;
 import java.util.Queue;
-
-import org.metafacture.framework.ObjectReceiver;
 
 /**
  * Collects the objects emitted by an upstream module.
@@ -40,7 +41,6 @@ public final class ObjectCollector<T> implements ObjectReceiver<T> {
     }
 
     public ObjectCollector(final int maxCapacity) {
-        super();
         this.maxCapacity = maxCapacity;
     }
 

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/SingleValue.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/SingleValue.java
@@ -13,32 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.javaintegration;
 
-import java.util.Collection;
+package org.metafacture.javaintegration;
 
 import org.metafacture.framework.helpers.DefaultStreamReceiver;
 
+import java.util.Collection;
 
 /**
  * just records the value of the last received literal.
  * @author Markus Michael Geipel
  *
  */
-public final class SingleValue extends DefaultStreamReceiver
-        implements Collector<String> {
+public final class SingleValue extends DefaultStreamReceiver implements Collector<String> {
 
     private boolean closed;
     private String value = "";
     private Collection<String> collection;
 
     public SingleValue() {
-        super();
         collection = null;
     }
 
     public SingleValue(final Collection<String> collection) {
-        super();
         this.collection = collection;
     }
 
@@ -72,9 +69,9 @@ public final class SingleValue extends DefaultStreamReceiver
     }
 
     @Override
-    public void literal(final String name, final String value) {
+    public void literal(final String name, final String newValue) {
         assert !closed;
-        this.setValue(value);
+        setValue(newValue);
     }
 
     @Override

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/StringListMap.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/StringListMap.java
@@ -13,16 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration;
+
+import org.metafacture.commons.types.ListMap;
+import org.metafacture.framework.helpers.DefaultStreamReceiver;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import org.metafacture.commons.types.ListMap;
-import org.metafacture.framework.helpers.DefaultStreamReceiver;
-
 
 /**
  * Collects the received results in a {@link ListMap}.
@@ -30,19 +30,16 @@ import org.metafacture.framework.helpers.DefaultStreamReceiver;
  * @author Markus Michael Geipel
  *
  */
-public final class StringListMap extends DefaultStreamReceiver
-        implements Collector<ListMap<String, String>>, Map<String, List<String>> {
+public final class StringListMap extends DefaultStreamReceiver implements Collector<ListMap<String, String>>, Map<String, List<String>> {
 
     private boolean closed;
     private Collection<ListMap<String, String>> collection;
     private ListMap<String, String> listMap = new ListMap<String, String>();
 
     public StringListMap() {
-        super();
     }
 
     public StringListMap(final Collection<ListMap<String, String>> collection) {
-        super();
         this.collection = collection;
     }
 
@@ -83,6 +80,11 @@ public final class StringListMap extends DefaultStreamReceiver
 
     public void putAll(final String name, final Collection<String> addValues) {
         listMap.putAll(name, addValues);
+    }
+
+    @Override
+    public void putAll(final Map<? extends String, ? extends List<String>> putMap) {
+        listMap.putAll(putMap);
     }
 
     @Override
@@ -144,11 +146,6 @@ public final class StringListMap extends DefaultStreamReceiver
     @Override
     public List<String> remove(final Object key) {
         return listMap.remove(key);
-    }
-
-    @Override
-    public void putAll(final Map<? extends String, ? extends List<String>> putMap) {
-        listMap.putAll(putMap);
     }
 
     @Override

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/StringListMapToStream.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/StringListMapToStream.java
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.javaintegration;
 
-import java.util.List;
-import java.util.Map.Entry;
+package org.metafacture.javaintegration;
 
 import org.metafacture.commons.types.ListMap;
 import org.metafacture.framework.FluxCommand;
@@ -25,6 +23,8 @@ import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
 
+import java.util.List;
+import java.util.Map.Entry;
 
 /**
  * Reads a {@link ListMap} and sends it to a {@link StreamReceiver}
@@ -35,21 +35,22 @@ import org.metafacture.framework.helpers.DefaultObjectPipe;
 @In(ListMap.class)
 @Out(StreamReceiver.class)
 @FluxCommand("string-list-map-to-stream")
-public final class StringListMapToStream
-        extends DefaultObjectPipe<ListMap<String, String>, StreamReceiver> {
+public final class StringListMapToStream extends DefaultObjectPipe<ListMap<String, String>, StreamReceiver> {
+
+    public StringListMapToStream() {
+    }
 
     @Override
-    public void process(final ListMap<String, String> listMap){
+    public void process(final ListMap<String, String> listMap) {
         assert !isClosed();
         process(listMap, getReceiver());
     }
 
     public static void process(final ListMap<String, String> listMap, final StreamReceiver receiver) {
-
         receiver.startRecord(listMap.getId());
-        for(Entry<String, List<String>> entry: listMap.entrySet()){
+        for (final Entry<String, List<String>> entry: listMap.entrySet()) {
             final String name = entry.getKey();
-            for(String value:entry.getValue()){
+            for (final String value:entry.getValue()) {
                 receiver.literal(name, value);
             }
         }

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/StringMap.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/StringMap.java
@@ -13,15 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration;
+
+import org.metafacture.framework.helpers.DefaultStreamReceiver;
 
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-
-import org.metafacture.framework.helpers.DefaultStreamReceiver;
-
 
 /**
  * Collects the received results in a {@link Map}. Duplicate names are thus lost.
@@ -29,30 +29,26 @@ import org.metafacture.framework.helpers.DefaultStreamReceiver;
  * @author Markus Michael Geipel
  *
  */
-public final class StringMap extends DefaultStreamReceiver
-        implements Map<String, String> , Collector<Map<String, String>>{
+public final class StringMap extends DefaultStreamReceiver implements Map<String, String>, Collector<Map<String, String>> {
 
     private boolean closed;
     private Collection<Map<String, String>> collection;
     private Map<String, String> map;
 
     public StringMap() {
-        super();
         map = new HashMap<String, String>();
-        collection=null;
+        collection = null;
     }
 
     public StringMap(final Collection<Map<String, String>> collection) {
-        super();
         map = new HashMap<String, String>();
-        this.collection=collection;
+        this.collection = collection;
     }
 
     /**
      * @param map is filled with the received results.
      */
     public StringMap(final Map<String, String> map) {
-        super();
         this.map = map;
     }
 

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/ValueSet.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/ValueSet.java
@@ -13,15 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration;
+
+import org.metafacture.framework.helpers.DefaultStreamReceiver;
 
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
-
-import org.metafacture.framework.helpers.DefaultStreamReceiver;
-
 
 /**
  * Collects {@link String}s in a {@link Set}.
@@ -29,14 +29,12 @@ import org.metafacture.framework.helpers.DefaultStreamReceiver;
  * @author Markus Michael Geipel
  *
  */
-public final class ValueSet extends DefaultStreamReceiver
-        implements Set<String>, Collector<Set<String>> {
+public final class ValueSet extends DefaultStreamReceiver implements Set<String>, Collector<Set<String>> {
 
     private Collection<Set<String>> collection;
     private Set<String> set;
 
     public ValueSet() {
-        super();
         set = new HashSet<>();
         this.collection = null;
 
@@ -49,7 +47,6 @@ public final class ValueSet extends DefaultStreamReceiver
      * @param collection is filled with the received results.
      */
     public ValueSet(final Collection<Set<String>> collection) {
-        super();
         set = new HashSet<>();
         this.collection = collection;
     }

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/ArrayTypeDecoder.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/ArrayTypeDecoder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration.pojo;
 
 import org.metafacture.framework.StreamReceiver;

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/CollectionTypeDecoder.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/CollectionTypeDecoder.java
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration.pojo;
 
-import java.util.Collection;
-
 import org.metafacture.framework.StreamReceiver;
+
+import java.util.Collection;
 
 /**
  * Decodes a {@link Collection} to a Metafacture event stream.
@@ -37,12 +38,10 @@ class CollectionTypeDecoder implements TypeDecoder {
     }
 
     @Override
-    public void decodeToStream(final StreamReceiver streamReceiver,
-            final String name, final Object object) {
+    public void decodeToStream(final StreamReceiver streamReceiver, final String name, final Object object) {
         final Collection<?> collection = (Collection<?>) object;
         for (final Object element : collection) {
-            final TypeDecoder typeDecoder = typeDecoderFactury
-                    .create(element.getClass());
+            final TypeDecoder typeDecoder = typeDecoderFactury.create(element.getClass());
             typeDecoder.decodeToStream(streamReceiver, name, element);
         }
     }

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/ComplexTypeDecoder.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/ComplexTypeDecoder.java
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration.pojo;
+
+import org.metafacture.framework.StreamReceiver;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
-
-import org.metafacture.framework.StreamReceiver;
 
 /**
  * Decodes a POJO to a Metafacture event stream.
@@ -32,15 +33,14 @@ class ComplexTypeDecoder implements TypeDecoder {
     private final TypeDecoderFactory typeDecoderFactory;
     private final List<ValueGetter> valueGetters;
 
-    ComplexTypeDecoder(final Class<?> clazz,
-            final TypeDecoderFactory typeDecoderFactory) {
+    ComplexTypeDecoder(final Class<?> clazz, final TypeDecoderFactory typeDecoderFactory) {
         this.typeDecoderFactory = typeDecoderFactory;
         valueGetters = new ArrayList<>();
         addFieldValueGettersFor(clazz);
         addMethodValueGettersFor(clazz);
     }
 
-    private void addFieldValueGettersFor(Class<?> clazz) {
+    private void addFieldValueGettersFor(final Class<?> clazz) {
         final Field[] fields = clazz.getDeclaredFields();
         for (final Field field : fields) {
             if (FieldValueGetter.supportsField(field)) {
@@ -49,7 +49,7 @@ class ComplexTypeDecoder implements TypeDecoder {
         }
     }
 
-    private void addMethodValueGettersFor(Class<?> clazz) {
+    private void addMethodValueGettersFor(final Class<?> clazz) {
         final Method[] methods = clazz.getDeclaredMethods();
         for (final Method method : methods) {
             if (MethodValueGetter.supportsMethod(method)) {
@@ -59,17 +59,15 @@ class ComplexTypeDecoder implements TypeDecoder {
     }
 
     static boolean supportsType(final Class<?> clazz) {
-        return !SimpleTypeDecoder.supportsType(clazz)
-                && !MetafactureSourceTypeDecoder.supportsType(clazz)
-                && !CollectionTypeDecoder.supportsType(clazz)
-                && !ArrayTypeDecoder.supportsType(clazz)
-                && !MapTypeDecoder.supportsType(clazz);
+        return !SimpleTypeDecoder.supportsType(clazz) && // checkstyle-disable-line BooleanExpressionComplexity
+            !MetafactureSourceTypeDecoder.supportsType(clazz) &&
+            !CollectionTypeDecoder.supportsType(clazz) &&
+            !ArrayTypeDecoder.supportsType(clazz) &&
+            !MapTypeDecoder.supportsType(clazz);
     }
 
     @Override
-    public void decodeToStream(final StreamReceiver streamReceiver,
-            final String name, final Object object) {
-
+    public void decodeToStream(final StreamReceiver streamReceiver, final String name, final Object object) {
         if (name != null) {
             streamReceiver.startEntity(name);
         }

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/ComplexTypeEncoder.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/ComplexTypeEncoder.java
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration.pojo;
+
+import org.metafacture.framework.MetafactureException;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
-
-import org.metafacture.framework.MetafactureException;
 
 /**
  * Encodes a Metafacture event stream to a POJO.
@@ -43,40 +44,36 @@ class ComplexTypeEncoder implements TypeEncoder {
     private static Object createInstance(final Class<?> clazz) {
         try {
             return clazz.newInstance();
-        } catch (final Exception e) {
-            throw new MetafactureException(
-                    "Can't instantiate object of class: " + clazz, e);
+        }
+        catch (final Exception e) { // checkstyle-disable-line IllegalCatch
+            throw new MetafactureException("Can't instantiate object of class: " + clazz, e);
         }
     }
 
-    private void addFieldValueSettersFor(Class<?> clazz) {
+    private void addFieldValueSettersFor(final Class<?> clazz) {
         final Field[] fields = clazz.getDeclaredFields();
         for (final Field field : fields) {
             if (FieldValueSetter.supportsField(field)) {
-                final FieldValueSetter fieldValueSetter = new FieldValueSetter(
-                        field);
-                valueSetters.put(fieldValueSetter.getName(),
-                        fieldValueSetter);
+                final FieldValueSetter fieldValueSetter = new FieldValueSetter(field);
+                valueSetters.put(fieldValueSetter.getName(), fieldValueSetter);
             }
         }
     }
 
-    private void addMethodValueSettersFor(Class<?> clazz) {
+    private void addMethodValueSettersFor(final Class<?> clazz) {
         final Method[] methods = clazz.getDeclaredMethods();
         for (final Method method : methods) {
             if (MethodValueSetter.supportsMethod(method)) {
-                final MethodValueSetter methodValueSetter = new MethodValueSetter(
-                        method);
-                valueSetters.put(methodValueSetter.getName(),
-                        methodValueSetter);
+                final MethodValueSetter methodValueSetter = new MethodValueSetter(method);
+                valueSetters.put(methodValueSetter.getName(), methodValueSetter);
             }
         }
     }
 
     static boolean supportsType(final Class<?> clazz) {
-        return !clazz.isPrimitive() && !clazz.equals(String.class)
-                && !MapTypeEncoder.supportsType(clazz)
-                && !ListTypeEncoder.supportsType(clazz);
+        return !clazz.isPrimitive() && !clazz.equals(String.class) &&
+            !MapTypeEncoder.supportsType(clazz) &&
+            !ListTypeEncoder.supportsType(clazz);
     }
 
     @Override

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/FieldValueGetter.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/FieldValueGetter.java
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration.pojo;
+
+import org.metafacture.framework.MetafactureException;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-
-import org.metafacture.framework.MetafactureException;
 
 /**
  * Retrieves a property of an object by reading a field.
@@ -42,13 +43,12 @@ class FieldValueGetter implements ValueGetter {
     public Object getValue(final Object object) {
         try {
             return field.get(object);
-        } catch (final IllegalArgumentException e) {
-            throw new MetafactureException(
-                    "The given object don't have a field named "
-                            + field.getName(), e);
-        } catch (final IllegalAccessException e) {
-            throw new MetafactureException("Can't access the field named "
-                    + field.getName(), e);
+        }
+        catch (final IllegalArgumentException e) {
+            throw new MetafactureException("The given object don't have a field named " + field.getName(), e);
+        }
+        catch (final IllegalAccessException e) {
+            throw new MetafactureException("Can't access the field named " + field.getName(), e);
         }
     }
 

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/FieldValueSetter.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/FieldValueSetter.java
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration.pojo;
+
+import org.metafacture.framework.MetafactureException;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-
-import org.metafacture.framework.MetafactureException;
 
 /**
  * Sets the value of a field. The field must be publicly accessible.
@@ -42,13 +43,12 @@ class FieldValueSetter implements ValueSetter {
     public void setValue(final Object object, final Object value) {
         try {
             field.set(object, value);
-        } catch (final IllegalArgumentException e) {
-            throw new MetafactureException(
-                    "The given object don't have a field named "
-                            + field.getName(), e);
-        } catch (final IllegalAccessException e) {
-            throw new MetafactureException("Can't access the field named "
-                    + field.getName(), e);
+        }
+        catch (final IllegalArgumentException e) {
+            throw new MetafactureException("The given object don't have a field named " + field.getName(), e);
+        }
+        catch (final IllegalAccessException e) {
+            throw new MetafactureException("Can't access the field named " + field.getName(), e);
         }
     }
 

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/ListTypeEncoder.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/ListTypeEncoder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration.pojo;
 
 import java.util.ArrayList;

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/MapTypeDecoder.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/MapTypeDecoder.java
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration.pojo;
 
-import java.util.Map;
-
 import org.metafacture.framework.StreamReceiver;
+
+import java.util.Map;
 
 /**
  * Decodes a {@link Map} to a Metafacture event stream.
@@ -37,8 +38,7 @@ class MapTypeDecoder implements TypeDecoder {
     }
 
     @Override
-    public void decodeToStream(final StreamReceiver streamReceiver,
-            final String name, final Object object) {
+    public void decodeToStream(final StreamReceiver streamReceiver, final String name, final Object object) {
         final Map<?, ?> map = (Map<?, ?>) object;
         if (name != null) {
             streamReceiver.startEntity(name);
@@ -46,8 +46,7 @@ class MapTypeDecoder implements TypeDecoder {
         for (final Map.Entry<?, ?> entry : map.entrySet()) {
             final String key = entry.getKey().toString();
             final Object value = entry.getValue();
-            final TypeDecoder typeDecoder = typeDecoderFactory.create(value
-                    .getClass());
+            final TypeDecoder typeDecoder = typeDecoderFactory.create(value.getClass());
             typeDecoder.decodeToStream(streamReceiver, key, value);
         }
         if (name != null) {

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/MapTypeEncoder.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/MapTypeEncoder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration.pojo;
 
 import java.util.HashMap;

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/MetafactureSource.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/MetafactureSource.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration.pojo;
 
 import org.metafacture.framework.StreamReceiver;
@@ -27,6 +28,6 @@ import org.metafacture.framework.StreamReceiver;
  */
 public interface MetafactureSource {
 
-    void sendToStream(final StreamReceiver streamReceiver);
+    void sendToStream(StreamReceiver streamReceiver);
 
 }

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/MetafactureSourceTypeDecoder.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/MetafactureSourceTypeDecoder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration.pojo;
 
 import org.metafacture.framework.StreamReceiver;
@@ -24,13 +25,15 @@ import org.metafacture.framework.StreamReceiver;
  */
 class MetafactureSourceTypeDecoder implements TypeDecoder {
 
+    MetafactureSourceTypeDecoder() {
+    }
+
     public static boolean supportsType(final Class<?> clazz) {
         return MetafactureSource.class.isAssignableFrom(clazz);
     }
 
     @Override
-    public void decodeToStream(final StreamReceiver streamReceiver,
-            final String name, final Object object) {
+    public void decodeToStream(final StreamReceiver streamReceiver, final String name, final Object object) {
         final MetafactureSource metafactureSource = (MetafactureSource) object;
         streamReceiver.startEntity(name);
         metafactureSource.sendToStream(streamReceiver);

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/MethodValueGetter.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/MethodValueGetter.java
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration.pojo;
+
+import org.metafacture.framework.MetafactureException;
 
 import java.beans.Introspector;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-
-import org.metafacture.framework.MetafactureException;
 
 /**
  * Retrieves a property of an object by calling a getter method.
@@ -38,30 +39,28 @@ class MethodValueGetter implements ValueGetter {
         assert supportsMethod(method);
         this.method = method;
         // remove prefix then lower case first character
-        name = Introspector.decapitalize(method.getName().substring(
-                METHOD_PREFIX.length()));
+        name = Introspector.decapitalize(method.getName().substring(METHOD_PREFIX.length()));
     }
 
     static boolean supportsMethod(final Method m) {
-        return Modifier.isPublic(m.getModifiers())
-                && m.getName().length() > METHOD_PREFIX.length()
-                && m.getName().startsWith(METHOD_PREFIX);
+        return Modifier.isPublic(m.getModifiers()) &&
+            m.getName().length() > METHOD_PREFIX.length() &&
+            m.getName().startsWith(METHOD_PREFIX);
     }
 
     @Override
     public Object getValue(final Object object) {
         try {
             return method.invoke(object);
-        } catch (final IllegalArgumentException e) {
-            throw new MetafactureException(
-                    "The given object don't have a method named "
-                            + method.getName(), e);
-        } catch (final IllegalAccessException e) {
-            throw new MetafactureException("Can't access the method named "
-                    + method.getName(), e);
-        } catch (final InvocationTargetException e) {
-            throw new MetafactureException("Invoking the method named "
-                    + method.getName() + " throws an excpetion", e);
+        }
+        catch (final IllegalArgumentException e) {
+            throw new MetafactureException("The given object don't have a method named " + method.getName(), e);
+        }
+        catch (final IllegalAccessException e) {
+            throw new MetafactureException("Can't access the method named " + method.getName(), e);
+        }
+        catch (final InvocationTargetException e) {
+            throw new MetafactureException("Invoking the method named " + method.getName() + " throws an excpetion", e);
         }
     }
 

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/MethodValueSetter.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/MethodValueSetter.java
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration.pojo;
+
+import org.metafacture.framework.MetafactureException;
 
 import java.beans.Introspector;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-
-import org.metafacture.framework.MetafactureException;
 
 /**
  * Invokes a setter method on an object. The method must be public, have exactly
@@ -44,26 +45,25 @@ class MethodValueSetter implements ValueSetter {
     }
 
     static boolean supportsMethod(final Method m) {
-        return Modifier.isPublic(m.getModifiers())
-                && m.getName().length() > METHOD_PREFIX.length()
-                && m.getName().startsWith(METHOD_PREFIX)
-                && m.getParameterTypes().length == 1;
+        return Modifier.isPublic(m.getModifiers()) &&
+            m.getName().length() > METHOD_PREFIX.length() &&
+            m.getName().startsWith(METHOD_PREFIX) &&
+            m.getParameterTypes().length == 1;
     }
 
     @Override
     public void setValue(final Object object, final Object value) {
         try {
             method.invoke(object, value);
-        } catch (final IllegalArgumentException e) {
-            throw new MetafactureException(
-                    "The given object don't have a method named "
-                            + method.getName(), e);
-        } catch (final IllegalAccessException e) {
-            throw new MetafactureException("Can't access the method named "
-                    + method.getName(), e);
-        } catch (final InvocationTargetException e) {
-            throw new MetafactureException("Invoking the method named "
-                    + method.getName() + " throws an excpetion", e);
+        }
+        catch (final IllegalArgumentException e) {
+            throw new MetafactureException("The given object don't have a method named " + method.getName(), e);
+        }
+        catch (final IllegalAccessException e) {
+            throw new MetafactureException("Can't access the method named " + method.getName(), e);
+        }
+        catch (final InvocationTargetException e) {
+            throw new MetafactureException("Invoking the method named " + method.getName() + " throws an excpetion", e);
         }
     }
 

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/PojoDecoder.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/PojoDecoder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration.pojo;
 
 import org.metafacture.framework.FluxCommand;
@@ -78,6 +79,9 @@ import org.metafacture.framework.helpers.DefaultObjectPipe;
 public class PojoDecoder<T> extends DefaultObjectPipe<T, StreamReceiver> {
 
     private final TypeDecoderFactory typeDecoderFactory = new TypeDecoderFactory();
+
+    public PojoDecoder() {
+    }
 
     @Override
     public void process(final T obj) {

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/PojoEncoder.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/PojoEncoder.java
@@ -13,12 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.javaintegration.pojo;
 
-import java.beans.PropertyEditor;
-import java.beans.PropertyEditorManager;
-import java.util.ArrayDeque;
-import java.util.Deque;
+package org.metafacture.javaintegration.pojo;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.ObjectReceiver;
@@ -27,6 +23,11 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultStreamPipe;
+
+import java.beans.PropertyEditor;
+import java.beans.PropertyEditorManager;
+import java.util.ArrayDeque;
+import java.util.Deque;
 
 /**
  * Creates and fills a new object instance with stream data and sends the result
@@ -44,12 +45,9 @@ public class PojoEncoder<T> extends DefaultStreamPipe<ObjectReceiver<T>> {
     static {
         // Initialize the property manager to map the primitive data types to
         // the corresponding object based types, e.g. int to Integer
-        PropertyEditorManager.registerEditor(Boolean.class,
-                PropertyEditorManager.findEditor(boolean.class).getClass());
-        PropertyEditorManager.registerEditor(Integer.class,
-                PropertyEditorManager.findEditor(int.class).getClass());
-        PropertyEditorManager.registerEditor(Long.class, PropertyEditorManager
-                .findEditor(long.class).getClass());
+        PropertyEditorManager.registerEditor(Boolean.class, PropertyEditorManager.findEditor(boolean.class).getClass());
+        PropertyEditorManager.registerEditor(Integer.class, PropertyEditorManager.findEditor(int.class).getClass());
+        PropertyEditorManager.registerEditor(Long.class, PropertyEditorManager.findEditor(long.class).getClass());
     }
 
     private final TypeEncoderFactory typeEncoderFactory = new TypeEncoderFactory();
@@ -92,16 +90,13 @@ public class PojoEncoder<T> extends DefaultStreamPipe<ObjectReceiver<T>> {
     @Override
     public void literal(final String name, final String value) {
         final TypeEncoder currentTypeEncoder = typeEncoderStack.peek();
-        final Class<?> targetType = currentTypeEncoder.getValueType(name)
-                .getRawClass();
-        currentTypeEncoder.setValue(name,
-                createObjectFromString(value, targetType));
+        final Class<?> targetType = currentTypeEncoder.getValueType(name).getRawClass();
+        currentTypeEncoder.setValue(name, createObjectFromString(value, targetType));
     }
 
     private static Object createObjectFromString(final String value,
             final Class<?> targetType) {
-        final PropertyEditor propertyEditor = PropertyEditorManager
-                .findEditor(targetType);
+        final PropertyEditor propertyEditor = PropertyEditorManager.findEditor(targetType);
         propertyEditor.setAsText(value);
         return propertyEditor.getValue();
     }

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/SimpleTypeDecoder.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/SimpleTypeDecoder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration.pojo;
 
 import org.metafacture.framework.StreamReceiver;
@@ -24,13 +25,15 @@ import org.metafacture.framework.StreamReceiver;
  */
 class SimpleTypeDecoder implements TypeDecoder {
 
+    SimpleTypeDecoder() {
+    }
+
     static boolean supportsType(final Class<?> clazz) {
         return clazz.isPrimitive() || clazz.equals(String.class);
     }
 
     @Override
-    public void decodeToStream(final StreamReceiver streamReceiver,
-            final String name, final Object object) {
+    public void decodeToStream(final StreamReceiver streamReceiver, final String name, final Object object) {
         streamReceiver.literal(name, object.toString());
     }
 

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/TypeDecoder.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/TypeDecoder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration.pojo;
 
 import org.metafacture.framework.StreamReceiver;
@@ -25,7 +26,6 @@ import org.metafacture.framework.StreamReceiver;
  */
 interface TypeDecoder {
 
-    void decodeToStream(final StreamReceiver streamReceiver, final String name,
-            final Object object);
+    void decodeToStream(StreamReceiver streamReceiver, String name, Object object);
 
 }

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/TypeDecoderFactory.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/TypeDecoderFactory.java
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration.pojo;
+
+import org.metafacture.framework.MetafactureException;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import org.metafacture.framework.MetafactureException;
 
 /**
  * Returns a decoder for a given class.
@@ -29,6 +30,9 @@ class TypeDecoderFactory {
 
     private final Map<Class<?>, TypeDecoder> typeDecoders = new HashMap<>();
 
+    TypeDecoderFactory() {
+    }
+
     TypeDecoder create(final Class<?> clazz) {
         if (typeDecoders.containsKey(clazz)) {
             return typeDecoders.get(clazz);
@@ -36,17 +40,23 @@ class TypeDecoderFactory {
         final TypeDecoder typeDecoder;
         if (SimpleTypeDecoder.supportsType(clazz)) {
             typeDecoder = new SimpleTypeDecoder();
-        } else if (MetafactureSourceTypeDecoder.supportsType(clazz)) {
+        }
+        else if (MetafactureSourceTypeDecoder.supportsType(clazz)) {
             typeDecoder = new MetafactureSourceTypeDecoder();
-        } else if (CollectionTypeDecoder.supportsType(clazz)) {
+        }
+        else if (CollectionTypeDecoder.supportsType(clazz)) {
             typeDecoder = new CollectionTypeDecoder(this);
-        } else if (ArrayTypeDecoder.supportsType(clazz)) {
+        }
+        else if (ArrayTypeDecoder.supportsType(clazz)) {
             typeDecoder = new ArrayTypeDecoder(this);
-        } else if (ComplexTypeDecoder.supportsType(clazz)) {
+        }
+        else if (ComplexTypeDecoder.supportsType(clazz)) {
             typeDecoder = new ComplexTypeDecoder(clazz, this);
-        } else if (MapTypeDecoder.supportsType(clazz)) {
+        }
+        else if (MapTypeDecoder.supportsType(clazz)) {
             typeDecoder = new MapTypeDecoder(this);
-        } else {
+        }
+        else {
             throw new MetafactureException("Can't decode type " + clazz);
         }
         typeDecoders.put(clazz, typeDecoder);

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/TypeEncoder.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/TypeEncoder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration.pojo;
 
 /**

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/TypeEncoderFactory.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/TypeEncoderFactory.java
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration.pojo;
+
+import org.metafacture.framework.MetafactureException;
 
 import java.util.List;
 import java.util.Map;
-
-import org.metafacture.framework.MetafactureException;
 
 /**
  * Returns {@link TypeEncoder}s for POJOs, {@link Map}s and {@link List}s.
@@ -27,16 +28,22 @@ import org.metafacture.framework.MetafactureException;
  */
 class TypeEncoderFactory {
 
+    TypeEncoderFactory() {
+    }
+
     TypeEncoder create(final ValueType valueType) {
         final TypeEncoder typeEncoder;
         final Class<?> rawClass = valueType.getRawClass();
         if (MapTypeEncoder.supportsType(rawClass)) {
             typeEncoder = new MapTypeEncoder(valueType);
-        } else if (ListTypeEncoder.supportsType(rawClass)) {
+        }
+        else if (ListTypeEncoder.supportsType(rawClass)) {
             typeEncoder = new ListTypeEncoder(valueType);
-        } else if (ComplexTypeEncoder.supportsType(rawClass)) {
+        }
+        else if (ComplexTypeEncoder.supportsType(rawClass)) {
             typeEncoder = new ComplexTypeEncoder(rawClass);
-        } else {
+        }
+        else {
             throw new MetafactureException("Can't encode type " + rawClass);
         }
         return typeEncoder;

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/ValueGetter.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/ValueGetter.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration.pojo;
 
 /**
@@ -24,7 +25,7 @@ package org.metafacture.javaintegration.pojo;
  */
 interface ValueGetter {
 
-    Object getValue(final Object object);
+    Object getValue(Object object);
 
     String getName();
 

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/ValueSetter.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/ValueSetter.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration.pojo;
 
 /**
@@ -23,7 +24,7 @@ package org.metafacture.javaintegration.pojo;
  */
 interface ValueSetter {
 
-    void setValue(final Object object, final Object value);
+    void setValue(Object object, Object value);
 
     String getName();
 

--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/ValueType.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/ValueType.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration.pojo;
 
 import java.lang.reflect.ParameterizedType;
@@ -41,10 +42,12 @@ class ValueType {
                     .getActualTypeArguments();
             if (Map.class.isAssignableFrom(clazz)) {
                 elementClass = (Class<?>) actualTypeArguments[1];
-            } else {
+            }
+            else {
                 elementClass = (Class<?>) actualTypeArguments[0];
             }
-        } else {
+        }
+        else {
             elementClass = null;
         }
     }

--- a/metafacture-javaintegration/src/test/java/org/metafacture/javaintegration/MapToStreamTest.java
+++ b/metafacture-javaintegration/src/test/java/org/metafacture/javaintegration/MapToStreamTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration;
 
 import static org.mockito.Mockito.inOrder;

--- a/metafacture-javaintegration/src/test/java/org/metafacture/javaintegration/pojo/PojoDecoderTest.java
+++ b/metafacture-javaintegration/src/test/java/org/metafacture/javaintegration/pojo/PojoDecoderTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration.pojo;
 
 import static org.junit.Assert.assertEquals;

--- a/metafacture-javaintegration/src/test/java/org/metafacture/javaintegration/pojo/PojoEncoderTest.java
+++ b/metafacture-javaintegration/src/test/java/org/metafacture/javaintegration/pojo/PojoEncoderTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.javaintegration.pojo;
 
 import static org.junit.Assert.assertEquals;

--- a/metafacture-jdom/src/main/java/org/metafacture/jdom/JDomDocumentToStream.java
+++ b/metafacture-jdom/src/main/java/org/metafacture/jdom/JDomDocumentToStream.java
@@ -13,17 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.jdom;
 
-import org.jdom2.Document;
-import org.jdom2.JDOMException;
-import org.jdom2.output.SAXOutputter;
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.ObjectPipe;
 import org.metafacture.framework.StreamReceiver;
 import org.metafacture.framework.XmlPipe;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
+
+import org.jdom2.Document;
+import org.jdom2.JDOMException;
+import org.jdom2.output.SAXOutputter;
 
 /**
  * Converts a {@link Document} to a stream.
@@ -46,10 +48,11 @@ public final class JDomDocumentToStream
 
     @Override
     public void process(final Document document) {
-        assert null!=document;
+        assert null != document;
         try {
             saxOutputer.output(document);
-        } catch (JDOMException e) {
+        }
+        catch (final JDOMException e) {
             throw new IllegalArgumentException("Invalid JDOM document", e);
         }
     }

--- a/metafacture-jdom/src/main/java/org/metafacture/jdom/StreamToJDomDocument.java
+++ b/metafacture-jdom/src/main/java/org/metafacture/jdom/StreamToJDomDocument.java
@@ -13,18 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.jdom;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Properties;
-import java.util.regex.Pattern;
-
-import org.jdom2.Document;
-import org.jdom2.Element;
-import org.jdom2.Namespace;
 import org.metafacture.commons.ResourceUtil;
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.MetafactureException;
@@ -34,6 +25,17 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultStreamPipe;
+
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.Namespace;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map.Entry;
+import java.util.Map;
+import java.util.Properties;
+import java.util.regex.Pattern;
 
 /**
  * Converts a stream into a {@link Document}.
@@ -54,7 +56,7 @@ public final class StreamToJDomDocument
     private Document document;
     private Element currentElement;
     private final String rootTagName;
-    private final Map<String, Namespace> namespaces = new HashMap<String,Namespace>();
+    private final Map<String, Namespace> namespaces = new HashMap<String, Namespace>();
 
     public StreamToJDomDocument(final String rootTagName, final String namespaceProperties) {
         this.rootTagName = rootTagName;
@@ -62,25 +64,24 @@ public final class StreamToJDomDocument
         final Properties properties;
         try {
             properties = ResourceUtil.loadProperties(namespaceProperties);
-        } catch (IOException e) {
+        }
+        catch (final IOException e) {
             throw new MetafactureException("Cannot load namespaces list", e);
         }
-        for (Entry<Object, Object> entry : properties.entrySet()) {
+        for (final Entry<Object, Object> entry : properties.entrySet()) {
             namespaces.put(entry.getKey().toString(), Namespace.getNamespace(entry.getKey().toString(), entry.getValue().toString()));
         }
     }
-
 
     @Override
     public void startRecord(final String identifier) {
         assert !isClosed();
         currentElement = createElement(rootTagName);
-        for (Namespace namespace : namespaces.values()) {
+        for (final Namespace namespace : namespaces.values()) {
             currentElement.addNamespaceDeclaration(namespace);
         }
         document = new Document(currentElement);
     }
-
 
     @Override
     public void startEntity(final String name) {
@@ -98,14 +99,13 @@ public final class StreamToJDomDocument
         return new Element(name);
     }
 
-    private Namespace getNamespace(final String name){
+    private Namespace getNamespace(final String name) {
         final Namespace namespace = namespaces.get(name);
-        if(namespace==null){
+        if (namespace == null) {
             throw new IllegalArgumentException("Namespace " + name + " not registered");
         }
         return namespace;
     }
-
 
     @Override
     public void endEntity() {
@@ -113,21 +113,23 @@ public final class StreamToJDomDocument
         currentElement = currentElement.getParentElement();
     }
 
-
     @Override
     public void literal(final String name, final String value) {
         assert !isClosed();
         if (name.isEmpty()) {
             currentElement.addContent(value);
-        } else if (name.startsWith(ATTRIBUTE_MARKER)) {
+        }
+        else if (name.startsWith(ATTRIBUTE_MARKER)) {
             final String[] parts = NAMESPACE_DELIMITER.split(name);
             if (parts.length == 2) {
                 currentElement.setAttribute(parts[1], value, getNamespace(parts[0].substring(1)));
-            } else{
+            }
+            else {
                 currentElement.setAttribute(name.substring(1), value);
             }
 
-        } else {
+        }
+        else {
             final Element temp = createElement(name);
             currentElement.addContent(temp);
             temp.setText(value);

--- a/metafacture-json/src/main/java/org/metafacture/json/JsonDecoder.java
+++ b/metafacture-json/src/main/java/org/metafacture/json/JsonDecoder.java
@@ -13,14 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.json;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.jayway.jsonpath.JsonPath;
+package org.metafacture.json;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.MetafactureException;
@@ -29,6 +23,13 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -41,8 +42,8 @@ import java.util.stream.Stream;
  * @author Jens Wille
  *
  */
-@Description("Decodes JSON to metadata events. The \'recordPath\' option can be used to set a JsonPath "
-        + "to extract a path as JSON - or to split the data into multiple JSON documents.")
+@Description("Decodes JSON to metadata events. The \'recordPath\' option can be used to set a JsonPath " +
+    "to extract a path as JSON - or to split the data into multiple JSON documents.")
 @In(String.class)
 @Out(StreamReceiver.class)
 @FluxCommand("decode-json")
@@ -67,8 +68,6 @@ public final class JsonDecoder extends DefaultObjectPipe<String, StreamReceiver>
     private String recordPath;
 
     public JsonDecoder() {
-        super();
-
         setArrayMarker(DEFAULT_ARRAY_MARKER);
         setArrayName(DEFAULT_ARRAY_NAME);
         setRecordId(DEFAULT_RECORD_ID);
@@ -134,30 +133,34 @@ public final class JsonDecoder extends DefaultObjectPipe<String, StreamReceiver>
         assert !isClosed();
         if (recordPath.isEmpty()) {
             processRecord(json);
-        } else {
+        }
+        else {
             matches(JsonPath.read(json, recordPath)).forEach(record -> {
                 processRecord(record);
             });
         }
     }
 
-    private void processRecord(String record) {
+    private void processRecord(final String record) {
         createParser(record);
         try {
             decode();
-        } catch (final IOException e) {
+        }
+        catch (final IOException e) {
             throw new MetafactureException(e);
-        } finally {
+        }
+        finally {
             closeParser();
         }
     }
 
-    private Stream<String> matches(Object obj) {
+    private Stream<String> matches(final Object obj) {
         final List<?> records = (obj instanceof List<?>) ? ((List<?>) obj) : Arrays.asList(obj);
         return records.stream().map(doc -> {
             try {
                 return new ObjectMapper().writeValueAsString(doc);
-            } catch (JsonProcessingException e) {
+            }
+            catch (final JsonProcessingException e) {
                 e.printStackTrace();
                 return doc.toString();
             }

--- a/metafacture-json/src/test/java/org/metafacture/json/JsonDecoderTest.java
+++ b/metafacture-json/src/test/java/org/metafacture/json/JsonDecoderTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.json;
 
 import static org.mockito.Mockito.inOrder;

--- a/metafacture-json/src/test/java/org/metafacture/json/JsonEncoderTest.java
+++ b/metafacture-json/src/test/java/org/metafacture/json/JsonEncoderTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.json;
 
 import static org.mockito.Mockito.inOrder;

--- a/metafacture-linkeddata/src/main/java/org/metafacture/linkeddata/BeaconReader.java
+++ b/metafacture-linkeddata/src/main/java/org/metafacture/linkeddata/BeaconReader.java
@@ -13,15 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.linkeddata;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.Reader;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+package org.metafacture.linkeddata;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.MetafactureException;
@@ -30,6 +23,14 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Reads BEACON format
@@ -56,6 +57,9 @@ public final class BeaconReader extends DefaultObjectPipe<java.io.Reader, Stream
     private Pattern metaDataFilter = Pattern.compile(".*");
     private String relation = DEFAULT_RELATION;
 
+    public BeaconReader() {
+    }
+
     /**
      * @param bufferSize
      *            in MB
@@ -72,7 +76,7 @@ public final class BeaconReader extends DefaultObjectPipe<java.io.Reader, Stream
         this.metaDataFilter = Pattern.compile(metaDataFilter);
     }
 
-    @Override
+    @Override // checkstyle-disable-line CyclomaticComplexity|ExecutableStatementCount
     public void process(final Reader reader) {
         final BufferedReader bReader = new BufferedReader(reader, bufferSize);
         final Map<String, String> institution = new HashMap<String, String>();
@@ -92,16 +96,19 @@ public final class BeaconReader extends DefaultObjectPipe<java.io.Reader, Stream
                             final String value = line.substring(splitPoint + 1).trim();
                             if (TARGET.equals(key)) {
                                 target = value;
-                            } else if (metaDataFilter.matcher(key).find()) {
+                            }
+                            else if (metaDataFilter.matcher(key).find()) {
                                 institution.put(key, value);
                             }
                         }
-                    } else {
+                    }
+                    else {
                         final String[] parts = line.split("\\|");
                         final String url;
                         if (parts.length == COLUMNS_EXTENDED_BEACON) {
                             url = parts[2];
-                        } else {
+                        }
+                        else {
                             if (target == null || target.isEmpty()) {
                                 throw new MetafactureException("Error in BEACON file: target missing");
                             }
@@ -111,7 +118,7 @@ public final class BeaconReader extends DefaultObjectPipe<java.io.Reader, Stream
                         receiver.startRecord(parts[0]);
                         receiver.startEntity(relation);
                         receiver.literal("url", url);
-                        for (Map.Entry<String, String> instEntry : institution.entrySet()) {
+                        for (final Map.Entry<String, String> instEntry : institution.entrySet()) {
                             receiver.literal(instEntry.getKey(), instEntry.getValue());
                         }
                         receiver.endEntity();
@@ -122,7 +129,8 @@ public final class BeaconReader extends DefaultObjectPipe<java.io.Reader, Stream
             }
             bReader.close();
 
-        } catch (IOException e) {
+        }
+        catch (final IOException e) {
             throw new MetafactureException("Error reading BEACON format", e);
         }
     }

--- a/metafacture-linkeddata/src/main/java/org/metafacture/linkeddata/OreAggregationAdder.java
+++ b/metafacture-linkeddata/src/main/java/org/metafacture/linkeddata/OreAggregationAdder.java
@@ -13,15 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.linkeddata;
 
-import java.io.IOException;
-import java.util.Deque;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map.Entry;
-import java.util.Properties;
-import java.util.regex.Pattern;
+package org.metafacture.linkeddata;
 
 import org.metafacture.commons.ResourceUtil;
 import org.metafacture.commons.types.ListMap;
@@ -33,7 +26,13 @@ import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultStreamPipe;
 
-
+import java.io.IOException;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.regex.Pattern;
 
 /**
  * Adds ore:Aggregation to an Europeana Data Model stream. The aggregation id is
@@ -63,16 +62,20 @@ public final class OreAggregationAdder extends DefaultStreamPipe<StreamReceiver>
         final Properties properties;
         try {
             properties = ResourceUtil.loadProperties(ORE_AGGREGATION_PROPERTIES);
-        } catch (IOException e) {
+        }
+        catch (final IOException e) {
             throw new MetafactureException("Failed to load properties", e);
         }
-        for (Entry<Object, Object> entry : properties.entrySet()) {
+        for (final Entry<Object, Object> entry : properties.entrySet()) {
             final String[] parts = SPLIT_PATTERN.split(entry.getValue().toString());
             final String name = entry.getKey().toString();
-            for (String value : parts) {
+            for (final String value : parts) {
                 AGGREGATED_ENTITIES.add(name, value);
             }
         }
+    }
+
+    public OreAggregationAdder() {
     }
 
     @Override
@@ -94,19 +97,20 @@ public final class OreAggregationAdder extends DefaultStreamPipe<StreamReceiver>
             final StreamReceiver receiver = getReceiver();
             receiver.startEntity(ORE_AGGREGATION);
             receiver.literal(RDF_ABOUT, aggregationId);
-            for (Entry<String, List<String>> entry : aggregation.entrySet()) {
+            for (final Entry<String, List<String>> entry : aggregation.entrySet()) {
                 final String key = entry.getKey();
                 if (AGGREGATED_ENTITIES.containsKey(key)) {
 
-                    for (String entity : AGGREGATED_ENTITIES.get(key)) {
-                        for (String value : entry.getValue()) {
+                    for (final String entity : AGGREGATED_ENTITIES.get(key)) {
+                        for (final String value : entry.getValue()) {
                             receiver.startEntity(entity);
                             receiver.literal(RDF_REFERENCE, value);
                             receiver.endEntity();
                         }
                     }
-                } else {
-                    for (String value : entry.getValue()) {
+                }
+                else {
+                    for (final String value : entry.getValue()) {
                         receiver.literal(key, value);
                     }
                 }
@@ -132,13 +136,14 @@ public final class OreAggregationAdder extends DefaultStreamPipe<StreamReceiver>
         if (entityStack.isEmpty()) {
             if (AGGREGATION_ID.equals(name)) {
                 aggregationId = value;
-            } else {
+            }
+            else {
                 aggregation.add(name, value);
             }
             return;
         }
 
-        if (entityStack.size()==1 && RDF_ABOUT.equals(name) && AGGREGATED_ENTITIES.containsKey(entityStack.peek())) {
+        if (entityStack.size() == 1 && RDF_ABOUT.equals(name) && AGGREGATED_ENTITIES.containsKey(entityStack.peek())) {
             aggregation.add(entityStack.peek(), value);
         }
         getReceiver().literal(name, value);

--- a/metafacture-linkeddata/src/main/java/org/metafacture/linkeddata/RdfMacroPipe.java
+++ b/metafacture-linkeddata/src/main/java/org/metafacture/linkeddata/RdfMacroPipe.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.linkeddata;
 
 import org.metafacture.framework.FluxCommand;
@@ -34,7 +35,6 @@ import org.metafacture.framework.helpers.DefaultStreamPipe;
 @FluxCommand("rdf-macros")
 public final class RdfMacroPipe extends DefaultStreamPipe<StreamReceiver> {
 
-
     public static final char REFERENCE_MARKER = '*';
     public static final char LANGUAGE_MARKER = '$';
     public static final String RDF_REFERENCE = "~rdf:resource";
@@ -42,15 +42,17 @@ public final class RdfMacroPipe extends DefaultStreamPipe<StreamReceiver> {
     public static final String XML_LANG = "~xml:lang";
     private String autoAddedSubject = "";
 
+    public RdfMacroPipe() {
+    }
+
     public void setAutoAddedSubject(final String autoAddedSubject) {
         this.autoAddedSubject = autoAddedSubject;
     }
 
-
     @Override
     public void startRecord(final String identifier) {
         getReceiver().startRecord(identifier);
-        if(!autoAddedSubject.isEmpty()){
+        if (!autoAddedSubject.isEmpty()) {
             getReceiver().startEntity(autoAddedSubject);
             getReceiver().literal(RDF_ABOUT, identifier);
         }
@@ -58,7 +60,7 @@ public final class RdfMacroPipe extends DefaultStreamPipe<StreamReceiver> {
 
     @Override
     public void endRecord() {
-        if(!autoAddedSubject.isEmpty()){
+        if (!autoAddedSubject.isEmpty()) {
             getReceiver().endEntity();
         }
         getReceiver().endRecord();
@@ -82,12 +84,14 @@ public final class RdfMacroPipe extends DefaultStreamPipe<StreamReceiver> {
             getReceiver().startEntity(name.substring(1));
             getReceiver().literal(RDF_REFERENCE, value);
             getReceiver().endEntity();
-        } else if (index > 0) {
+        }
+        else if (index > 0) {
             getReceiver().startEntity(name.substring(0, index));
             getReceiver().literal(XML_LANG, name.substring(index + 1));
             getReceiver().literal("", value);
             getReceiver().endEntity();
-        } else {
+        }
+        else {
             getReceiver().literal(name, value);
         }
     }

--- a/metafacture-linkeddata/src/test/java/org/metafacture/linkeddata/OreAggregationAdderTest.java
+++ b/metafacture-linkeddata/src/test/java/org/metafacture/linkeddata/OreAggregationAdderTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.linkeddata;
 
 import static org.mockito.Mockito.inOrder;

--- a/metafacture-mangling/src/main/java/org/metafacture/mangling/DuplicateObjectFilter.java
+++ b/metafacture-mangling/src/main/java/org/metafacture/mangling/DuplicateObjectFilter.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.mangling;
 
 import org.metafacture.framework.FluxCommand;
@@ -34,10 +35,12 @@ import org.metafacture.framework.helpers.DefaultObjectPipe;
 @In(Object.class)
 @Out(Object.class)
 @FluxCommand("filter-duplicate-objects")
-public final class DuplicateObjectFilter<T> extends
-        DefaultObjectPipe<T, ObjectReceiver<T>> {
+public final class DuplicateObjectFilter<T> extends DefaultObjectPipe<T, ObjectReceiver<T>> {
 
     private T lastObj;
+
+    public DuplicateObjectFilter() {
+    }
 
     @Override
     public void process(final T obj) {

--- a/metafacture-mangling/src/main/java/org/metafacture/mangling/EntityPathTracker.java
+++ b/metafacture-mangling/src/main/java/org/metafacture/mangling/EntityPathTracker.java
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.mangling;
+
+import org.metafacture.framework.helpers.DefaultStreamReceiver;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
-
-import org.metafacture.framework.helpers.DefaultStreamReceiver;
 
 /**
  * Tracks the <i>path</i> of the current entity. The entity path consists of the
@@ -45,6 +46,9 @@ public class EntityPathTracker extends DefaultStreamReceiver {
     private final StringBuilder currentPath = new StringBuilder();
 
     private String entitySeparator = DEFAULT_ENTITY_SEPARATOR;
+
+    public EntityPathTracker() {
+    }
 
     /**
      * Returns the current entity path.

--- a/metafacture-mangling/src/main/java/org/metafacture/mangling/LiteralToObject.java
+++ b/metafacture-mangling/src/main/java/org/metafacture/mangling/LiteralToObject.java
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.mangling;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+package org.metafacture.mangling;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.ObjectReceiver;
@@ -25,6 +23,9 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultStreamPipe;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Emits the values of literals matching {@literal #setPattern(String)}
@@ -48,6 +49,9 @@ public final class LiteralToObject extends DefaultStreamPipe<ObjectReceiver<Stri
     public static final java.lang.String DEFAULT_PATTERN = ".*";
 
     private Matcher matcher = Pattern.compile(DEFAULT_PATTERN).matcher("");
+
+    public LiteralToObject() {
+    }
 
     /**
      * Sets the pattern against which literal names are matched. Only the

--- a/metafacture-mangling/src/main/java/org/metafacture/mangling/NullFilter.java
+++ b/metafacture-mangling/src/main/java/org/metafacture/mangling/NullFilter.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.mangling;
 
 import org.metafacture.framework.FluxCommand;
@@ -35,7 +36,10 @@ import org.metafacture.framework.helpers.ForwardingStreamPipe;
 @FluxCommand("filter-null-values")
 public final class NullFilter extends ForwardingStreamPipe {
 
-    private String replacement = null;
+    private String replacement;
+
+    public NullFilter() {
+    }
 
     public void setReplacement(final String replacement) {
         this.replacement = replacement;
@@ -49,7 +53,8 @@ public final class NullFilter extends ForwardingStreamPipe {
     public void literal(final String name, final String value) {
         if (value != null) {
             getReceiver().literal(name, value);
-        } else if (replacement != null) {
+        }
+        else if (replacement != null) {
             getReceiver().literal(name, replacement);
         }
     }

--- a/metafacture-mangling/src/main/java/org/metafacture/mangling/ObjectToLiteral.java
+++ b/metafacture-mangling/src/main/java/org/metafacture/mangling/ObjectToLiteral.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.mangling;
 
 import org.metafacture.framework.FluxCommand;
@@ -41,10 +42,9 @@ public final class ObjectToLiteral<T> extends
     private int recordCount;
 
     public ObjectToLiteral() {
-        super();
         setLiteralName(DEFAULT_LITERAL_NAME);
         setRecordId(DEFAULT_RECORD_ID);
-        recordCount=0;
+        recordCount = 0;
     }
 
     public void setLiteralName(final String literalName) {
@@ -65,7 +65,7 @@ public final class ObjectToLiteral<T> extends
 
     @Override
     public void process(final T obj) {
-        assert obj!=null;
+        assert obj != null;
         assert !isClosed();
         getReceiver().startRecord(String.format(recordId, ++recordCount));
         getReceiver().literal(literalName, obj.toString());

--- a/metafacture-mangling/src/main/java/org/metafacture/mangling/RecordIdChanger.java
+++ b/metafacture-mangling/src/main/java/org/metafacture/mangling/RecordIdChanger.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.mangling;
 
 import org.metafacture.flowcontrol.StreamBuffer;
@@ -77,6 +78,9 @@ public final class RecordIdChanger extends DefaultStreamPipe<StreamReceiver> {
     private String originalIdentifier;
     private boolean keepRecordsWithoutIdLiteral = true;
     private boolean keepIdLiteral;
+
+    public RecordIdChanger() {
+    }
 
     /**
      * Sets the name of the literal that contains the new record id. This must be
@@ -158,7 +162,8 @@ public final class RecordIdChanger extends DefaultStreamPipe<StreamReceiver> {
         if (currentIdentifier != null || keepRecordsWithoutIdLiteral) {
             if (currentIdentifier == null) {
                 getReceiver().startRecord(originalIdentifier);
-            } else {
+            }
+            else {
                 getReceiver().startRecord(currentIdentifier);
             }
             streamBuffer.replay();

--- a/metafacture-mangling/src/main/java/org/metafacture/mangling/RecordPathFilter.java
+++ b/metafacture-mangling/src/main/java/org/metafacture/mangling/RecordPathFilter.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.mangling;
 
 import org.metafacture.framework.FluxCommand;
@@ -49,7 +50,6 @@ public final class RecordPathFilter extends DefaultStreamPipe<StreamReceiver> {
     }
 
     public RecordPathFilter(final String path) {
-        super();
         resetRecord();
         setPath(path);
         setRecordIdFormat(DEFAULT_RECORD_ID_FORMAT);

--- a/metafacture-mangling/src/main/java/org/metafacture/mangling/RecordToEntity.java
+++ b/metafacture-mangling/src/main/java/org/metafacture/mangling/RecordToEntity.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.mangling;
 
 import org.metafacture.framework.FluxCommand;
@@ -46,6 +47,9 @@ public class RecordToEntity extends ForwardingStreamPipe {
 
     private String entityName = DEFAULT_ENTITY_NAME;
     private String idLiteralName;
+
+    public RecordToEntity() {
+    }
 
     public String getEntityName() {
         return entityName;

--- a/metafacture-mangling/src/main/java/org/metafacture/mangling/StreamEventDiscarder.java
+++ b/metafacture-mangling/src/main/java/org/metafacture/mangling/StreamEventDiscarder.java
@@ -13,15 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.mangling;
 
-import java.util.EnumSet;
+package org.metafacture.mangling;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.StreamPipe;
 import org.metafacture.framework.StreamReceiver;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
+
+import java.util.EnumSet;
 
 /**
  * Discards stream events by type. The type of a stream event is either
@@ -48,10 +49,13 @@ public class StreamEventDiscarder implements StreamPipe<StreamReceiver> {
 
     private EnumSet<EventType> discardedEvents = EnumSet.noneOf(EventType.class);
 
+    public StreamEventDiscarder() {
+    }
+
     @Override
-    public <R extends StreamReceiver> R setReceiver(final R receiver) {
-        this.receiver = receiver;
-        return receiver;
+    public <R extends StreamReceiver> R setReceiver(final R newReceiver) {
+        receiver = newReceiver;
+        return newReceiver;
     }
 
     /**
@@ -122,7 +126,8 @@ public class StreamEventDiscarder implements StreamPipe<StreamReceiver> {
                                         final boolean discard) {
         if (discard) {
             discardedEvents.add(type);
-        } else {
+        }
+        else {
             discardedEvents.remove(type);
         }
     }

--- a/metafacture-mangling/src/main/java/org/metafacture/mangling/StreamFlattener.java
+++ b/metafacture-mangling/src/main/java/org/metafacture/mangling/StreamFlattener.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.mangling;
 
 import org.metafacture.framework.FluxCommand;

--- a/metafacture-mangling/src/test/java/org/metafacture/mangling/DuplicateObjectFilterTest.java
+++ b/metafacture-mangling/src/test/java/org/metafacture/mangling/DuplicateObjectFilterTest.java
@@ -17,6 +17,7 @@
 /**
  *
  */
+
 package org.metafacture.mangling;
 
 import static org.mockito.Mockito.verify;

--- a/metafacture-mangling/src/test/java/org/metafacture/mangling/EntityPathTrackerTest.java
+++ b/metafacture-mangling/src/test/java/org/metafacture/mangling/EntityPathTrackerTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.mangling;
 
 import static org.junit.Assert.assertEquals;

--- a/metafacture-mangling/src/test/java/org/metafacture/mangling/LiteralToObjectTest.java
+++ b/metafacture-mangling/src/test/java/org/metafacture/mangling/LiteralToObjectTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.mangling;
 
 import static org.mockito.Mockito.verify;

--- a/metafacture-mangling/src/test/java/org/metafacture/mangling/NullFilterTest.java
+++ b/metafacture-mangling/src/test/java/org/metafacture/mangling/NullFilterTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.mangling;
 
 import static org.mockito.Mockito.inOrder;

--- a/metafacture-mangling/src/test/java/org/metafacture/mangling/ObjectToLiteralTest.java
+++ b/metafacture-mangling/src/test/java/org/metafacture/mangling/ObjectToLiteralTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.mangling;
 
 import static org.mockito.Mockito.inOrder;

--- a/metafacture-mangling/src/test/java/org/metafacture/mangling/RecordIdChangerTest.java
+++ b/metafacture-mangling/src/test/java/org/metafacture/mangling/RecordIdChangerTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.mangling;
 
 import static org.mockito.Mockito.inOrder;

--- a/metafacture-mangling/src/test/java/org/metafacture/mangling/RecordPathFilterTest.java
+++ b/metafacture-mangling/src/test/java/org/metafacture/mangling/RecordPathFilterTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.mangling;
 
 import org.junit.Rule;

--- a/metafacture-mangling/src/test/java/org/metafacture/mangling/RecordToEntityTest.java
+++ b/metafacture-mangling/src/test/java/org/metafacture/mangling/RecordToEntityTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.mangling;
 
 import static org.mockito.Mockito.inOrder;

--- a/metafacture-mangling/src/test/java/org/metafacture/mangling/StreamEventDiscarderTest.java
+++ b/metafacture-mangling/src/test/java/org/metafacture/mangling/StreamEventDiscarderTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.mangling;
 
 import static org.mockito.Mockito.inOrder;

--- a/metafacture-mangling/src/test/java/org/metafacture/mangling/StreamFlattenerTest.java
+++ b/metafacture-mangling/src/test/java/org/metafacture/mangling/StreamFlattenerTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.mangling;
 
 import static org.junit.Assert.assertEquals;

--- a/metafacture-mangling/src/test/java/org/metafacture/mangling/TestHelpers.java
+++ b/metafacture-mangling/src/test/java/org/metafacture/mangling/TestHelpers.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.mangling;
 
 import org.metafacture.framework.StreamReceiver;

--- a/metafacture-monitoring/src/main/java/org/metafacture/monitoring/ObjectBatchLogger.java
+++ b/metafacture-monitoring/src/main/java/org/metafacture/monitoring/ObjectBatchLogger.java
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.monitoring;
 
-import java.util.HashMap;
-import java.util.Map;
+package org.metafacture.monitoring;
 
 import org.metafacture.commons.StringUtil;
 import org.metafacture.framework.FluxCommand;
@@ -25,8 +23,12 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Writes log info for every BATCHSIZE records.
@@ -60,18 +62,15 @@ public final class ObjectBatchLogger<T> extends DefaultObjectPipe<T, ObjectRecei
     private long batchCount;
 
     public ObjectBatchLogger() {
-        super();
         this.format = DEFAULT_FORMAT;
 
     }
 
     public ObjectBatchLogger(final String format) {
-        super();
         this.format = format;
     }
 
     public ObjectBatchLogger(final String format, final Map<String, String> vars) {
-        super();
         this.format = format;
         this.vars.putAll(vars);
     }

--- a/metafacture-monitoring/src/main/java/org/metafacture/monitoring/ObjectLogger.java
+++ b/metafacture-monitoring/src/main/java/org/metafacture/monitoring/ObjectLogger.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.monitoring;
 
 import org.metafacture.framework.FluxCommand;
@@ -21,9 +22,9 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 
 /**
  * Logs the string representation of every object.
@@ -49,7 +50,6 @@ public final class ObjectLogger<T>
     }
 
     public ObjectLogger(final String logPrefix) {
-        super();
         this.logPrefix = logPrefix;
     }
 

--- a/metafacture-monitoring/src/main/java/org/metafacture/monitoring/ObjectTimer.java
+++ b/metafacture-monitoring/src/main/java/org/metafacture/monitoring/ObjectTimer.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.monitoring;
 
 import org.metafacture.framework.FluxCommand;

--- a/metafacture-monitoring/src/main/java/org/metafacture/monitoring/StreamBatchLogger.java
+++ b/metafacture-monitoring/src/main/java/org/metafacture/monitoring/StreamBatchLogger.java
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.monitoring;
 
-import java.util.HashMap;
-import java.util.Map;
+package org.metafacture.monitoring;
 
 import org.metafacture.commons.StringUtil;
 import org.metafacture.framework.FluxCommand;
@@ -25,8 +23,12 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.ForwardingStreamPipe;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Writes log info every {@code batchSize} records.
@@ -73,11 +75,11 @@ public final class StreamBatchLogger extends ForwardingStreamPipe {
         this.vars.putAll(vars);
     }
 
-    public final void setBatchSize(final int batchSize) {
+    public void setBatchSize(final int batchSize) {
         this.batchSize = batchSize;
     }
 
-    public final long getBatchSize() {
+    public long getBatchSize() {
         return batchSize;
     }
 
@@ -90,12 +92,12 @@ public final class StreamBatchLogger extends ForwardingStreamPipe {
     }
 
     @Override
-    public final void endRecord() {
+    public void endRecord() {
         getReceiver().endRecord();
-        recordCount++;
+        ++recordCount;
         recordCount %= batchSize;
         if (recordCount == 0) {
-            batchCount++;
+            ++batchCount;
             writeLog();
         }
     }
@@ -106,7 +108,7 @@ public final class StreamBatchLogger extends ForwardingStreamPipe {
     }
 
     @Override
-    protected final void onResetStream() {
+    protected void onResetStream() {
         recordCount = 0;
         batchCount = 0;
     }

--- a/metafacture-monitoring/src/main/java/org/metafacture/monitoring/StreamLogger.java
+++ b/metafacture-monitoring/src/main/java/org/metafacture/monitoring/StreamLogger.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.monitoring;
 
 import org.metafacture.framework.FluxCommand;
@@ -21,9 +22,9 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultStreamPipe;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 
 /**
  * Leaves the event stream untouched but logs it to the info log.
@@ -49,7 +50,6 @@ public final class StreamLogger
     }
 
     public StreamLogger(final String logPrefix) {
-        super();
         this.logPrefix = logPrefix;
     }
 

--- a/metafacture-monitoring/src/main/java/org/metafacture/monitoring/StreamTimer.java
+++ b/metafacture-monitoring/src/main/java/org/metafacture/monitoring/StreamTimer.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.monitoring;
 
 import org.metafacture.framework.FluxCommand;

--- a/metafacture-monitoring/src/main/java/org/metafacture/monitoring/TimerBase.java
+++ b/metafacture-monitoring/src/main/java/org/metafacture/monitoring/TimerBase.java
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.monitoring;
 
 import org.metafacture.commons.TimeUtil;
 import org.metafacture.framework.Receiver;
 import org.metafacture.framework.Sender;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 
 /**
  * @author Christoph Böhme
@@ -41,14 +42,13 @@ public class TimerBase<R extends Receiver> implements Sender<R> {
     private R receiver;
 
     protected TimerBase(final String logPrefix) {
-        super();
         this.logPrefix = logPrefix;
     }
 
     @Override
-    public final <S extends R> S setReceiver(final S receiver) {
-        this.receiver = receiver;
-        return receiver;
+    public final <S extends R> S setReceiver(final S newReceiver) {
+        receiver = newReceiver;
+        return newReceiver;
     }
 
     public final R getReceiver() {
@@ -69,12 +69,12 @@ public class TimerBase<R extends Receiver> implements Sender<R> {
         final long averageDuration;
         if (count > 0) {
             averageDuration = cumulativeDuration / count;
-        } else {
+        }
+        else {
             averageDuration = 0;
         }
-        LOG.info(logPrefix
-                + String.format("Executions: %d; Cumulative duration: %s; Average duration: %s", Long.valueOf(count),
-                        TimeUtil.formatDuration(cumulativeDuration), TimeUtil.formatDuration(averageDuration)));
+        LOG.info(logPrefix + String.format("Executions: %d; Cumulative duration: %s; Average duration: %s", Long.valueOf(count),
+                    TimeUtil.formatDuration(cumulativeDuration), TimeUtil.formatDuration(averageDuration)));
         startMeasurement();
         if (receiver != null) {
             receiver.closeStream();
@@ -86,7 +86,7 @@ public class TimerBase<R extends Receiver> implements Sender<R> {
         startTime = System.nanoTime();
     }
 
-    protected final void stopMeasurement(){
+    protected final void stopMeasurement() {
         stopMeasurement("Execution %1$d:");
     }
 

--- a/metafacture-monitoring/src/test/java/org/metafacture/monitoring/ObjectTimerTest.java
+++ b/metafacture-monitoring/src/test/java/org/metafacture/monitoring/ObjectTimerTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.monitoring;
 
 import org.junit.Before;
@@ -41,7 +42,8 @@ public final class ObjectTimerTest {
         public void process(final String obj) {
             try {
                 Thread.sleep(getDuration());
-            } catch (final InterruptedException e) {
+            }
+            catch (final InterruptedException e) {
                 return;
             }
         }

--- a/metafacture-monitoring/src/test/java/org/metafacture/monitoring/StreamLoggerTest.java
+++ b/metafacture-monitoring/src/test/java/org/metafacture/monitoring/StreamLoggerTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.monitoring;
 
 import static org.mockito.Mockito.inOrder;

--- a/metafacture-monitoring/src/test/java/org/metafacture/monitoring/StreamTimerTest.java
+++ b/metafacture-monitoring/src/test/java/org/metafacture/monitoring/StreamTimerTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.monitoring;
 
 import org.junit.Before;
@@ -41,7 +42,8 @@ public final class StreamTimerTest {
         public void startRecord(final String id) {
             try {
                 Thread.sleep(getDuration());
-            } catch (final InterruptedException e) {
+            }
+            catch (final InterruptedException e) {
                 return;
             }
         }

--- a/metafacture-plumbing/src/main/java/org/metafacture/plumbing/IdentityStreamPipe.java
+++ b/metafacture-plumbing/src/main/java/org/metafacture/plumbing/IdentityStreamPipe.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.plumbing;
 
 import org.metafacture.framework.FluxCommand;
@@ -32,5 +33,8 @@ import org.metafacture.framework.helpers.ForwardingStreamPipe;
 @Out(StreamReceiver.class)
 @FluxCommand("pass-through")
 public final class IdentityStreamPipe extends ForwardingStreamPipe {
+
+    public IdentityStreamPipe() {
+    }
 
 }

--- a/metafacture-plumbing/src/main/java/org/metafacture/plumbing/ObjectTee.java
+++ b/metafacture-plumbing/src/main/java/org/metafacture/plumbing/ObjectTee.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.plumbing;
 
 import org.metafacture.framework.FluxCommand;
@@ -35,12 +36,14 @@ import org.metafacture.framework.helpers.DefaultTee;
 @In(Object.class)
 @Out(Object.class)
 @FluxCommand("object-tee")
-public final class ObjectTee<T> extends DefaultTee<ObjectReceiver<T>>
-        implements ObjectPipe<T, ObjectReceiver<T>> {
+public final class ObjectTee<T> extends DefaultTee<ObjectReceiver<T>> implements ObjectPipe<T, ObjectReceiver<T>> {
+
+    public ObjectTee() {
+    }
 
     @Override
     public void process(final T obj) {
-        for (ObjectReceiver<T> receiver : getReceivers()) {
+        for (final ObjectReceiver<T> receiver : getReceivers()) {
             receiver.process(obj);
         }
     }

--- a/metafacture-plumbing/src/main/java/org/metafacture/plumbing/StreamBatchMerger.java
+++ b/metafacture-plumbing/src/main/java/org/metafacture/plumbing/StreamBatchMerger.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.plumbing;
 
 import org.metafacture.framework.FluxCommand;
@@ -43,6 +44,9 @@ public final class StreamBatchMerger extends DefaultStreamPipe<StreamReceiver> {
 
     private long batchSize = DEFAULT_BATCH_SIZE;
     private long recordCount;
+
+    public StreamBatchMerger() {
+    }
 
     /**
      * Sets the number of records that should be merged into a batch.

--- a/metafacture-plumbing/src/main/java/org/metafacture/plumbing/StreamMerger.java
+++ b/metafacture-plumbing/src/main/java/org/metafacture/plumbing/StreamMerger.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.plumbing;
 
 import org.metafacture.framework.FluxCommand;
@@ -37,11 +38,13 @@ import org.metafacture.framework.helpers.DefaultStreamPipe;
 @In(StreamReceiver.class)
 @Out(StreamReceiver.class)
 @FluxCommand("merge-same-ids")
-public final class StreamMerger
-        extends DefaultStreamPipe<StreamReceiver> {
+public final class StreamMerger extends DefaultStreamPipe<StreamReceiver> {
 
     private boolean hasRecordsReceived;
     private String currentId = "";
+
+    public StreamMerger() {
+    }
 
     @Override
     public void startRecord(final String identifier) {

--- a/metafacture-plumbing/src/main/java/org/metafacture/plumbing/StreamTee.java
+++ b/metafacture-plumbing/src/main/java/org/metafacture/plumbing/StreamTee.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.plumbing;
 
 import org.metafacture.framework.FluxCommand;
@@ -33,40 +34,42 @@ import org.metafacture.framework.helpers.DefaultTee;
 @In(StreamReceiver.class)
 @Out(StreamReceiver.class)
 @FluxCommand("stream-tee")
-public final class StreamTee extends DefaultTee<StreamReceiver>
-        implements StreamPipe<StreamReceiver> {
+public final class StreamTee extends DefaultTee<StreamReceiver> implements StreamPipe<StreamReceiver> {
+
+    public StreamTee() {
+    }
 
     @Override
     public void startRecord(final String identifier) {
-        for (StreamReceiver receiver : getReceivers()) {
+        for (final StreamReceiver receiver : getReceivers()) {
             receiver.startRecord(identifier);
         }
     }
 
     @Override
     public void endRecord() {
-        for (StreamReceiver receiver : getReceivers()) {
+        for (final StreamReceiver receiver : getReceivers()) {
             receiver.endRecord();
         }
     }
 
     @Override
     public void startEntity(final String name) {
-        for (StreamReceiver receiver : getReceivers()) {
+        for (final StreamReceiver receiver : getReceivers()) {
             receiver.startEntity(name);
         }
     }
 
     @Override
     public void endEntity() {
-        for (StreamReceiver receiver : getReceivers()) {
+        for (final StreamReceiver receiver : getReceivers()) {
             receiver.endEntity();
         }
     }
 
     @Override
     public void literal(final String name, final String value) {
-        for (StreamReceiver receiver : getReceivers()) {
+        for (final StreamReceiver receiver : getReceivers()) {
             receiver.literal(name, value);
         }
     }

--- a/metafacture-plumbing/src/main/java/org/metafacture/plumbing/XmlTee.java
+++ b/metafacture-plumbing/src/main/java/org/metafacture/plumbing/XmlTee.java
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.plumbing;
 
-import java.io.IOException;
+package org.metafacture.plumbing;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.XmlPipe;
@@ -24,11 +23,14 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultTee;
+
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.Locator;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
+
+import java.io.IOException;
 
 /**
  * Sends one {@link XmlReceiver} to two {@link XmlReceiver}s.
@@ -40,7 +42,10 @@ import org.xml.sax.SAXParseException;
 @In(XmlReceiver.class)
 @Out(XmlReceiver.class)
 @FluxCommand("xml-tee")
-public final class XmlTee extends DefaultTee<XmlReceiver>implements XmlPipe<XmlReceiver> {
+public final class XmlTee extends DefaultTee<XmlReceiver> implements XmlPipe<XmlReceiver> {
+
+    public XmlTee() {
+    }
 
     @Override
     public void characters(final char[] ch, final int start, final int length) throws SAXException {

--- a/metafacture-plumbing/src/test/java/org/metafacture/plumbing/IdentityStreamPipeTest.java
+++ b/metafacture-plumbing/src/test/java/org/metafacture/plumbing/IdentityStreamPipeTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.plumbing;
 
 import static org.mockito.Mockito.inOrder;

--- a/metafacture-plumbing/src/test/java/org/metafacture/plumbing/StreamBatchMergerTest.java
+++ b/metafacture-plumbing/src/test/java/org/metafacture/plumbing/StreamBatchMergerTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.plumbing;
 
 import org.junit.Before;

--- a/metafacture-plumbing/src/test/java/org/metafacture/plumbing/StreamMergerTest.java
+++ b/metafacture-plumbing/src/test/java/org/metafacture/plumbing/StreamMergerTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.plumbing;
 
 import static org.mockito.Mockito.inOrder;

--- a/metafacture-plumbing/src/test/java/org/metafacture/plumbing/StreamTeeTest.java
+++ b/metafacture-plumbing/src/test/java/org/metafacture/plumbing/StreamTeeTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.plumbing;
 
 import static org.mockito.Mockito.inOrder;

--- a/metafacture-runner/src/main/java/org/metafacture/runner/Flux.java
+++ b/metafacture-runner/src/main/java/org/metafacture/runner/Flux.java
@@ -13,7 +13,15 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
 package org.metafacture.runner;
+
+import org.metafacture.commons.ResourceUtil;
+import org.metafacture.flux.FluxCompiler;
+import org.metafacture.flux.parser.FluxProgramm;
+import org.metafacture.runner.util.DirectoryClassLoader;
+
+import org.antlr.runtime.RecognitionException;
 
 import java.io.File;
 import java.io.IOException;
@@ -21,12 +29,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import org.antlr.runtime.RecognitionException;
-import org.metafacture.commons.ResourceUtil;
-import org.metafacture.flux.FluxCompiler;
-import org.metafacture.flux.parser.FluxProgramm;
-import org.metafacture.runner.util.DirectoryClassLoader;
 
 /**
  * @author Markus Michael Geipel
@@ -46,25 +48,22 @@ public final class Flux {
     }
 
     public static void main(final String[] args) throws IOException, RecognitionException {
-
         loadCustomJars();
 
-        if (args.length < (1)) {
+        if (args.length < 1) {
             FluxProgramm.printHelp(System.out);
             System.exit(2);
-        } else {
-
+        }
+        else {
             final File fluxFile = new File(args[0]);
             if (!fluxFile.exists()) {
                 System.err.println("File not found: " + args[0]);
                 System.exit(1);
-                return;
             }
 
             // get variable assignments
             final Map<String, String> vars = new HashMap<String, String>();
-            vars.put(SCRIPT_HOME, fluxFile.getAbsoluteFile().getParent()
-                    + System.getProperty("file.separator"));
+            vars.put(SCRIPT_HOME, fluxFile.getAbsoluteFile().getParent() + System.getProperty("file.separator"));
 
             for (int i = 1; i < args.length; ++i) {
                 final Matcher matcher = VAR_PATTERN.matcher(args[i]);

--- a/metafacture-runner/src/main/java/org/metafacture/runner/util/DirectoryClassLoader.java
+++ b/metafacture-runner/src/main/java/org/metafacture/runner/util/DirectoryClassLoader.java
@@ -13,15 +13,16 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
 package org.metafacture.runner.util;
+
+import org.metafacture.framework.MetafactureException;
 
 import java.io.File;
 import java.io.FilenameFilter;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
-
-import org.metafacture.framework.MetafactureException;
 
 /**
  * A class loader which allows adding directories to the class
@@ -36,14 +37,13 @@ public final class DirectoryClassLoader extends URLClassLoader {
     private static final String CLASS_FILE_EXTENSION = ".class";
 
     private static final FilenameFilter JAR_AND_CLASS_FILTER =
-            new FilenameFilter() {
+        new FilenameFilter() {
 
-                @Override
-                public boolean accept(final File dir, final String name) {
-                    return name.endsWith(JAR_FILE_EXTENSION)
-                            || name.endsWith(CLASS_FILE_EXTENSION);
-                }
-            };
+            @Override
+            public boolean accept(final File dir, final String name) {
+                return name.endsWith(JAR_FILE_EXTENSION) || name.endsWith(CLASS_FILE_EXTENSION);
+            }
+        };
 
     public DirectoryClassLoader(final ClassLoader parent) {
         super(new URL[0], parent);
@@ -53,7 +53,8 @@ public final class DirectoryClassLoader extends URLClassLoader {
         for (final File file : dir.listFiles(JAR_AND_CLASS_FILTER)) {
             try {
                 addURL(file.toURI().toURL());
-            } catch (final MalformedURLException e) {
+            }
+            catch (final MalformedURLException e) {
                 throw new MetafactureException("Could not add " + file + " to class loader", e);
             }
         }

--- a/metafacture-scripting/src/main/java/org/metafacture/scripting/JScriptObjectPipe.java
+++ b/metafacture-scripting/src/main/java/org/metafacture/scripting/JScriptObjectPipe.java
@@ -13,14 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.scripting;
-
-import java.io.FileNotFoundException;
-
-import javax.script.Invocable;
-import javax.script.ScriptEngine;
-import javax.script.ScriptEngineManager;
-import javax.script.ScriptException;
 
 import org.metafacture.commons.ResourceUtil;
 import org.metafacture.framework.FluxCommand;
@@ -30,6 +24,12 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
+
+import java.io.FileNotFoundException;
+import javax.script.Invocable;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
 
 /**
  * Executes the function process(obj) in a given jscript.
@@ -62,15 +62,15 @@ public final class JScriptObjectPipe extends DefaultObjectPipe<Object, ObjectRec
         try {
             // LOG.info("loading code from '" + file + "'");
             engine.eval(ResourceUtil.getReader(file));
-        } catch (ScriptException e) {
+        }
+        catch (final ScriptException e) {
             throw new MetafactureException("Error in script", e);
-        } catch (FileNotFoundException e) {
+        }
+        catch (final FileNotFoundException e) {
             throw new MetafactureException("Error loading script '" + file + "'", e);
         }
         invocable = (Invocable) engine;
     }
-
-
 
     @Override
     public void process(final Object obj) {
@@ -83,9 +83,11 @@ public final class JScriptObjectPipe extends DefaultObjectPipe<Object, ObjectRec
 
             getReceiver().process(retObj);
 
-        } catch (ScriptException e) {
+        }
+        catch (final ScriptException e) {
             throw new MetafactureException("Error in script while evaluating 'process' method", e);
-        } catch (NoSuchMethodException e) {
+        }
+        catch (final NoSuchMethodException e) {
             throw new MetafactureException("'process' method is missing in script", e);
         }
     }

--- a/metafacture-statistics/src/main/java/org/metafacture/statistics/AbstractCountProcessor.java
+++ b/metafacture-statistics/src/main/java/org/metafacture/statistics/AbstractCountProcessor.java
@@ -13,15 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.statistics;
 
-import java.util.Hashtable;
-import java.util.Map;
-import java.util.regex.Pattern;
+package org.metafacture.statistics;
 
 import org.metafacture.framework.ObjectReceiver;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
 import org.metafacture.framework.objects.Triple;
+
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * Base class for operating on count data. The expected inputs are triples
@@ -32,7 +33,6 @@ import org.metafacture.framework.objects.Triple;
  * @author Markus Michael Geipel
  */
 public abstract class AbstractCountProcessor extends DefaultObjectPipe<Triple, ObjectReceiver<Triple>> {
-
 
     private static final Pattern KEY_SPLIT_PATTERN = Pattern.compile("&", Pattern.LITERAL);
 
@@ -67,7 +67,8 @@ public abstract class AbstractCountProcessor extends DefaultObjectPipe<Triple, O
                 marginals.put(triple.getSubject().substring(2), Integer.valueOf(marginal));
             }
 
-        } else {
+        }
+        else {
             inHeader = false;
             if (!triple.getSubject().startsWith(JOINT_PREFIX)) {
                 throw new IllegalArgumentException("Joint counts must start with '2:'");
@@ -84,12 +85,11 @@ public abstract class AbstractCountProcessor extends DefaultObjectPipe<Triple, O
         }
     }
 
-    protected abstract void processCount(final String varA, final String varB, final int countA, final int countB,
-            final int countAandB);
+    protected abstract void processCount(String varA, String varB, int countA, int countB, int countAandB);
 
     private int getMarginal(final String string) {
         final Integer value = marginals.get(string);
-        if(null==value){
+        if (null == value) {
             return 0;
         }
         return value.intValue();
@@ -104,7 +104,6 @@ public abstract class AbstractCountProcessor extends DefaultObjectPipe<Triple, O
 
     protected void reset() {
         // nothing to do
-
     }
 
     @Override
@@ -115,7 +114,6 @@ public abstract class AbstractCountProcessor extends DefaultObjectPipe<Triple, O
 
     protected void close() {
         // nothing to do
-
     }
 
 }

--- a/metafacture-statistics/src/main/java/org/metafacture/statistics/CooccurrenceMetricCalculator.java
+++ b/metafacture-statistics/src/main/java/org/metafacture/statistics/CooccurrenceMetricCalculator.java
@@ -13,16 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.statistics;
 
-import java.util.ArrayList;
-import java.util.List;
+package org.metafacture.statistics;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.objects.Triple;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Calculates values for various co-occurrence metrics. The expected inputs are
@@ -32,8 +33,8 @@ import org.metafacture.framework.objects.Triple;
  *
  * @author Markus Michael Geipel
  */
-@Description("Calculates values for various cooccurrence metrics. The expected inputs are triples containing as subject the var name and as object the count. "
-        + "Marginal counts must appear first, joint counts second. Marinal counts must be written as 1:A, Joint counts as 2:A&B")
+@Description("Calculates values for various cooccurrence metrics. The expected inputs are triples containing as subject the var name and as object the count. " +
+    "Marginal counts must appear first, joint counts second. Marinal counts must be written as 1:A, Joint counts as 2:A&B")
 @In(Triple.class)
 @Out(Triple.class)
 @FluxCommand("calculate-metrics")
@@ -51,8 +52,7 @@ public final class CooccurrenceMetricCalculator extends AbstractCountProcessor {
                 final double o22 = total - countAandB;
                 final double d = (countAandB * o22) - (o12 * o21);
 
-                final double x2 = total * Math.pow(d, 2)
-                        / ((countAandB + o12) * (countAandB + o21) * (o12 + o22) * (o21 + o22));
+                final double x2 = total * Math.pow(d, 2) / ((countAandB + o12) * (countAandB + o21) * (o12 + o22) * (o21 + o22));
                 return x2 * Math.signum(d);
             }
         },
@@ -87,11 +87,11 @@ public final class CooccurrenceMetricCalculator extends AbstractCountProcessor {
         JACCARD {
             @Override
             double calculate(final int countA, final int countB, final int countAandB, final int total) {
-                return countAandB / (double)(countA + countB - countAandB);
+                return countAandB / (double) (countA + countB - countAandB);
             }
         };
 
-        abstract double calculate(final int countA, final int countB, final int countAandB, final int total);
+        abstract double calculate(int countA, int countB, int countAandB, int total);
     }
 
     private static final int MIN_COUNT = 5;
@@ -99,24 +99,22 @@ public final class CooccurrenceMetricCalculator extends AbstractCountProcessor {
     private final List<Metric> metrics = new ArrayList<Metric>();
 
     public CooccurrenceMetricCalculator(final String allMetrics) {
-        final String[] metrics = allMetrics.split("\\s*,\\s*");
         setMinCount(MIN_COUNT);
-        for (String metric : metrics) {
-            this.metrics.add(Metric.valueOf(metric));
+        for (final String metric : allMetrics.split("\\s*,\\s*")) {
+            metrics.add(Metric.valueOf(metric));
         }
     }
 
     public CooccurrenceMetricCalculator(final Metric... metrics) {
         setMinCount(MIN_COUNT);
-        for (Metric metric : metrics) {
+        for (final Metric metric : metrics) {
             this.metrics.add(metric);
         }
     }
 
     @Override
-    protected void processCount(final String varA, final String varB, final int countA, final int countB,
-            final int countAandB) {
-        for (Metric metric : metrics) {
+    protected void processCount(final String varA, final String varB, final int countA, final int countB, final int countAandB) {
+        for (final Metric metric : metrics) {
             final double value = metric.calculate(countA, countB, countAandB, getTotal());
             getReceiver().process(new Triple(varA + "&" + varB, metric.toString(), String.valueOf(value)));
         }

--- a/metafacture-statistics/src/main/java/org/metafacture/statistics/Counter.java
+++ b/metafacture-statistics/src/main/java/org/metafacture/statistics/Counter.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.statistics;
 
 import org.metafacture.framework.FluxCommand;
@@ -42,6 +43,9 @@ public final class Counter extends DefaultStreamPipe<StreamReceiver> {
     private int numEntities;
     private int numLiterals;
 
+    public Counter() {
+    }
+
     /**
      * @return the numRecords
      */
@@ -67,7 +71,7 @@ public final class Counter extends DefaultStreamPipe<StreamReceiver> {
     public void startRecord(final String identifier) {
         assert !isClosed();
         ++numRecords;
-        if(getReceiver() != null) {
+        if (getReceiver() != null) {
             getReceiver().startRecord(identifier);
         }
     }
@@ -76,7 +80,7 @@ public final class Counter extends DefaultStreamPipe<StreamReceiver> {
     public void startEntity(final String name) {
         assert !isClosed();
         ++numEntities;
-        if(getReceiver() != null) {
+        if (getReceiver() != null) {
             getReceiver().startEntity(name);
         }
     }
@@ -85,21 +89,21 @@ public final class Counter extends DefaultStreamPipe<StreamReceiver> {
     public void literal(final String name, final String value) {
         assert !isClosed();
         ++numLiterals;
-        if(getReceiver() != null) {
+        if (getReceiver() != null) {
             getReceiver().literal(name, value);
         }
     }
 
     @Override
     public void endRecord() {
-        if(getReceiver() != null) {
+        if (getReceiver() != null) {
             getReceiver().endRecord();
         }
     }
 
     @Override
     public void endEntity() {
-        if(getReceiver() != null) {
+        if (getReceiver() != null) {
             getReceiver().endEntity();
         }
     }
@@ -113,11 +117,7 @@ public final class Counter extends DefaultStreamPipe<StreamReceiver> {
 
     @Override
     public String toString() {
-        String streamClosed = "";
-        if (isClosed()) {
-            streamClosed =" Stream has been closed.";
-        }
-
+        final String streamClosed = isClosed() ? " Stream has been closed." : "";
         return "counted " + numRecords + " records, " + numEntities + " entities, " + numLiterals + " literals." + streamClosed;
     }
 }

--- a/metafacture-statistics/src/main/java/org/metafacture/statistics/Histogram.java
+++ b/metafacture-statistics/src/main/java/org/metafacture/statistics/Histogram.java
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.statistics;
+
+import org.metafacture.framework.helpers.DefaultStreamReceiver;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
-import org.metafacture.framework.helpers.DefaultStreamReceiver;
-
 
 /**
  * Counts entity names, literal names, or literal values.
@@ -36,7 +36,6 @@ public final class Histogram extends DefaultStreamReceiver {
     private String countField;
 
     public Histogram() {
-        super();
     }
 
     /**
@@ -45,7 +44,6 @@ public final class Histogram extends DefaultStreamReceiver {
      * @param countField name of the field whose content is counted
      */
     public Histogram(final String countField) {
-        super();
         setCountField(countField);
     }
 

--- a/metafacture-statistics/src/main/java/org/metafacture/statistics/UniformSampler.java
+++ b/metafacture-statistics/src/main/java/org/metafacture/statistics/UniformSampler.java
@@ -13,11 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.statistics;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
+package org.metafacture.statistics;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.ObjectReceiver;
@@ -26,6 +23,9 @@ import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
 
 /**
  * Draws a uniform sample of records from the input stream.
@@ -50,21 +50,17 @@ public final class UniformSampler<T> extends
     private long count;
 
     public UniformSampler(final int sampleSize) {
-        super();
         this.sampleSize = sampleSize;
         sample = new ArrayList<T>(sampleSize);
     }
-
 
     public UniformSampler(final String sampleSize) {
         this(Integer.parseInt(sampleSize));
     }
 
-
     public int getSampleSize() {
         return sampleSize;
     }
-
 
     public void setSeed(final long seed) {
         random.setSeed(seed);
@@ -73,12 +69,13 @@ public final class UniformSampler<T> extends
     @Override
     public void process(final T obj) {
         assert !isClosed();
-        assert null!=obj;
+        assert null != obj;
         count += 1;
         if (sample.size() < sampleSize) {
             sample.add(obj);
-        } else {
-            final double p = sampleSize / (double)count;
+        }
+        else {
+            final double p = sampleSize / (double) count;
             if (random.nextDouble() < p) {
                 sample.set(random.nextInt(sampleSize), obj);
             }
@@ -87,7 +84,7 @@ public final class UniformSampler<T> extends
 
     @Override
     protected void onCloseStream() {
-        for(T obj : sample) {
+        for (final T obj : sample) {
             getReceiver().process(obj);
         }
         sample.clear();

--- a/metafacture-statistics/src/test/java/org/metafacture/statistics/CooccurrenceMetricCalculatorTest.java
+++ b/metafacture-statistics/src/test/java/org/metafacture/statistics/CooccurrenceMetricCalculatorTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.statistics;
 
 import static org.junit.Assert.assertEquals;

--- a/metafacture-statistics/src/test/java/org/metafacture/statistics/HistogramTest.java
+++ b/metafacture-statistics/src/test/java/org/metafacture/statistics/HistogramTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.statistics;
 
 import static org.junit.Assert.assertEquals;

--- a/metafacture-statistics/src/test/java/org/metafacture/statistics/UniformSamplerTest.java
+++ b/metafacture-statistics/src/test/java/org/metafacture/statistics/UniformSamplerTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.statistics;
 
 import static org.mockito.Mockito.inOrder;

--- a/metafacture-strings/src/main/java/org/metafacture/strings/LineRecorder.java
+++ b/metafacture-strings/src/main/java/org/metafacture/strings/LineRecorder.java
@@ -41,7 +41,10 @@ public final class LineRecorder implements ObjectPipe<String, ObjectReceiver<Str
     private String recordMarkerRegexp = "^\\s*$";
     private StringBuilder record = new StringBuilder(SB_CAPACITY);
     private ObjectReceiver<String> receiver;
-    private boolean isClosed = false;
+    private boolean isClosed;
+
+    public LineRecorder() {
+    }
 
     public void setRecordMarkerRegexp(final String regexp) {
         recordMarkerRegexp = regexp;
@@ -53,8 +56,10 @@ public final class LineRecorder implements ObjectPipe<String, ObjectReceiver<Str
         if (line.matches(recordMarkerRegexp)) {
             getReceiver().process(record.toString());
             record = new StringBuilder(SB_CAPACITY);
-        } else
+        }
+        else {
             record.append(line + "\n");
+        }
     }
 
     private boolean isClosed() {
@@ -73,9 +78,9 @@ public final class LineRecorder implements ObjectPipe<String, ObjectReceiver<Str
     }
 
     @Override
-    public <R extends ObjectReceiver<String>> R setReceiver(R receiver) {
-        this.receiver = receiver;
-        return receiver;
+    public <R extends ObjectReceiver<String>> R setReceiver(final R newReceiver) {
+        receiver = newReceiver;
+        return newReceiver;
     }
 
     /**
@@ -83,7 +88,7 @@ public final class LineRecorder implements ObjectPipe<String, ObjectReceiver<Str
      *
      * @return reference to the downstream module
      */
-    protected final ObjectReceiver<String> getReceiver() {
+    protected ObjectReceiver<String> getReceiver() {
         return receiver;
     }
 

--- a/metafacture-strings/src/main/java/org/metafacture/strings/LineSplitter.java
+++ b/metafacture-strings/src/main/java/org/metafacture/strings/LineSplitter.java
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.strings;
 
-import java.util.regex.Pattern;
+package org.metafacture.strings;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.ObjectReceiver;
@@ -23,6 +22,8 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
+
+import java.util.regex.Pattern;
 
 /**
  * Splits a string at new lines and sends each line to the receiver.
@@ -34,12 +35,13 @@ import org.metafacture.framework.helpers.DefaultObjectPipe;
 @In(String.class)
 @Out(String.class)
 @FluxCommand("split-lines")
-public final class LineSplitter
-        extends DefaultObjectPipe<String, ObjectReceiver<String>> {
+public final class LineSplitter extends DefaultObjectPipe<String, ObjectReceiver<String>> {
 
     private static final char NEWLINE = '\n';
-    private static final Pattern LINE_PATTERN = Pattern.compile(
-            String.valueOf(NEWLINE), Pattern.LITERAL);
+    private static final Pattern LINE_PATTERN = Pattern.compile(String.valueOf(NEWLINE), Pattern.LITERAL);
+
+    public LineSplitter() {
+    }
 
     @Override
     public void process(final String lines) {

--- a/metafacture-strings/src/main/java/org/metafacture/strings/RegexDecoder.java
+++ b/metafacture-strings/src/main/java/org/metafacture/strings/RegexDecoder.java
@@ -13,12 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.strings;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+package org.metafacture.strings;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.StreamReceiver;
@@ -27,6 +23,10 @@ import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Decodes a string based on a regular expression using named capture groups.

--- a/metafacture-strings/src/main/java/org/metafacture/strings/StreamUnicodeNormalizer.java
+++ b/metafacture-strings/src/main/java/org/metafacture/strings/StreamUnicodeNormalizer.java
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.strings;
 
-import java.text.Normalizer;
+package org.metafacture.strings;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.StreamReceiver;
@@ -23,6 +22,8 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultStreamPipe;
+
+import java.text.Normalizer;
 
 /**
  * Normalises Unicode characters in record identifiers, entity and literal
@@ -42,20 +43,21 @@ import org.metafacture.framework.helpers.DefaultStreamPipe;
 @In(StreamReceiver.class)
 @Out(StreamReceiver.class)
 @FluxCommand("normalize-unicode-stream")
-public final class StreamUnicodeNormalizer
-        extends DefaultStreamPipe<StreamReceiver> {
+public final class StreamUnicodeNormalizer extends DefaultStreamPipe<StreamReceiver> {
 
     /**
      * The default value for {@link #setNormalizationForm(Normalizer.Form)}.
      */
-    public static final Normalizer.Form DEFAULT_NORMALIZATION_FORM =
-            Normalizer.Form.NFC;
+    public static final Normalizer.Form DEFAULT_NORMALIZATION_FORM = Normalizer.Form.NFC;
 
     private boolean normalizeIds;
     private boolean normalizeKeys;
     private boolean normalizeValues = true;
 
     private Normalizer.Form normalizationForm = DEFAULT_NORMALIZATION_FORM;
+
+    public StreamUnicodeNormalizer() {
+    }
 
     /**
      * Controls whether to normalise record identifiers. By default record
@@ -161,10 +163,8 @@ public final class StreamUnicodeNormalizer
 
     @Override
     public void literal(final String name, final String value) {
-        final String normalizedName =
-                normalizeKeys ? normalize(name) : name;
-        final String normalizedValue=
-                normalizeValues ? normalize(value) : value;
+        final String normalizedName = normalizeKeys ? normalize(name) : name;
+        final String normalizedValue = normalizeValues ? normalize(value) : value;
 
         getReceiver().literal(normalizedName, normalizedValue);
     }

--- a/metafacture-strings/src/main/java/org/metafacture/strings/StringConcatenator.java
+++ b/metafacture-strings/src/main/java/org/metafacture/strings/StringConcatenator.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.strings;
 
 import org.metafacture.framework.ObjectReceiver;
@@ -28,10 +29,12 @@ public final class StringConcatenator implements ObjectReceiver<String> {
     private StringBuilder builder = new StringBuilder();
     private String separator = "";
 
+    public StringConcatenator() {
+    }
+
     @Override
     public void resetStream() {
         reset();
-
     }
 
     public void setSeparator(final String separator) {
@@ -41,21 +44,19 @@ public final class StringConcatenator implements ObjectReceiver<String> {
     @Override
     public void closeStream() {
         // nothing to do
-
     }
 
     @Override
     public void process(final String obj) {
         builder.append(separator);
         builder.append(obj);
-
     }
 
-    public void reset(){
+    public void reset() {
         builder = new StringBuilder();
     }
 
-    public String getString(){
+    public String getString() {
         return builder.toString();
     }
 

--- a/metafacture-strings/src/main/java/org/metafacture/strings/StringDecoder.java
+++ b/metafacture-strings/src/main/java/org/metafacture/strings/StringDecoder.java
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.strings;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+package org.metafacture.strings;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.ObjectReceiver;
@@ -24,6 +22,9 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Splits a {@link String} into several {@link String}s, either by extracting
@@ -65,10 +66,11 @@ public final class StringDecoder extends DefaultObjectPipe<String, ObjectReceive
 
         final ObjectReceiver<String> receiver = getReceiver();
         if (mode == Mode.SPLIT) {
-            for (String part : pattern.split(obj)) {
+            for (final String part : pattern.split(obj)) {
                 receiver.process(part);
             }
-        } else {
+        }
+        else {
             final Matcher matcher = pattern.matcher(obj);
             while (matcher.find()) {
                 receiver.process(matcher.group());

--- a/metafacture-strings/src/main/java/org/metafacture/strings/StringFilter.java
+++ b/metafacture-strings/src/main/java/org/metafacture/strings/StringFilter.java
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.strings;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+package org.metafacture.strings;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.ObjectReceiver;
@@ -25,6 +23,8 @@ import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Only forwards records which match (or do not match) a regular expression
@@ -41,7 +41,7 @@ public final class StringFilter extends
         DefaultObjectPipe<String, ObjectReceiver<String>> {
 
     private final Matcher matcher;
-    private boolean passMatches=true;
+    private boolean passMatches = true;
 
     public StringFilter(final String pattern) {
         this.matcher = Pattern.compile(pattern).matcher("");
@@ -62,7 +62,7 @@ public final class StringFilter extends
     @Override
     public void process(final String obj) {
         assert !isClosed();
-        assert null!=obj;
+        assert null != obj;
         matcher.reset(obj);
         if (matcher.find() == passMatches) {
             getReceiver().process(obj);

--- a/metafacture-strings/src/main/java/org/metafacture/strings/StringMatcher.java
+++ b/metafacture-strings/src/main/java/org/metafacture/strings/StringMatcher.java
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.strings;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+package org.metafacture.strings;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.ObjectReceiver;
@@ -25,6 +23,8 @@ import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Matches the incoming strings against a regular expression and replaces
@@ -36,11 +36,13 @@ import org.metafacture.framework.helpers.DefaultObjectPipe;
 @In(String.class)
 @Out(String.class)
 @FluxCommand("match")
-public final class StringMatcher extends
-        DefaultObjectPipe<String, ObjectReceiver<String>> {
+public final class StringMatcher extends DefaultObjectPipe<String, ObjectReceiver<String>> {
 
     private Matcher matcher;
     private String replacement;
+
+    public StringMatcher() {
+    }
 
     public String getPattern() {
         return matcher.pattern().pattern();
@@ -61,7 +63,7 @@ public final class StringMatcher extends
     @Override
     public void process(final String obj) {
         assert !isClosed();
-        assert null!=obj;
+        assert null != obj;
         matcher.reset(obj);
         getReceiver().process(matcher.replaceAll(replacement));
     }

--- a/metafacture-strings/src/main/java/org/metafacture/strings/StringReader.java
+++ b/metafacture-strings/src/main/java/org/metafacture/strings/StringReader.java
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.strings;
 
-import java.io.Reader;
+package org.metafacture.strings;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.ObjectReceiver;
@@ -24,6 +23,7 @@ import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
 
+import java.io.Reader;
 
 /**
  * Creates a reader for the supplied string and sends it to the receiver.
@@ -35,8 +35,10 @@ import org.metafacture.framework.helpers.DefaultObjectPipe;
 @In(String.class)
 @Out(java.io.Reader.class)
 @FluxCommand("read-string")
-public final class StringReader
-        extends DefaultObjectPipe<String, ObjectReceiver<Reader>> {
+public final class StringReader extends DefaultObjectPipe<String, ObjectReceiver<Reader>> {
+
+    public StringReader() {
+    }
 
     @Override
     public void process(final String str) {

--- a/metafacture-strings/src/main/java/org/metafacture/strings/UnicodeNormalizer.java
+++ b/metafacture-strings/src/main/java/org/metafacture/strings/UnicodeNormalizer.java
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.strings;
 
-import java.text.Normalizer;
+package org.metafacture.strings;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.ObjectReceiver;
@@ -23,6 +22,8 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
+
+import java.text.Normalizer;
 
 /**
  * Normalises Unicode characters in strings. Unicode normalisation converts
@@ -37,16 +38,17 @@ import org.metafacture.framework.helpers.DefaultObjectPipe;
 @In(String.class)
 @Out(String.class)
 @FluxCommand("normalize-unicode-string")
-public final class UnicodeNormalizer extends
-        DefaultObjectPipe<String, ObjectReceiver<String>> {
+public final class UnicodeNormalizer extends DefaultObjectPipe<String, ObjectReceiver<String>> {
 
     /**
      * The default value for {@link #setNormalizationForm(Normalizer.Form)}.
      */
-    public static final Normalizer.Form DEFAULT_NORMALIZATION_FORM =
-            Normalizer.Form.NFC;
+    public static final Normalizer.Form DEFAULT_NORMALIZATION_FORM = Normalizer.Form.NFC;
 
     private Normalizer.Form normalizationForm = DEFAULT_NORMALIZATION_FORM;
+
+    public UnicodeNormalizer() {
+    }
 
     /**
      * Sets the normalisation form used for normalising strings.

--- a/metafacture-strings/src/test/java/org/metafacture/strings/LineRecorderTest.java
+++ b/metafacture-strings/src/test/java/org/metafacture/strings/LineRecorderTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.strings;
 
 import static org.mockito.Mockito.inOrder;

--- a/metafacture-strings/src/test/java/org/metafacture/strings/LineSplitterTest.java
+++ b/metafacture-strings/src/test/java/org/metafacture/strings/LineSplitterTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.strings;
 
 import static org.mockito.Mockito.inOrder;

--- a/metafacture-strings/src/test/java/org/metafacture/strings/RegexDecoderTest.java
+++ b/metafacture-strings/src/test/java/org/metafacture/strings/RegexDecoderTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.strings;
 
 import static org.mockito.ArgumentMatchers.any;

--- a/metafacture-strings/src/test/java/org/metafacture/strings/StreamUnicodeNormalizerTest.java
+++ b/metafacture-strings/src/test/java/org/metafacture/strings/StreamUnicodeNormalizerTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.strings;
 
 import static org.mockito.Mockito.inOrder;

--- a/metafacture-strings/src/test/java/org/metafacture/strings/StringFilterTest.java
+++ b/metafacture-strings/src/test/java/org/metafacture/strings/StringFilterTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.strings;
 
 import static org.mockito.Mockito.inOrder;

--- a/metafacture-strings/src/test/java/org/metafacture/strings/StringMatcherTest.java
+++ b/metafacture-strings/src/test/java/org/metafacture/strings/StringMatcherTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.strings;
 
 import static org.mockito.Mockito.verify;

--- a/metafacture-strings/src/test/java/org/metafacture/strings/UnicodeNormalizerTest.java
+++ b/metafacture-strings/src/test/java/org/metafacture/strings/UnicodeNormalizerTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.strings;
 
 import static org.mockito.Mockito.verify;

--- a/metafacture-triples/src/main/java/org/metafacture/triples/AbstractTripleSort.java
+++ b/metafacture-triples/src/main/java/org/metafacture/triples/AbstractTripleSort.java
@@ -13,7 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.triples;
+
+import org.metafacture.framework.MetafactureException;
+import org.metafacture.framework.ObjectReceiver;
+import org.metafacture.framework.helpers.DefaultObjectPipe;
+import org.metafacture.framework.objects.Triple;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -25,11 +31,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.PriorityQueue;
 
-import org.metafacture.framework.MetafactureException;
-import org.metafacture.framework.ObjectReceiver;
-import org.metafacture.framework.helpers.DefaultObjectPipe;
-import org.metafacture.framework.objects.Triple;
-
 /**
  * @author markus geipel
  *
@@ -39,7 +40,7 @@ public abstract class AbstractTripleSort extends DefaultObjectPipe<Triple, Objec
      * specifies the comparator
      */
     public enum Compare {
-        SUBJECT, PREDICATE, OBJECT, ALL;
+        SUBJECT, PREDICATE, OBJECT, ALL
     }
 
     /**
@@ -88,8 +89,8 @@ public abstract class AbstractTripleSort extends DefaultObjectPipe<Triple, Objec
         return compare;
     }
 
-    protected final void setSortOrder(final Order order) {
-        this.order = order;
+    protected final void setSortOrder(final Order newOrder) {
+        order = newOrder;
     }
 
     @Override
@@ -99,9 +100,11 @@ public abstract class AbstractTripleSort extends DefaultObjectPipe<Triple, Objec
                 if (!buffer.isEmpty()) {
                     nextBatch();
                 }
-            } catch (final IOException e) {
+            }
+            catch (final IOException e) {
                 throw new MetafactureException("Error writing to temp file after sorting", e);
-            } finally {
+            }
+            finally {
                 memoryLow = false;
             }
         }
@@ -118,7 +121,8 @@ public abstract class AbstractTripleSort extends DefaultObjectPipe<Triple, Objec
             for (final Triple triple : buffer) {
                 triple.write(out);
             }
-        } finally {
+        }
+        finally {
             out.close();
         }
         buffer.clear();
@@ -134,7 +138,8 @@ public abstract class AbstractTripleSort extends DefaultObjectPipe<Triple, Objec
                 sortedTriple(triple);
             }
             onFinished();
-        } else {
+        }
+        else {
             final Comparator<Triple> comparator = createComparator(compare, order);
             final PriorityQueue<SortedTripleFileFacade> queue = new PriorityQueue<SortedTripleFileFacade>(11,
                     new Comparator<SortedTripleFileFacade>() {
@@ -158,14 +163,17 @@ public abstract class AbstractTripleSort extends DefaultObjectPipe<Triple, Objec
                     sortedTriple(triple);
                     if (sortedFileFacade.isEmpty()) {
                         sortedFileFacade.close();
-                    } else {
+                    }
+                    else {
                         queue.add(sortedFileFacade);
                     }
                 }
                 onFinished();
-            } catch (final IOException e) {
+            }
+            catch (final IOException e) {
                 throw new MetafactureException("Error merging temp files", e);
-            } finally {
+            }
+            finally {
                 for (final SortedTripleFileFacade sortedFileFacade : queue) {
                     sortedFileFacade.close();
                 }
@@ -176,7 +184,6 @@ public abstract class AbstractTripleSort extends DefaultObjectPipe<Triple, Objec
 
     protected void onFinished() {
         // nothing to do
-
     }
 
     protected abstract void sortedTriple(Triple namedValue);
@@ -188,39 +195,39 @@ public abstract class AbstractTripleSort extends DefaultObjectPipe<Triple, Objec
     public static Comparator<Triple> createComparator(final Compare compareBy, final Order order) {
         final Comparator<Triple> comparator;
         switch (compareBy) {
-        case ALL:
-            comparator = new Comparator<Triple>() {
-                @Override
-                public int compare(final Triple o1, final Triple o2) {
-                    return order.order(o1.compareTo(o2));
-                }
-            };
-            break;
-        case OBJECT:
-            comparator = new Comparator<Triple>() {
-                @Override
-                public int compare(final Triple o1, final Triple o2) {
-                    return order.order(o1.getObject().compareTo(o2.getObject()));
-                }
-            };
-            break;
-        case SUBJECT:
-            comparator = new Comparator<Triple>() {
-                @Override
-                public int compare(final Triple o1, final Triple o2) {
-                    return order.order(o1.getSubject().compareTo(o2.getSubject()));
-                }
-            };
-            break;
-        case PREDICATE:
-        default:
-            comparator = new Comparator<Triple>() {
-                @Override
-                public int compare(final Triple o1, final Triple o2) {
-                    return order.order(o1.getPredicate().compareTo(o2.getPredicate()));
-                }
-            };
-            break;
+            case ALL:
+                comparator = new Comparator<Triple>() {
+                    @Override
+                    public int compare(final Triple o1, final Triple o2) {
+                        return order.order(o1.compareTo(o2));
+                    }
+                };
+                break;
+            case OBJECT:
+                comparator = new Comparator<Triple>() {
+                    @Override
+                    public int compare(final Triple o1, final Triple o2) {
+                        return order.order(o1.getObject().compareTo(o2.getObject()));
+                    }
+                };
+                break;
+            case SUBJECT:
+                comparator = new Comparator<Triple>() {
+                    @Override
+                    public int compare(final Triple o1, final Triple o2) {
+                        return order.order(o1.getSubject().compareTo(o2.getSubject()));
+                    }
+                };
+                break;
+            case PREDICATE:
+            default:
+                comparator = new Comparator<Triple>() {
+                    @Override
+                    public int compare(final Triple o1, final Triple o2) {
+                        return order.order(o1.getPredicate().compareTo(o2.getPredicate()));
+                    }
+                };
+                break;
         }
 
         return comparator;

--- a/metafacture-triples/src/main/java/org/metafacture/triples/MemoryWarningSystem.java
+++ b/metafacture-triples/src/main/java/org/metafacture/triples/MemoryWarningSystem.java
@@ -16,6 +16,7 @@
 /*
  *  Code based on http://www.javaspecialists.eu/archive/Issue092.html
  */
+
 package org.metafacture.triples;
 
 import java.lang.management.ManagementFactory;
@@ -25,7 +26,6 @@ import java.lang.management.MemoryPoolMXBean;
 import java.lang.management.MemoryType;
 import java.util.Collection;
 import java.util.concurrent.CopyOnWriteArrayList;
-
 import javax.management.Notification;
 import javax.management.NotificationEmitter;
 import javax.management.NotificationListener;
@@ -61,7 +61,7 @@ final class MemoryWarningSystem {
         }, null, null);
     }
 
-    private static Collection<Listener> getListeners(){
+    private static Collection<Listener> getListeners() {
         return LISTENERS;
     }
 
@@ -97,10 +97,11 @@ final class MemoryWarningSystem {
     private static MemoryPoolMXBean findTenuredGenPool() {
         // I don't know whether this approach is better, or whether
         // we should rather check for the pool name "Tenured Gen"?
-        for (final MemoryPoolMXBean pool : ManagementFactory.getMemoryPoolMXBeans())
+        for (final MemoryPoolMXBean pool : ManagementFactory.getMemoryPoolMXBeans()) {
             if (pool.getType() == MemoryType.HEAP && pool.isUsageThresholdSupported()) {
                 return pool;
             }
+        }
         throw new AssertionError("Could not find tenured space");
     }
 

--- a/metafacture-triples/src/main/java/org/metafacture/triples/SortedTripleFileFacade.java
+++ b/metafacture-triples/src/main/java/org/metafacture/triples/SortedTripleFileFacade.java
@@ -13,7 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.triples;
+
+import org.metafacture.framework.MetafactureException;
+import org.metafacture.framework.objects.Triple;
 
 import java.io.BufferedInputStream;
 import java.io.EOFException;
@@ -21,10 +25,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
-
-import org.metafacture.framework.MetafactureException;
-import org.metafacture.framework.objects.Triple;
-
 
 /**
  * @author markus geipel
@@ -51,18 +51,18 @@ public final class SortedTripleFileFacade {
         try {
             triple = Triple.read(in);
             empty = false;
-
-        } catch (EOFException e) {
+        }
+        catch (final EOFException e) {
             empty = true;
             triple = null;
         }
     }
 
     public void close() {
-
         try {
             in.close();
-        } catch (IOException e) {
+        }
+        catch (final IOException e) {
             throw new MetafactureException("Error closing input stream", e);
         }
         if (file.exists()) {
@@ -78,10 +78,9 @@ public final class SortedTripleFileFacade {
     }
 
     public Triple pop() throws IOException {
-        final Triple triple = peek();
+        final Triple nextTriple = peek();
         next();
-        return triple;
+        return nextTriple;
     }
-
 
 }

--- a/metafacture-triples/src/main/java/org/metafacture/triples/StreamToTriples.java
+++ b/metafacture-triples/src/main/java/org/metafacture/triples/StreamToTriples.java
@@ -13,12 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.triples;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+package org.metafacture.triples;
 
 import org.metafacture.formeta.formatter.ConciseFormatter;
 import org.metafacture.formeta.formatter.Formatter;
@@ -30,8 +26,13 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultStreamPipe;
-import org.metafacture.framework.objects.Triple;
 import org.metafacture.framework.objects.Triple.ObjectType;
+import org.metafacture.framework.objects.Triple;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Emits the literals which are received as triples such
@@ -82,6 +83,9 @@ public final class StreamToTriples extends DefaultStreamPipe<ObjectReceiver<Trip
     private String predicateName;
     private String currentId;
 
+    public StreamToTriples() {
+    }
+
     public boolean isRedirect() {
         return redirect;
     }
@@ -107,7 +111,8 @@ public final class StreamToTriples extends DefaultStreamPipe<ObjectReceiver<Trip
         if (recordPredicate != null) {
             encodeLevel = 0;
             startEncode(recordPredicate);
-        } else {
+        }
+        else {
             encodeLevel = 1;
         }
 
@@ -140,7 +145,8 @@ public final class StreamToTriples extends DefaultStreamPipe<ObjectReceiver<Trip
 
         if (nestingLevel > encodeLevel) {
             formatter.startGroup(name);
-        } else {
+        }
+        else {
             startEncode(name);
         }
         ++nestingLevel;
@@ -153,7 +159,8 @@ public final class StreamToTriples extends DefaultStreamPipe<ObjectReceiver<Trip
         --nestingLevel;
         if (nestingLevel == encodeLevel) {
             endEncode();
-        } else {
+        }
+        else {
             formatter.endGroup();
         }
     }
@@ -165,10 +172,12 @@ public final class StreamToTriples extends DefaultStreamPipe<ObjectReceiver<Trip
         if (nestingLevel > encodeLevel) {
             if (nestingLevel == 1 && redirect && StandardEventNames.ID.equals(name)) {
                 currentId = value;
-            } else {
+            }
+            else {
                 formatter.literal(name, value);
             }
-        } else {
+        }
+        else {
             dispatch(name, value, ObjectType.STRING);
         }
     }
@@ -188,17 +197,20 @@ public final class StreamToTriples extends DefaultStreamPipe<ObjectReceiver<Trip
         if (redirect) {
             if (StandardEventNames.ID.equals(name)) {
                 currentId = value;
-            } else {
+            }
+            else {
                 final Matcher matcher = REDIRECT_PATTERN.matcher(name);
                 if (matcher.find()) {
                     getReceiver().process(new Triple(matcher.group(1), matcher.group(2), value, type));
-                } else {
+                }
+                else {
                     nameBuffer.add(name);
                     valueBuffer.add(value);
                     typeBuffer.add(type);
                 }
             }
-        } else {
+        }
+        else {
             getReceiver().process(new Triple(currentId, name, value, type));
         }
     }

--- a/metafacture-triples/src/main/java/org/metafacture/triples/TripleCollect.java
+++ b/metafacture-triples/src/main/java/org/metafacture/triples/TripleCollect.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.triples;
 
 import org.metafacture.formeta.parser.FormetaParser;
@@ -57,7 +58,8 @@ public final class TripleCollect extends DefaultObjectPipe<Triple, StreamReceive
 
         if (currentSubject.equals(triple.getSubject())) {
             decodeTriple(triple);
-        } else {
+        }
+        else {
             getReceiver().endRecord();
             currentSubject = triple.getSubject();
             getReceiver().startRecord(currentSubject);
@@ -66,12 +68,14 @@ public final class TripleCollect extends DefaultObjectPipe<Triple, StreamReceive
     }
 
     public void decodeTriple(final Triple triple) {
-        if(triple.getObjectType() == ObjectType.STRING){
+        if (triple.getObjectType() == ObjectType.STRING) {
             getReceiver().literal(triple.getPredicate(), triple.getObject());
-        }else if (triple.getObjectType() == ObjectType.ENTITY){
+        }
+        else if (triple.getObjectType() == ObjectType.ENTITY) {
             emitter.setDefaultName(triple.getPredicate());
             parser.parse(triple.getObject());
-        }else{
+        }
+        else {
             throw new UnsupportedOperationException(triple.getObjectType() + " can not yet be decoded");
         }
     }

--- a/metafacture-triples/src/main/java/org/metafacture/triples/TripleCount.java
+++ b/metafacture-triples/src/main/java/org/metafacture/triples/TripleCount.java
@@ -13,15 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.triples;
 
-import java.util.Comparator;
+package org.metafacture.triples;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.objects.Triple;
+
+import java.util.Comparator;
 
 /**
  * Counts triples.
@@ -44,17 +45,20 @@ public final class TripleCount extends AbstractTripleSort {
     private String countPredicate = DEFAULT_COUNTP_REDICATE;
     private Comparator<Triple> comparator;
 
+    public TripleCount() {
+    }
+
     @Override
     protected void sortedTriple(final Triple triple) {
-
-        if(current==INIT){
+        if (current == INIT) {
             current = triple;
             comparator = createComparator();
         }
 
-        if(comparator.compare(current, triple)==0){
+        if (comparator.compare(current, triple) == 0) {
             ++count;
-        }else{
+        }
+        else {
             writeResult();
             current = triple;
             count = 1;
@@ -73,23 +77,23 @@ public final class TripleCount extends AbstractTripleSort {
     private void writeResult() {
         final Compare compareBy = getCompare();
         switch (compareBy) {
-        case ALL:
-            getReceiver().process(new Triple(current.toString(), countPredicate , String.valueOf(count)));
-            break;
-        case OBJECT:
-            getReceiver().process(new Triple(current.getObject(), countPredicate, String.valueOf(count)));
-            break;
-        case PREDICATE:
-            getReceiver().process(new Triple(current.getPredicate(), countPredicate, String.valueOf(count)));
-            break;
-        case SUBJECT:
-        default:
-            getReceiver().process(new Triple(current.getSubject(), countPredicate, String.valueOf(count)));
-            break;
+            case ALL:
+                getReceiver().process(new Triple(current.toString(), countPredicate, String.valueOf(count)));
+                break;
+            case OBJECT:
+                getReceiver().process(new Triple(current.getObject(), countPredicate, String.valueOf(count)));
+                break;
+            case PREDICATE:
+                getReceiver().process(new Triple(current.getPredicate(), countPredicate, String.valueOf(count)));
+                break;
+            case SUBJECT:
+            default:
+                getReceiver().process(new Triple(current.getSubject(), countPredicate, String.valueOf(count)));
+                break;
         }
     }
 
-    public void setCountBy(final Compare countBy){
+    public void setCountBy(final Compare countBy) {
         setCompare(countBy);
     }
 }

--- a/metafacture-triples/src/main/java/org/metafacture/triples/TripleFilter.java
+++ b/metafacture-triples/src/main/java/org/metafacture/triples/TripleFilter.java
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.triples;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+package org.metafacture.triples;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.ObjectReceiver;
@@ -25,6 +23,9 @@ import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
 import org.metafacture.framework.objects.Triple;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Filters triples. The patterns for subject, predicate and object are disjunctive.
@@ -36,8 +37,7 @@ import org.metafacture.framework.objects.Triple;
 @In(Triple.class)
 @Out(Triple.class)
 @FluxCommand("filter-triples")
-public final class TripleFilter extends
-        DefaultObjectPipe<Triple, ObjectReceiver<Triple>> {
+public final class TripleFilter extends DefaultObjectPipe<Triple, ObjectReceiver<Triple>> {
 
     // A regexp that is guaranteed to never match ( an `a` after the end
     // of the string, see http://stackoverflow.com/a/1723225 for details):
@@ -47,6 +47,9 @@ public final class TripleFilter extends
     private Matcher predicateMatcher = MATCH_NOTHING;
     private Matcher objectMatcher = MATCH_NOTHING;
     private boolean passMatches = true;
+
+    public TripleFilter() {
+    }
 
     public String getSubjectPattern() {
         return subjectMatcher.pattern().pattern();

--- a/metafacture-triples/src/main/java/org/metafacture/triples/TripleObjectRetriever.java
+++ b/metafacture-triples/src/main/java/org/metafacture/triples/TripleObjectRetriever.java
@@ -13,14 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.triples;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.net.URLConnection;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
+package org.metafacture.triples;
 
 import org.metafacture.commons.ResourceUtil;
 import org.metafacture.framework.FluxCommand;
@@ -30,8 +24,15 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
-import org.metafacture.framework.objects.Triple;
 import org.metafacture.framework.objects.Triple.ObjectType;
+import org.metafacture.framework.objects.Triple;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Uses the object value of the triple as a URL and emits a new triple
@@ -40,16 +41,18 @@ import org.metafacture.framework.objects.Triple.ObjectType;
  *
  * @author Christoph Böhme
  */
-@Description("Uses the object value of the triple as a URL and emits a new triple "
-        + "in which the object value is replaced with the contents of the resource "
-        + "identified by the URL.")
+@Description("Uses the object value of the triple as a URL and emits a new triple " +
+    "in which the object value is replaced with the contents of the resource " +
+    "identified by the URL.")
 @In(Triple.class)
 @Out(Triple.class)
 @FluxCommand("retrieve-triple-objects")
-public final class TripleObjectRetriever
-        extends DefaultObjectPipe<Triple, ObjectReceiver<Triple>> {
+public final class TripleObjectRetriever extends DefaultObjectPipe<Triple, ObjectReceiver<Triple>> {
 
     private Charset defaultEncoding = StandardCharsets.UTF_8;
+
+    public TripleObjectRetriever() {
+    }
 
     /**
      * Sets the default encoding to use when no encoding is
@@ -98,13 +101,12 @@ public final class TripleObjectRetriever
             final URLConnection connection = url.openConnection();
             connection.connect();
             final String encodingName = connection.getContentEncoding();
-            final Charset encoding = encodingName != null ?
-                    Charset.forName(encodingName) :
-                    defaultEncoding;
+            final Charset encoding = encodingName != null ? Charset.forName(encodingName) : defaultEncoding;
             try (InputStream inputStream = connection.getInputStream()) {
                 return ResourceUtil.readAll(inputStream, encoding);
             }
-        } catch (final IOException e) {
+        }
+        catch (final IOException e) {
             throw new MetafactureException(e);
         }
     }

--- a/metafacture-triples/src/main/java/org/metafacture/triples/TripleObjectWriter.java
+++ b/metafacture-triples/src/main/java/org/metafacture/triples/TripleObjectWriter.java
@@ -13,15 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.triples;
 
-import java.io.IOException;
-import java.io.Writer;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+package org.metafacture.triples;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.MetafactureException;
@@ -30,6 +23,14 @@ import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectReceiver;
 import org.metafacture.framework.objects.Triple;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 /**
  * Writes the object value of the triple into a file. The filename
@@ -42,11 +43,11 @@ import org.metafacture.framework.objects.Triple;
  *
  * @author Christoph Böhme
  */
-@Description("Writes the object value of the triple into a file. The filename is "
-        + "constructed from subject and predicate. Please note: This module does "
-        + "not check if the filename constructed from subject and predicate stays "
-        + "within `baseDir`. THIS MODULE SHOULD NOT BE USED IN ENVIRONMENTS IN WHICH "
-        + "THE VALUES OF SUBJECT AND PREDICATE A PROVIDED BY AN UNTRUSTED SOURCE!")
+@Description("Writes the object value of the triple into a file. The filename is " +
+    "constructed from subject and predicate. Please note: This module does " +
+    "not check if the filename constructed from subject and predicate stays " +
+    "within `baseDir`. THIS MODULE SHOULD NOT BE USED IN ENVIRONMENTS IN WHICH " +
+    "THE VALUES OF SUBJECT AND PREDICATE A PROVIDED BY AN UNTRUSTED SOURCE!")
 @In(Triple.class)
 @Out(Void.class)
 @FluxCommand("write-triple-objects")
@@ -93,9 +94,10 @@ public final class TripleObjectWriter extends DefaultObjectReceiver<Triple> {
     public void process(final Triple triple) {
         final Path filePath = buildFilePath(triple);
         ensureParentPathExists(filePath);
-        try(final Writer writer = Files.newBufferedWriter(filePath, encoding)) {
+        try (Writer writer = Files.newBufferedWriter(filePath, encoding)) {
             writer.write(triple.getObject());
-        } catch (final IOException e) {
+        }
+        catch (final IOException e) {
             throw new MetafactureException(e);
         }
     }
@@ -110,7 +112,8 @@ public final class TripleObjectWriter extends DefaultObjectReceiver<Triple> {
         if (parentDir != null) {
             try {
                 Files.createDirectories(parentDir);
-            } catch (final IOException e) {
+            }
+            catch (final IOException e) {
                 throw new MetafactureException(e);
             }
         }

--- a/metafacture-triples/src/main/java/org/metafacture/triples/TripleReader.java
+++ b/metafacture-triples/src/main/java/org/metafacture/triples/TripleReader.java
@@ -13,13 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.triples;
 
-import java.io.BufferedInputStream;
-import java.io.EOFException;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.ObjectInputStream;
+package org.metafacture.triples;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.MetafactureException;
@@ -27,15 +22,23 @@ import org.metafacture.framework.ObjectReceiver;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
 import org.metafacture.framework.objects.Triple;
 
+import java.io.BufferedInputStream;
+import java.io.EOFException;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+
 /**
  * @author Christoph Böhme
  *
  */
 @FluxCommand("read-triples")
-public final class TripleReader extends
-        DefaultObjectPipe<String, ObjectReceiver<Triple>> {
+public final class TripleReader extends DefaultObjectPipe<String, ObjectReceiver<Triple>> {
 
     public static final int BUFFERSIZE = 2048;
+
+    public TripleReader() {
+    }
 
     @Override
     public void process(final String filename) {
@@ -46,11 +49,14 @@ public final class TripleReader extends
                 while (true) {
                     getReceiver().process(Triple.read(in));
                 }
-            } catch (EOFException e) {
-            } finally {
+            }
+            catch (final EOFException e) {
+            }
+            finally {
                 in.close();
             }
-        } catch (IOException e) {
+        }
+        catch (final IOException e) {
             throw new MetafactureException(e);
         }
     }

--- a/metafacture-triples/src/main/java/org/metafacture/triples/TripleReorder.java
+++ b/metafacture-triples/src/main/java/org/metafacture/triples/TripleReorder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.triples;
 
 import org.metafacture.framework.FluxCommand;
@@ -33,19 +34,21 @@ import org.metafacture.framework.objects.Triple;
 @In(Triple.class)
 @Out(Triple.class)
 @FluxCommand("reorder-triple")
-public final class TripleReorder extends
-        DefaultObjectPipe<Triple, ObjectReceiver<Triple>> {
+public final class TripleReorder extends DefaultObjectPipe<Triple, ObjectReceiver<Triple>> {
 
     /**
      * Names of the elements in the triple
      */
-    public enum TripleElement { SUBJECT, PREDICATE, OBJECT };
+    public enum TripleElement { SUBJECT, PREDICATE, OBJECT }
     // Do not change the item order because the process method
     // uses ordinal().
 
     private TripleElement subjectFrom = TripleElement.SUBJECT;
     private TripleElement predicateFrom = TripleElement.PREDICATE;
     private TripleElement objectFrom =  TripleElement.OBJECT;
+
+    public TripleReorder() {
+    }
 
     public TripleElement getSubjectFrom() {
         return subjectFrom;
@@ -76,7 +79,7 @@ public final class TripleReorder extends
         final String[] elements = {
                 triple.getSubject(),
                 triple.getPredicate(),
-                triple.getObject(),
+                triple.getObject()
         };
 
         getReceiver().process(new Triple(

--- a/metafacture-triples/src/main/java/org/metafacture/triples/TripleSort.java
+++ b/metafacture-triples/src/main/java/org/metafacture/triples/TripleSort.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.triples;
 
 import org.metafacture.framework.FluxCommand;
@@ -32,18 +33,20 @@ import org.metafacture.framework.objects.Triple;
 @FluxCommand("sort-triples")
 public final class TripleSort extends AbstractTripleSort {
 
+    public TripleSort() {
+    }
+
     @Override
     protected void sortedTriple(final Triple triple) {
         getReceiver().process(triple);
     }
 
-    public void setBy(final Compare compare){
+    public void setBy(final Compare compare) {
         setCompare(compare);
     }
 
-    public void setOrder(final Order order){
+    public void setOrder(final Order order) {
         setSortOrder(order);
     }
-
 
 }

--- a/metafacture-triples/src/main/java/org/metafacture/triples/TripleWriter.java
+++ b/metafacture-triples/src/main/java/org/metafacture/triples/TripleWriter.java
@@ -13,12 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.triples;
 
-import java.io.BufferedOutputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.ObjectOutputStream;
+package org.metafacture.triples;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.MetafactureException;
@@ -27,6 +23,11 @@ import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectReceiver;
 import org.metafacture.framework.objects.Triple;
+
+import java.io.BufferedOutputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
 
 /**
  * @author Christoph Böhme
@@ -53,7 +54,8 @@ public final class TripleWriter extends DefaultObjectReceiver<Triple> {
     public void process(final Triple obj) {
         try {
             obj.write(outputStream);
-        } catch (IOException e) {
+        }
+        catch (final IOException e) {
             throw new MetafactureException(e);
         }
     }
@@ -65,7 +67,8 @@ public final class TripleWriter extends DefaultObjectReceiver<Triple> {
                 outputStream.close();
             }
             outputStream = new ObjectOutputStream(new BufferedOutputStream(new FileOutputStream(filename), BUFFERSIZE));
-        } catch (IOException e) {
+        }
+        catch (final IOException e) {
             throw new MetafactureException(e);
         }
     }
@@ -76,7 +79,8 @@ public final class TripleWriter extends DefaultObjectReceiver<Triple> {
             if (outputStream != null) {
                 outputStream.close();
             }
-        } catch (IOException e) {
+        }
+        catch (final IOException e) {
             throw new MetafactureException(e);
         }
     }

--- a/metafacture-triples/src/main/java/org/metafacture/triples/TriplesToStream.java
+++ b/metafacture-triples/src/main/java/org/metafacture/triples/TriplesToStream.java
@@ -17,6 +17,7 @@
 /**
  *
  */
+
 package org.metafacture.triples;
 
 import org.metafacture.formeta.parser.FormetaParser;
@@ -53,12 +54,14 @@ public final class TriplesToStream extends
     @Override
     public void process(final Triple triple) {
         getReceiver().startRecord(triple.getSubject());
-        if(triple.getObjectType() == ObjectType.STRING){
+        if (triple.getObjectType() == ObjectType.STRING) {
             getReceiver().literal(triple.getPredicate(), triple.getObject());
-        }else if (triple.getObjectType() == ObjectType.ENTITY){
+        }
+        else if (triple.getObjectType() == ObjectType.ENTITY) {
             emitter.setDefaultName(triple.getPredicate());
             parser.parse(triple.getObject());
-        }else{
+        }
+        else {
             throw new UnsupportedOperationException(triple.getObjectType() + " can not yet be decoded");
         }
         getReceiver().endRecord();

--- a/metafacture-triples/src/test/java/org/metafacture/triples/AbstractTripleSortTest.java
+++ b/metafacture-triples/src/test/java/org/metafacture/triples/AbstractTripleSortTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.triples;
 
 import static org.junit.Assert.assertTrue;

--- a/metafacture-triples/src/test/java/org/metafacture/triples/StreamToTriplesTest.java
+++ b/metafacture-triples/src/test/java/org/metafacture/triples/StreamToTriplesTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.triples;
 
 import org.junit.Before;

--- a/metafacture-triples/src/test/java/org/metafacture/triples/TripleCollectTest.java
+++ b/metafacture-triples/src/test/java/org/metafacture/triples/TripleCollectTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.triples;
 
 import static org.mockito.Mockito.never;

--- a/metafacture-triples/src/test/java/org/metafacture/triples/TripleFilterTest.java
+++ b/metafacture-triples/src/test/java/org/metafacture/triples/TripleFilterTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.triples;
 
 import static org.mockito.Mockito.verify;

--- a/metafacture-triples/src/test/java/org/metafacture/triples/TripleObjectRetrieverTest.java
+++ b/metafacture-triples/src/test/java/org/metafacture/triples/TripleObjectRetrieverTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.triples;
 
 import static org.mockito.Mockito.verify;

--- a/metafacture-triples/src/test/java/org/metafacture/triples/TripleObjectWriterTest.java
+++ b/metafacture-triples/src/test/java/org/metafacture/triples/TripleObjectWriterTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.triples;
 
 import static org.junit.Assert.assertEquals;

--- a/metafacture-triples/src/test/java/org/metafacture/triples/TripleReaderWriterTest.java
+++ b/metafacture-triples/src/test/java/org/metafacture/triples/TripleReaderWriterTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.triples;
 
 import static org.mockito.Mockito.verify;

--- a/metafacture-xml/src/main/java/org/metafacture/xml/CGXmlHandler.java
+++ b/metafacture-xml/src/main/java/org/metafacture/xml/CGXmlHandler.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.xml;
 
 import org.metafacture.framework.FluxCommand;
@@ -23,6 +24,7 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultXmlPipe;
+
 import org.xml.sax.Attributes;
 
 /**
@@ -60,8 +62,7 @@ import org.xml.sax.Attributes;
 @FluxCommand("handle-cg-xml")
 public final class CGXmlHandler extends DefaultXmlPipe<StreamReceiver> {
 
-    public static final String CGXML_NAMESPACE =
-            "http://www.culturegraph.org/cgxml";
+    public static final String CGXML_NAMESPACE = "http://www.culturegraph.org/cgxml";
 
     private static final String ROOT_TAG = "cgxml";
     private static final String RECORDS_TAG = "records";
@@ -75,6 +76,9 @@ public final class CGXmlHandler extends DefaultXmlPipe<StreamReceiver> {
     private static final String VALUE_ATTR = "value";
 
     private static final String VERSION = "1.0";
+
+    public CGXmlHandler() {
+    }
 
     @Override
     public void startElement(final String uri, final String localName,
@@ -114,7 +118,8 @@ public final class CGXmlHandler extends DefaultXmlPipe<StreamReceiver> {
         final String recordId = attributes.getValue("", ID_ATTR);
         if (recordId == null) {
             getReceiver().startRecord("");
-        } else {
+        }
+        else {
             getReceiver().startRecord(recordId);
         }
     }
@@ -144,7 +149,8 @@ public final class CGXmlHandler extends DefaultXmlPipe<StreamReceiver> {
         }
         if (RECORD_TAG.equals(localName)) {
             getReceiver().endRecord();
-        } else if (ENTITY_TAG.equals(localName)) {
+        }
+        else if (ENTITY_TAG.equals(localName)) {
             getReceiver().endEntity();
         }
     }

--- a/metafacture-xml/src/main/java/org/metafacture/xml/FilenameExtractor.java
+++ b/metafacture-xml/src/main/java/org/metafacture/xml/FilenameExtractor.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.xml;
 
 import java.io.File;
@@ -24,34 +25,6 @@ import java.io.File;
  *
  */
 public interface FilenameExtractor extends RecordIdentifier {
-
-    /**
-     * Provides functions and fields that all {@link FilenameExtractor}
-     * implementing classes may found useful.
-     *
-     * @author Pascal Christoph (dr0i)
-     *
-     */
-    class FilenameUtil {
-        public String target = "tmp";
-        public String encoding = "UTF-8";
-        public String property = null;
-        public String fileSuffix = null;
-        public int startIndex = 0;
-        public int endIndex = 0;
-        public String filename = "test";
-
-        /**
-         * Ensures that path exists. If not, make it.
-         *
-         * @param path
-         *            the path of the to be stored file.
-         */
-        public void ensurePathExists(final File path) {
-            final File parent = path.getAbsoluteFile().getParentFile();
-            parent.mkdirs();
-        }
-    }
 
     /**
      * Returns the encoding used to open the resource.
@@ -66,7 +39,7 @@ public interface FilenameExtractor extends RecordIdentifier {
      * @param encoding
      *            new encoding
      */
-    void setEncoding(final String encoding);
+    void setEncoding(String encoding);
 
     /**
      * Sets the end of the index in the filename to extract the name of the
@@ -75,7 +48,7 @@ public interface FilenameExtractor extends RecordIdentifier {
      * @param endIndex
      *            This marks the index' end.
      */
-    void setEndIndex(final int endIndex);
+    void setEndIndex(int endIndex);
 
     /**
      * Sets the file's suffix.
@@ -83,7 +56,7 @@ public interface FilenameExtractor extends RecordIdentifier {
      * @param fileSuffix
      *            the suffix used for the to be generated files
      */
-    void setFileSuffix(final String fileSuffix);
+    void setFileSuffix(String fileSuffix);
 
     /**
      * Sets the beginning of the index in the filename to extract the name of
@@ -92,7 +65,7 @@ public interface FilenameExtractor extends RecordIdentifier {
      * @param startIndex
      *            This marks the index' beginning.
      */
-    void setStartIndex(final int startIndex);
+    void setStartIndex(int startIndex);
 
     /**
      * Sets the target path.
@@ -100,6 +73,95 @@ public interface FilenameExtractor extends RecordIdentifier {
      * @param target
      *            the basis directory in which the files are stored
      */
-    void setTarget(final String target);
+    void setTarget(String target);
+
+    /**
+     * Provides functions and fields that all {@link FilenameExtractor}
+     * implementing classes may found useful.
+     *
+     * @author Pascal Christoph (dr0i)
+     *
+     */
+    class FilenameUtil {
+
+        private String encoding = "UTF-8";
+        private String fileSuffix;
+        private String filename = "test";
+        private String property;
+        private String target = "tmp";
+        private int endIndex;
+        private int startIndex;
+
+        FilenameUtil() {
+        }
+
+        /**
+         * Ensures that path exists. If not, make it.
+         *
+         * @param path
+         *            the path of the to be stored file.
+         */
+        public void ensurePathExists(final File path) {
+            final File parent = path.getAbsoluteFile().getParentFile();
+            parent.mkdirs();
+        }
+
+        public void setEncoding(final String encoding) {
+            this.encoding = encoding;
+        }
+
+        public String getEncoding() {
+            return encoding;
+        }
+
+        public void setFileSuffix(final String fileSuffix) {
+            this.fileSuffix = fileSuffix;
+        }
+
+        public String getFileSuffix() {
+            return fileSuffix;
+        }
+
+        public void setFilename(final String filename) {
+            this.filename = filename;
+        }
+
+        public String getFilename() {
+            return filename;
+        }
+
+        public void setProperty(final String property) {
+            this.property = property;
+        }
+
+        public String getProperty() {
+            return property;
+        }
+
+        public void setTarget(final String target) {
+            this.target = target;
+        }
+
+        public String getTarget() {
+            return target;
+        }
+
+        public void setEndIndex(final int endIndex) {
+            this.endIndex = endIndex;
+        }
+
+        public int getEndIndex() {
+            return endIndex;
+        }
+
+        public void setStartIndex(final int startIndex) {
+            this.startIndex = startIndex;
+        }
+
+        public int getStartIndex() {
+            return startIndex;
+        }
+
+    }
 
 }

--- a/metafacture-xml/src/main/java/org/metafacture/xml/GenericXmlHandler.java
+++ b/metafacture-xml/src/main/java/org/metafacture/xml/GenericXmlHandler.java
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.xml;
 
-import java.util.regex.Pattern;
+package org.metafacture.xml;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.StreamReceiver;
@@ -24,8 +23,10 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultXmlPipe;
+
 import org.xml.sax.Attributes;
 
+import java.util.regex.Pattern;
 
 /**
  * A generic xml reader.
@@ -41,6 +42,8 @@ public final class GenericXmlHandler extends DefaultXmlPipe<StreamReceiver> {
 
     public static final String DEFAULT_RECORD_TAG = "record";
 
+    public static final boolean EMIT_NAMESPACE = false;
+
     private static final Pattern TABS = Pattern.compile("\t+");
 
     private String recordTagName = DEFAULT_RECORD_TAG;
@@ -48,15 +51,12 @@ public final class GenericXmlHandler extends DefaultXmlPipe<StreamReceiver> {
     private boolean inRecord;
     private StringBuilder valueBuffer = new StringBuilder();
 
-    public static final boolean EMIT_NAMESPACE = false;
     private boolean emitNamespace = EMIT_NAMESPACE;
 
     public GenericXmlHandler() {
-        super();
-        final String recordTagNameProperty = System.getProperty(
-                "org.culturegraph.metamorph.xml.recordtag");
+        final String recordTagNameProperty = System.getProperty("org.culturegraph.metamorph.xml.recordtag");
         if (recordTagNameProperty != null) {
-           recordTagName = recordTagNameProperty;
+            recordTagName = recordTagNameProperty;
         }
     }
 
@@ -71,7 +71,6 @@ public final class GenericXmlHandler extends DefaultXmlPipe<StreamReceiver> {
      */
     @Deprecated
     public GenericXmlHandler(final String recordTagName) {
-        super();
         this.recordTagName = recordTagName;
     }
 
@@ -85,7 +84,7 @@ public final class GenericXmlHandler extends DefaultXmlPipe<StreamReceiver> {
      *
      * @param recordTagName the tag name which marks the start of a record.
      */
-    public void setRecordTagName(String recordTagName) {
+    public void setRecordTagName(final String recordTagName) {
         this.recordTagName = recordTagName;
     }
 
@@ -103,7 +102,7 @@ public final class GenericXmlHandler extends DefaultXmlPipe<StreamReceiver> {
      * @param emitNamespace set to "true" if namespace should be emitted. Defaults
      *                      to "false".
      */
-    public void setEmitNamespace(boolean emitNamespace) {
+    public void setEmitNamespace(final boolean emitNamespace) {
         this.emitNamespace = emitNamespace;
     }
 
@@ -112,22 +111,23 @@ public final class GenericXmlHandler extends DefaultXmlPipe<StreamReceiver> {
     }
 
     @Override
-    public void startElement(final String uri, final String localName,
-            final String qName, final Attributes attributes) {
-
+    public void startElement(final String uri, final String localName, final String qName, final Attributes attributes) {
         if (inRecord) {
             writeValue();
             if (emitNamespace) {
                 getReceiver().startEntity(qName);
-            } else {
+            }
+            else {
                 getReceiver().startEntity(localName);
             }
             writeAttributes(attributes);
-        } else if (localName.equals(recordTagName)) {
+        }
+        else if (localName.equals(recordTagName)) {
             final String identifier = attributes.getValue("id");
             if (identifier == null) {
                 getReceiver().startRecord("");
-            } else {
+            }
+            else {
                 getReceiver().startRecord(identifier);
             }
             writeAttributes(attributes);
@@ -136,14 +136,14 @@ public final class GenericXmlHandler extends DefaultXmlPipe<StreamReceiver> {
     }
 
     @Override
-    public void endElement(final String uri, final String localName,
-            final String qName) {
+    public void endElement(final String uri, final String localName, final String qName) {
         if (inRecord) {
             writeValue();
             if (localName.equals(recordTagName)) {
                 inRecord = false;
                 getReceiver().endRecord();
-            } else {
+            }
+            else {
                 getReceiver().endEntity();
             }
         }
@@ -152,8 +152,7 @@ public final class GenericXmlHandler extends DefaultXmlPipe<StreamReceiver> {
     @Override
     public void characters(final char[] chars, final int start, final int length) {
         if (inRecord) {
-            valueBuffer.append(TABS.matcher(new String(chars, start, length))
-                    .replaceAll(""));
+            valueBuffer.append(TABS.matcher(new String(chars, start, length)).replaceAll(""));
         }
     }
 
@@ -169,11 +168,7 @@ public final class GenericXmlHandler extends DefaultXmlPipe<StreamReceiver> {
         final int length = attributes.getLength();
 
         for (int i = 0; i < length; ++i) {
-            String name;
-            if (emitNamespace) {
-                name = attributes.getQName(i);
-            } else
-                name = attributes.getLocalName(i);
+            final String name = emitNamespace ? attributes.getQName(i) : attributes.getLocalName(i);
             final String value = attributes.getValue(i);
             getReceiver().literal(name, value);
         }

--- a/metafacture-xml/src/main/java/org/metafacture/xml/RecordIdentifier.java
+++ b/metafacture-xml/src/main/java/org/metafacture/xml/RecordIdentifier.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.xml;
 
 /**
@@ -32,6 +33,6 @@ public interface RecordIdentifier {
      * @param property
      *            the property which will be used to extract a record name.
      */
-    public void setProperty(final String property);
+    void setProperty(String property);
 
 }

--- a/metafacture-xml/src/main/java/org/metafacture/xml/SimpleXmlEncoder.java
+++ b/metafacture-xml/src/main/java/org/metafacture/xml/SimpleXmlEncoder.java
@@ -13,17 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.xml;
 
-import java.io.IOException;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Properties;
+package org.metafacture.xml;
 
 import org.metafacture.commons.ResourceUtil;
 import org.metafacture.commons.XmlUtil;
@@ -35,6 +26,16 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultStreamPipe;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Map;
+import java.util.Properties;
 
 /**
  *
@@ -84,6 +85,9 @@ public final class SimpleXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Str
     private Element element;
     private boolean atStreamStart = true;
 
+    public SimpleXmlEncoder() {
+    }
+
     public void setRootTag(final String rootTag) {
         this.rootTag = rootTag;
     }
@@ -96,7 +100,8 @@ public final class SimpleXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Str
         final Properties properties;
         try {
             properties = ResourceUtil.loadProperties(file);
-        } catch (IOException e) {
+        }
+        catch (final IOException e) {
             throw new MetafactureException("Failed to load namespaces list", e);
         }
         for (final Entry<Object, Object> entry : properties.entrySet()) {
@@ -108,7 +113,8 @@ public final class SimpleXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Str
         final Properties properties;
         try {
             properties = ResourceUtil.loadProperties(url);
-        } catch (IOException e) {
+        }
+        catch (final IOException e) {
             throw new MetafactureException("Failed to load namespaces list", e);
         }
         for (final Entry<Object, Object> entry : properties.entrySet()) {
@@ -120,9 +126,13 @@ public final class SimpleXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Str
         this.writeXmlHeader = writeXmlHeader;
     }
 
-    public void setXmlHeaderEncoding(final String xmlHeaderEncoding) { this.xmlHeaderEncoding = xmlHeaderEncoding; }
+    public void setXmlHeaderEncoding(final String xmlHeaderEncoding) {
+        this.xmlHeaderEncoding = xmlHeaderEncoding;
+    }
 
-    public void setXmlHeaderVersion(final String xmlHeaderVersion) { this.xmlHeaderVersion = xmlHeaderVersion; }
+    public void setXmlHeaderVersion(final String xmlHeaderVersion) {
+        this.xmlHeaderVersion = xmlHeaderVersion;
+    }
 
     public void setWriteRootTag(final boolean writeRootTag) {
         this.writeRootTag  = writeRootTag;
@@ -140,7 +150,8 @@ public final class SimpleXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Str
     public void startRecord(final String identifier) {
         if (separateRoots) {
             writeHeader();
-        } else if (atStreamStart) {
+        }
+        else if (atStreamStart) {
             writeHeader();
             sendAndClearData();
         }
@@ -183,9 +194,11 @@ public final class SimpleXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Str
     public void literal(final String name, final String value) {
         if (name.isEmpty()) {
             element.setText(value);
-        } else if (name.startsWith(ATTRIBUTE_MARKER)) {
+        }
+        else if (name.startsWith(ATTRIBUTE_MARKER)) {
             element.addAttribute(name.substring(1), value);
-        } else {
+        }
+        else {
             element.createChild(name).setText(value);
         }
     }
@@ -263,7 +276,7 @@ public final class SimpleXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Str
         private String text = "";
         private List<Element> children = NO_CHILDREN;
 
-        public Element(final String name) {
+        Element(final String name) {
             this.name = name;
             this.parent = null;
         }
@@ -273,9 +286,9 @@ public final class SimpleXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Str
             this.parent = parent;
         }
 
-        public void addAttribute(final String name, final String value) {
+        public void addAttribute(final String attributeName, final String value) {
             attributes.append(" ");
-            attributes.append(name);
+            attributes.append(attributeName);
             attributes.append(BEGIN_ATTRIBUTE);
             writeEscaped(attributes, value);
             attributes.append(END_ATTRIBUTE);
@@ -285,8 +298,8 @@ public final class SimpleXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Str
             this.text = text;
         }
 
-        public Element createChild(final String name) {
-            final Element child = new Element(name, this);
+        public Element createChild(final String attributeName) {
+            final Element child = new Element(attributeName, this);
             if (children == NO_CHILDREN) {
                 children = new ArrayList<SimpleXmlEncoder.Element>();
             }

--- a/metafacture-xml/src/main/java/org/metafacture/xml/XmlDecoder.java
+++ b/metafacture-xml/src/main/java/org/metafacture/xml/XmlDecoder.java
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.xml;
 
-import java.io.IOException;
-import java.io.Reader;
+package org.metafacture.xml;
 
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.MetafactureException;
@@ -25,6 +23,7 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
+
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXNotRecognizedException;
@@ -32,6 +31,8 @@ import org.xml.sax.SAXNotSupportedException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.XMLReaderFactory;
 
+import java.io.IOException;
+import java.io.Reader;
 
 /**
  * Reads an XML file and passes the XML events to a receiver.
@@ -43,18 +44,17 @@ import org.xml.sax.helpers.XMLReaderFactory;
 @In(Reader.class)
 @Out(XmlReceiver.class)
 @FluxCommand("decode-xml")
-public final class XmlDecoder
-        extends DefaultObjectPipe<Reader, XmlReceiver> {
+public final class XmlDecoder extends DefaultObjectPipe<Reader, XmlReceiver> {
 
     private static final String SAX_PROPERTY_LEXICAL_HANDLER = "http://xml.org/sax/properties/lexical-handler";
 
     private final XMLReader saxReader;
 
     public XmlDecoder() {
-        super();
         try {
             saxReader = XMLReaderFactory.createXMLReader();
-        } catch (SAXException e) {
+        }
+        catch (final SAXException e) {
             throw new MetafactureException(e);
         }
     }
@@ -63,9 +63,11 @@ public final class XmlDecoder
     public void process(final Reader reader) {
         try {
             saxReader.parse(new InputSource(reader));
-        } catch (IOException e) {
+        }
+        catch (final IOException e) {
             throw new MetafactureException(e);
-        } catch (SAXException e) {
+        }
+        catch (final SAXException e) {
             throw new MetafactureException(e);
         }
     }
@@ -78,9 +80,11 @@ public final class XmlDecoder
         saxReader.setErrorHandler(getReceiver());
         try {
             saxReader.setProperty(SAX_PROPERTY_LEXICAL_HANDLER, getReceiver());
-        } catch (SAXNotRecognizedException e) {
+        }
+        catch (final SAXNotRecognizedException e) {
             throw new MetafactureException(e);
-        } catch (SAXNotSupportedException e) {
+        }
+        catch (final SAXNotSupportedException e) {
             throw new MetafactureException(e);
         }
     }

--- a/metafacture-xml/src/main/java/org/metafacture/xml/XmlFilenameWriter.java
+++ b/metafacture-xml/src/main/java/org/metafacture/xml/XmlFilenameWriter.java
@@ -13,7 +13,22 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
 package org.metafacture.xml;
+
+import org.metafacture.framework.FluxCommand;
+import org.metafacture.framework.MetafactureException;
+import org.metafacture.framework.ObjectReceiver;
+import org.metafacture.framework.StreamReceiver;
+import org.metafacture.framework.annotations.Description;
+import org.metafacture.framework.annotations.In;
+import org.metafacture.framework.annotations.Out;
+import org.metafacture.framework.helpers.DefaultStreamPipe;
+
+import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.InputSource;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -25,23 +40,9 @@ import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.nio.file.Paths;
 import java.util.function.Function;
-
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
-
-import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
-import org.metafacture.framework.FluxCommand;
-import org.metafacture.framework.MetafactureException;
-import org.metafacture.framework.ObjectReceiver;
-import org.metafacture.framework.StreamReceiver;
-import org.metafacture.framework.annotations.Description;
-import org.metafacture.framework.annotations.In;
-import org.metafacture.framework.annotations.Out;
-import org.metafacture.framework.helpers.DefaultStreamPipe;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.xml.sax.InputSource;
 
 /**
  * A sink, writing an xml file. The filename is constructed from the xpath given
@@ -50,20 +51,17 @@ import org.xml.sax.InputSource;
  * @author Pascal Christoph
  * @author Christoph Böhme
  */
-@Description("Writes the xml into the filesystem. The filename is constructed from the xpath given as 'property'.\n"
-        + " Variables are\n" + "- 'target' (determining the output directory)\n"
-        + "- 'property' (the element in the XML entity. Constitutes the main part of the file's name.)\n"
-        + "- 'startIndex' ( a subfolder will be extracted out of the filename. This marks the index' beginning )\n"
-        + "- 'stopIndex' ( a subfolder will be extracted out of the filename. This marks the index' end )\n")
+@Description("Writes the xml into the filesystem. The filename is constructed from the xpath given as 'property'.\n" + // checkstyle-disable-line ClassDataAbstractionCoupling|ClassFanOutComplexity
+    " Variables are\n" + "- 'target' (determining the output directory)\n" +
+    "- 'property' (the element in the XML entity. Constitutes the main part of the file's name.)\n" +
+    "- 'startIndex' ( a subfolder will be extracted out of the filename. This marks the index' beginning )\n" +
+    "- 'stopIndex' ( a subfolder will be extracted out of the filename. This marks the index' end )\n")
 @In(StreamReceiver.class)
 @Out(Void.class)
 @FluxCommand("write-xml-files")
-public final class XmlFilenameWriter
-        extends DefaultStreamPipe<ObjectReceiver<String>>
-        implements FilenameExtractor {
+public final class XmlFilenameWriter extends DefaultStreamPipe<ObjectReceiver<String>> implements FilenameExtractor {
 
-    private static final Logger LOG = LoggerFactory.getLogger(
-            XmlFilenameWriter.class);
+    private static final Logger LOG = LoggerFactory.getLogger(XmlFilenameWriter.class);
 
     private final XPath xPath = XPathFactory.newInstance().newXPath();
     private final FilenameUtil filenameUtil = new FilenameUtil();
@@ -89,38 +87,38 @@ public final class XmlFilenameWriter
 
     @Override
     public void setEncoding(final String encoding) {
-        filenameUtil.encoding = encoding;
+        filenameUtil.setEncoding(encoding);
     }
 
     @Override
     public String getEncoding() {
-        return filenameUtil.encoding;
+        return filenameUtil.getEncoding();
     }
 
     @Override
     public void setEndIndex(final int endIndex) {
-        filenameUtil.endIndex = endIndex;
+        filenameUtil.setEndIndex(endIndex);
     }
 
     @Override
     public void setFileSuffix(final String fileSuffix) {
-        filenameUtil.fileSuffix = fileSuffix;
+        filenameUtil.setFileSuffix(fileSuffix);
 
     }
 
     @Override
     public void setProperty(final String property) {
-        filenameUtil.property = property;
+        filenameUtil.setProperty(property);
     }
 
     @Override
     public void setStartIndex(final int startIndex) {
-        filenameUtil.startIndex = startIndex;
+        filenameUtil.setStartIndex(startIndex);
     }
 
     @Override
     public void setTarget(final String target) {
-        filenameUtil.target = target;
+        filenameUtil.setTarget(target);
     }
 
     @Override
@@ -133,21 +131,22 @@ public final class XmlFilenameWriter
         filenameUtil.ensurePathExists(file);
         if (compression == null) {
             writeXml(xml, file);
-        } else if ("bz2".equals(compression)) {
+        }
+        else if ("bz2".equals(compression)) {
             final File compressedFile = new File(file.getPath() + ".bz2");
             writeXml(xml, compressedFile, this::createBZip2Compressor);
         }
     }
 
-    private String extractIdentifier(String xml) {
+    private String extractIdentifier(final String xml) {
         final String identifier;
         try {
-            identifier = xPath.evaluate(this.filenameUtil.property,
-                    new InputSource(new StringReader(xml)));
-        } catch (XPathExpressionException e) {
+            identifier = xPath.evaluate(this.filenameUtil.getProperty(), new InputSource(new StringReader(xml)));
+        }
+        catch (final XPathExpressionException e) {
             throw new MetafactureException(e);
         }
-        if (identifier == null || identifier.length() < filenameUtil.endIndex) {
+        if (identifier == null || identifier.length() < filenameUtil.getEndIndex()) {
             LOG.info("No identifier found, skip writing");
             LOG.debug("the xml: {}", xml);
             return null;
@@ -155,37 +154,36 @@ public final class XmlFilenameWriter
         return identifier;
     }
 
-    private File buildTargetFileName(String identifier) {
-        final String directory = identifier.substring(filenameUtil.startIndex,
-                filenameUtil.endIndex);
-        return Paths.get(filenameUtil.target)
+    private File buildTargetFileName(final String identifier) {
+        final String directory = identifier.substring(filenameUtil.getStartIndex(), filenameUtil.getEndIndex());
+        return Paths.get(filenameUtil.getTarget())
                 .resolve(directory)
-                .resolve(identifier + filenameUtil.fileSuffix)
+                .resolve(identifier + filenameUtil.getFileSuffix())
                 .toFile();
     }
 
-    private void writeXml(String xml, File file) {
+    private void writeXml(final String xml, final File file) {
         writeXml(xml, file, Function.identity());
     }
 
-    private void writeXml(String xml, File file,
-            Function<OutputStream, OutputStream> compressorFactory) {
+    private void writeXml(final String xml, final File file, final Function<OutputStream, OutputStream> compressorFactory) {
         try (
                 OutputStream fileStream = new FileOutputStream(file);
                 OutputStream compressedStream = compressorFactory.apply(fileStream);
-                Writer writer = new OutputStreamWriter(compressedStream,
-                        filenameUtil.encoding);
+                Writer writer = new OutputStreamWriter(compressedStream, filenameUtil.getEncoding())
         ) {
             writer.write(xml);
-        } catch (IOException | UncheckedIOException e) {
+        }
+        catch (final IOException | UncheckedIOException e) {
             throw new MetafactureException(e);
         }
     }
 
-    private OutputStream createBZip2Compressor(OutputStream stream) {
+    private OutputStream createBZip2Compressor(final OutputStream stream) {
         try {
             return new BZip2CompressorOutputStream(stream);
-        } catch (IOException e) {
+        }
+        catch (final IOException e) {
             throw new UncheckedIOException(e);
         }
     }

--- a/metafacture-xml/src/test/java/org/metafacture/xml/CGXmlHandlerTest.java
+++ b/metafacture-xml/src/test/java/org/metafacture/xml/CGXmlHandlerTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.xml;
 
 import static org.mockito.Mockito.inOrder;

--- a/metafacture-xml/src/test/java/org/metafacture/xml/GenericXMLHandlerTest.java
+++ b/metafacture-xml/src/test/java/org/metafacture/xml/GenericXMLHandlerTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.xml;
 
 import static org.mockito.Mockito.inOrder;

--- a/metafacture-xml/src/test/java/org/metafacture/xml/SimpleXmlEncoderTest.java
+++ b/metafacture-xml/src/test/java/org/metafacture/xml/SimpleXmlEncoderTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.xml;
 
 import static org.junit.Assert.assertEquals;

--- a/metafacture-xml/src/test/java/org/metafacture/xml/XmlElementSplitterTest.java
+++ b/metafacture-xml/src/test/java/org/metafacture/xml/XmlElementSplitterTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.xml;
 
 import static org.mockito.Mockito.inOrder;

--- a/metafacture-xml/src/test/java/org/metafacture/xml/XmlFilenameWriterTest.java
+++ b/metafacture-xml/src/test/java/org/metafacture/xml/XmlFilenameWriterTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.xml;
 
 import static org.junit.Assert.assertEquals;

--- a/metamorph-api/src/main/java/org/metafacture/metamorph/api/Collect.java
+++ b/metamorph-api/src/main/java/org/metafacture/metamorph/api/Collect.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.api;
 
 /**
@@ -21,10 +22,9 @@ package org.metafacture.metamorph.api;
  * @author Markus Michael Geipel
  *
  */
-public interface Collect extends FlushListener, ConditionAware,
-        NamedValuePipe {
+public interface Collect extends FlushListener, ConditionAware, NamedValuePipe {
 
-    void setWaitForFlush(final boolean waitForFlush);
+    void setWaitForFlush(boolean waitForFlush);
 
     void setSameEntity(boolean sameEntity);
 

--- a/metamorph-api/src/main/java/org/metafacture/metamorph/api/ConditionAware.java
+++ b/metamorph-api/src/main/java/org/metafacture/metamorph/api/ConditionAware.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.api;
 
 /**

--- a/metamorph-api/src/main/java/org/metafacture/metamorph/api/FlushListener.java
+++ b/metamorph-api/src/main/java/org/metafacture/metamorph/api/FlushListener.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.api;
 
 /**
@@ -22,6 +23,6 @@ package org.metafacture.metamorph.api;
  */
 public interface FlushListener {
 
-    void flush(final int recordCount, final int entityCount);
+    void flush(int recordCount, int entityCount);
 
 }

--- a/metamorph-api/src/main/java/org/metafacture/metamorph/api/Function.java
+++ b/metamorph-api/src/main/java/org/metafacture/metamorph/api/Function.java
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.metamorph.api;
 
+package org.metafacture.metamorph.api;
 
 /**
  * Interface for functions used in Metamorph.
@@ -25,6 +25,7 @@ package org.metafacture.metamorph.api;
 public interface Function extends NamedValuePipe, FlushListener {
 
     void putValue(String key, String value);
+
     void setMaps(Maps maps);
 
 }

--- a/metamorph-api/src/main/java/org/metafacture/metamorph/api/InterceptorFactory.java
+++ b/metamorph-api/src/main/java/org/metafacture/metamorph/api/InterceptorFactory.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.api;
 
 /**

--- a/metamorph-api/src/main/java/org/metafacture/metamorph/api/KnowsSourceLocation.java
+++ b/metamorph-api/src/main/java/org/metafacture/metamorph/api/KnowsSourceLocation.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.api;
 
 /**
@@ -31,7 +32,7 @@ public interface KnowsSourceLocation {
      *
      * @param sourceLocation a source location
      */
-    void setSourceLocation(final SourceLocation sourceLocation);
+    void setSourceLocation(SourceLocation sourceLocation);
 
     /**
      * Gets the location object for the location in the morph definition file

--- a/metamorph-api/src/main/java/org/metafacture/metamorph/api/Maps.java
+++ b/metamorph-api/src/main/java/org/metafacture/metamorph/api/Maps.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.api;
 
 import java.util.Collection;

--- a/metamorph-api/src/main/java/org/metafacture/metamorph/api/MorphBuildException.java
+++ b/metamorph-api/src/main/java/org/metafacture/metamorph/api/MorphBuildException.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.api;
 
 /**

--- a/metamorph-api/src/main/java/org/metafacture/metamorph/api/MorphErrorHandler.java
+++ b/metamorph-api/src/main/java/org/metafacture/metamorph/api/MorphErrorHandler.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.api;
 
 /**

--- a/metamorph-api/src/main/java/org/metafacture/metamorph/api/MorphExecutionException.java
+++ b/metamorph-api/src/main/java/org/metafacture/metamorph/api/MorphExecutionException.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.api;
 
 /**

--- a/metamorph-api/src/main/java/org/metafacture/metamorph/api/NamedValuePipe.java
+++ b/metamorph-api/src/main/java/org/metafacture/metamorph/api/NamedValuePipe.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.api;
 
 /**

--- a/metamorph-api/src/main/java/org/metafacture/metamorph/api/NamedValueReceiver.java
+++ b/metamorph-api/src/main/java/org/metafacture/metamorph/api/NamedValueReceiver.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.api;
 
 /**
@@ -24,9 +25,8 @@ package org.metafacture.metamorph.api;
  */
 public interface NamedValueReceiver extends KnowsSourceLocation {
 
-    void receive(String name, String value, NamedValueSource source,
-            int recordCount, int entityCount);
+    void receive(String name, String value, NamedValueSource source, int recordCount, int entityCount);
 
-    void addNamedValueSource(final NamedValueSource namedValueSource);
+    void addNamedValueSource(NamedValueSource namedValueSource);
 
 }

--- a/metamorph-api/src/main/java/org/metafacture/metamorph/api/NamedValueSource.java
+++ b/metamorph-api/src/main/java/org/metafacture/metamorph/api/NamedValueSource.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.api;
 
 /**

--- a/metamorph-api/src/main/java/org/metafacture/metamorph/api/SourceLocation.java
+++ b/metamorph-api/src/main/java/org/metafacture/metamorph/api/SourceLocation.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.api;
 
 /**

--- a/metamorph-api/src/main/java/org/metafacture/metamorph/api/helpers/AbstractCollect.java
+++ b/metamorph-api/src/main/java/org/metafacture/metamorph/api/helpers/AbstractCollect.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.api.helpers;
 
 import org.metafacture.metamorph.api.Collect;
@@ -130,8 +131,12 @@ public abstract class AbstractCollect extends AbstractNamedValuePipe
         return currentRecord == oldRecord;
     }
 
+    protected final boolean sameEntityConstraintSatisfied(final int entityCount) {
+        return !sameEntity || oldEntity == entityCount;
+    }
+
     @Override
-    public final void receive(final String name, final String value,
+    public final void receive(final String currentName, final String currentValue,
             final NamedValueSource source, final int recordCount,
             final int entityCount) {
 
@@ -139,8 +144,9 @@ public abstract class AbstractCollect extends AbstractNamedValuePipe
 
         if (source == conditionSource) {
             conditionMet = true;
-        } else {
-            receive(name, value, source);
+        }
+        else {
+            receive(currentName, currentValue, source);
         }
 
         if (!waitForFlush && isConditionMet() && isComplete()) {
@@ -152,12 +158,7 @@ public abstract class AbstractCollect extends AbstractNamedValuePipe
         }
     }
 
-    protected final boolean sameEntityConstraintSatisfied(final int entityCount) {
-        return !sameEntity || oldEntity == entityCount;
-    }
-
-    protected abstract void receive(final String name, final String value,
-            final NamedValueSource source);
+    protected abstract void receive(String currentName, String currentValue, NamedValueSource source);
 
     protected abstract boolean isComplete();
 

--- a/metamorph-api/src/main/java/org/metafacture/metamorph/api/helpers/AbstractFilter.java
+++ b/metamorph-api/src/main/java/org/metafacture/metamorph/api/helpers/AbstractFilter.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.api.helpers;
 
 /**
@@ -26,7 +27,7 @@ public abstract class AbstractFilter extends AbstractSimpleStatelessFunction {
 
     @Override
     public final String process(final String value) {
-        if(accept(value)){
+        if (accept(value)) {
             return value;
         }
         return null;
@@ -34,7 +35,7 @@ public abstract class AbstractFilter extends AbstractSimpleStatelessFunction {
 
     protected abstract boolean accept(String value);
 
-    protected final  String getString() {
+    protected final String getString() {
         return string;
     }
 

--- a/metamorph-api/src/main/java/org/metafacture/metamorph/api/helpers/AbstractFlushingCollect.java
+++ b/metamorph-api/src/main/java/org/metafacture/metamorph/api/helpers/AbstractFlushingCollect.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.api.helpers;
 
 /**
@@ -33,7 +34,7 @@ public abstract class AbstractFlushingCollect extends AbstractCollect {
     @Override
     public final void flush(final int recordCount, final int entityCount) {
         if (isSameRecord(recordCount) && sameEntityConstraintSatisfied(entityCount)) {
-            if(isConditionMet() && (flushIncomplete || isComplete())) {
+            if (isConditionMet() && (flushIncomplete || isComplete())) {
                 emit();
             }
             if (getReset()) {

--- a/metamorph-api/src/main/java/org/metafacture/metamorph/api/helpers/AbstractFunction.java
+++ b/metamorph-api/src/main/java/org/metafacture/metamorph/api/helpers/AbstractFunction.java
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.metamorph.api.helpers;
 
-import java.util.HashMap;
-import java.util.Map;
+package org.metafacture.metamorph.api.helpers;
 
 import org.metafacture.metamorph.api.Function;
 import org.metafacture.metamorph.api.Maps;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Base class for functions.
@@ -33,8 +34,8 @@ public abstract class AbstractFunction extends AbstractNamedValuePipe
     private Map<String, String> localMap;
     private String mapName;
 
-    protected final String getValue(final String mapName, final String key) {
-        return maps.getValue(mapName, key);
+    protected final String getValue(final String currentMapName, final String key) {
+        return maps.getValue(currentMapName, key);
     }
 
     protected final String getLocalValue(final String key) {
@@ -55,8 +56,8 @@ public abstract class AbstractFunction extends AbstractNamedValuePipe
         return localMap;
     }
 
-    public final void setMap(final String mapName) {
-        this.mapName = mapName;
+    public final void setMap(final String newMapName) {
+        mapName = newMapName;
     }
 
     @Override

--- a/metamorph-api/src/main/java/org/metafacture/metamorph/api/helpers/AbstractNamedValuePipe.java
+++ b/metamorph-api/src/main/java/org/metafacture/metamorph/api/helpers/AbstractNamedValuePipe.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.api.helpers;
 
 import org.metafacture.metamorph.api.NamedValuePipe;

--- a/metamorph-api/src/main/java/org/metafacture/metamorph/api/helpers/AbstractReadOnlyMap.java
+++ b/metamorph-api/src/main/java/org/metafacture/metamorph/api/helpers/AbstractReadOnlyMap.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.api.helpers;
 
 import java.util.Collection;

--- a/metamorph-api/src/main/java/org/metafacture/metamorph/api/helpers/AbstractSimpleStatelessFunction.java
+++ b/metamorph-api/src/main/java/org/metafacture/metamorph/api/helpers/AbstractSimpleStatelessFunction.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.api.helpers;
 
 import org.metafacture.metamorph.api.Function;

--- a/metamorph-api/src/main/java/org/metafacture/metamorph/api/helpers/AbstractStatefulFunction.java
+++ b/metamorph-api/src/main/java/org/metafacture/metamorph/api/helpers/AbstractStatefulFunction.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.api.helpers;
 
 import org.metafacture.metamorph.api.NamedValueSource;
@@ -46,36 +47,35 @@ public abstract class AbstractStatefulFunction extends AbstractFunction {
     }
 
     @Override
-    public final void receive(final String name, final String value,
-            final NamedValueSource source, final int recordCount,
-            final int entityCount) {
+    public final void receive(final String currentName, final String value,
+            final NamedValueSource currentSource, final int currentRecordCount,
+            final int currentEntityCount) {
 
-        if (!sameRecord(recordCount)) {
+        if (!sameRecord(currentRecordCount)) {
             reset();
-            this.recordCount = recordCount;
+            recordCount = currentRecordCount;
         }
-        if (entityClearNeeded(entityCount)) {
+        if (entityClearNeeded(currentEntityCount)) {
             reset();
         }
-        this.entityCount = entityCount;
-        this.source = source;
-        this.lastName = name;
+        entityCount = currentEntityCount;
+        source = currentSource;
+        lastName = currentName;
 
         final String processedValue = process(value);
         if (processedValue == null) {
             return;
         }
 
-        getNamedValueReceiver().receive(name, processedValue, this,
-                recordCount, entityCount);
+        getNamedValueReceiver().receive(currentName, processedValue, this, currentRecordCount, currentEntityCount);
     }
 
-    private boolean entityClearNeeded(final int entityCount) {
-        return doResetOnEntityChange() && this.entityCount != entityCount;
+    private boolean entityClearNeeded(final int currentEntityCount) {
+        return doResetOnEntityChange() && entityCount != currentEntityCount;
     }
 
-    private boolean sameRecord(final int recordCount) {
-        return this.recordCount == recordCount;
+    private boolean sameRecord(final int currentRecordCount) {
+        return recordCount == currentRecordCount;
     }
 
     protected abstract String process(String value);

--- a/metamorph-test/src/main/java/org/metafacture/metamorph/test/MetamorphTestCase.java
+++ b/metamorph-test/src/main/java/org/metafacture/metamorph/test/MetamorphTestCase.java
@@ -13,13 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.test;
 
-import java.io.FileNotFoundException;
-import java.io.StringReader;
-
-import org.junit.runners.model.InitializationError;
-import org.junit.runners.model.Statement;
 import org.metafacture.commons.ResourceUtil;
 import org.metafacture.commons.XmlUtil;
 import org.metafacture.commons.reflection.ReflectionUtil;
@@ -30,9 +26,15 @@ import org.metafacture.metamorph.Metamorph;
 import org.metafacture.metamorph.test.reader.MultiFormatReader;
 import org.metafacture.metamorph.test.reader.Reader;
 import org.metafacture.metamorph.test.validators.StreamValidator;
+
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.Statement;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
+
+import java.io.FileNotFoundException;
+import java.io.StringReader;
 
 /**
  * Runs a test defined in a Metamorph-Test definition.
@@ -40,10 +42,9 @@ import org.xml.sax.InputSource;
  * @author Christoph Böhme
  *
  */
-final class MetamorphTestCase extends Statement {
+final class MetamorphTestCase extends Statement { // checkstyle-disable-line ClassDataAbstractionCoupling
 
-    private static final String NO_DATA_FOUND =
-            "Please specify either element content or a src attribute";
+    private static final String NO_DATA_FOUND = "Please specify either element content or a src attribute";
 
     private static final String NAME_ATTR = "name";
     private static final String IGNORE_ATTR = "ignore";
@@ -77,12 +78,13 @@ final class MetamorphTestCase extends Statement {
     public void evaluate() throws InitializationError {
         final Reader inputReader = getReader(INPUT_TAG);
         @SuppressWarnings("unchecked")
-        final StreamPipe<StreamReceiver>transformation = getTransformation();
+        final StreamPipe<StreamReceiver> transformation = getTransformation();
         final EventList resultStream = new EventList();
 
         if (transformation == null) {
             inputReader.setReceiver(resultStream);
-        } else {
+        }
+        else {
             inputReader.setReceiver(transformation).setReceiver(resultStream);
         }
 
@@ -90,7 +92,9 @@ final class MetamorphTestCase extends Statement {
         inputReader.closeStream();
 
         final StreamValidator validator = new StreamValidator(resultStream.getEvents());
-        validator.setErrorHandler(msg -> { throw new AssertionError(msg); });
+        validator.setErrorHandler(msg -> {
+            throw new AssertionError(msg);
+        });
 
         final Element result = (Element) config.getElementsByTagName(RESULT_TAG).item(0);
         validator.setStrictRecordOrder(Boolean.parseBoolean(
@@ -113,8 +117,7 @@ final class MetamorphTestCase extends Statement {
         return new MultiFormatReader(mimeType);
     }
 
-    @SuppressWarnings("rawtypes")
-    private StreamPipe getTransformation() throws InitializationError {
+    private StreamPipe getTransformation() throws InitializationError { // checkstyle-disable-line ReturnCount
         final NodeList nodes = config.getElementsByTagName(TRANSFORMATION_TAG);
         if (nodes.getLength() == 0) {
             return null;
@@ -133,7 +136,8 @@ final class MetamorphTestCase extends Statement {
             }
             return new Metamorph(src);
 
-        } else if (MIME_JAVACLASS.equals(type)) {
+        }
+        else if (MIME_JAVACLASS.equals(type)) {
             if (src.isEmpty()) {
                 throw new InitializationError(
                         "class defining transformation not specified");
@@ -165,7 +169,8 @@ final class MetamorphTestCase extends Statement {
             throws InitializationError {
         try {
             return ResourceUtil.getReader(src);
-        } catch (final FileNotFoundException e) {
+        }
+        catch (final FileNotFoundException e) {
             throw new InitializationError("Could not find input file '" + src +
                     "': " + e.getMessage());
         }

--- a/metamorph-test/src/main/java/org/metafacture/metamorph/test/MetamorphTestLoader.java
+++ b/metamorph-test/src/main/java/org/metafacture/metamorph/test/MetamorphTestLoader.java
@@ -1,4 +1,4 @@
-    /*
+/*
  * Copyright 2013, 2014 Deutsche Nationalbibliothek
  *
  * Licensed under the Apache License, Version 2.0 the "License";
@@ -13,19 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.test;
-
-import java.io.IOException;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.xml.XMLConstants;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.validation.Schema;
-import javax.xml.validation.SchemaFactory;
 
 import org.junit.runners.model.InitializationError;
 import org.w3c.dom.Document;
@@ -34,6 +23,16 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
 
 /**
  * Utility methods for loading Metamorph-Test resources.
@@ -81,17 +80,17 @@ final class MetamorphTestLoader {
 
             final List<MetamorphTestCase> metamorphTestCases = new ArrayList<>();
             final NodeList testCaseNodes = doc.getElementsByTagName(TEST_CASE_TAG);
-            for(int i=0; i < testCaseNodes.getLength(); ++i) {
+            for (int i = 0; i < testCaseNodes.getLength(); ++i) {
                 final Element testCaseElement = (Element) testCaseNodes.item(i);
                 metamorphTestCases.add(new MetamorphTestCase(testCaseElement));
             }
 
             return metamorphTestCases;
 
-        } catch (final ParserConfigurationException|SAXException|IOException e) {
+        }
+        catch (final ParserConfigurationException | SAXException | IOException e) {
             throw new InitializationError(e);
         }
     }
 
 }
-

--- a/metamorph-test/src/main/java/org/metafacture/metamorph/test/MetamorphTestRunner.java
+++ b/metamorph-test/src/main/java/org/metafacture/metamorph/test/MetamorphTestRunner.java
@@ -13,15 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.metamorph.test;
 
-import java.net.URL;
-import java.util.List;
+package org.metafacture.metamorph.test;
 
 import org.junit.runner.Description;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.ParentRunner;
 import org.junit.runners.model.InitializationError;
+
+import java.net.URL;
+import java.util.List;
 
 /**
  * Executes test cases defined in a metamorph-test file.
@@ -71,7 +72,8 @@ final class MetamorphTestRunner extends ParentRunner<MetamorphTestCase> {
         final Description description = describeChild(child);
         if (child.isIgnore()) {
             notifier.fireTestIgnored(description);
-        } else {
+        }
+        else {
             runLeaf(child, description, notifier);
         }
     }

--- a/metamorph-test/src/main/java/org/metafacture/metamorph/test/MetamorphTestSuite.java
+++ b/metamorph-test/src/main/java/org/metafacture/metamorph/test/MetamorphTestSuite.java
@@ -13,7 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.test;
+
+import org.junit.runner.Description;
+import org.junit.runner.Runner;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.ParentRunner;
+import org.junit.runners.model.InitializationError;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -21,12 +28,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.ArrayList;
 import java.util.List;
-
-import org.junit.runner.Description;
-import org.junit.runner.Runner;
-import org.junit.runner.notification.RunNotifier;
-import org.junit.runners.ParentRunner;
-import org.junit.runners.model.InitializationError;
 
 /**
  * Binds a list of Metamorph-Test resources to a class.
@@ -45,8 +46,7 @@ public final class MetamorphTestSuite extends ParentRunner<Runner> {
         runners = loadDefinitions(suiteRoot);
     }
 
-    private static List<Runner> loadDefinitions(final Class<?> suiteRoot)
-            throws InitializationError{
+    private static List<Runner> loadDefinitions(final Class<?> suiteRoot) throws InitializationError {
         final List<Runner> runners = new ArrayList<>();
         for (final String testDef : getTestDefinitionNames(suiteRoot)) {
             runners.add(new MetamorphTestRunner(suiteRoot, testDef));
@@ -54,9 +54,8 @@ public final class MetamorphTestSuite extends ParentRunner<Runner> {
         return runners;
     }
 
-    private static String[] getTestDefinitionNames(final Class<?> suiteRoot){
-        final TestDefinitions testDefs =
-                suiteRoot.getAnnotation(TestDefinitions.class);
+    private static String[] getTestDefinitionNames(final Class<?> suiteRoot) {
+        final TestDefinitions testDefs = suiteRoot.getAnnotation(TestDefinitions.class);
         if (testDefs == null) {
             // if no xmls are given assume an xml with the same name as the class:
             return new String[]{suiteRoot.getSimpleName() + ".xml"};

--- a/metamorph-test/src/main/java/org/metafacture/metamorph/test/reader/CGXmlReader.java
+++ b/metamorph-test/src/main/java/org/metafacture/metamorph/test/reader/CGXmlReader.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.test.reader;
 
 import org.metafacture.xml.CGXmlHandler;

--- a/metamorph-test/src/main/java/org/metafacture/metamorph/test/reader/FormetaReader.java
+++ b/metamorph-test/src/main/java/org/metafacture/metamorph/test/reader/FormetaReader.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.test.reader;
 
 import org.metafacture.formeta.FormetaDecoder;

--- a/metamorph-test/src/main/java/org/metafacture/metamorph/test/reader/JsonLinesReader.java
+++ b/metamorph-test/src/main/java/org/metafacture/metamorph/test/reader/JsonLinesReader.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.test.reader;
 
 import org.metafacture.io.LineReader;

--- a/metamorph-test/src/main/java/org/metafacture/metamorph/test/reader/JsonReader.java
+++ b/metamorph-test/src/main/java/org/metafacture/metamorph/test/reader/JsonReader.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.test.reader;
 
 import org.metafacture.io.RecordReader;

--- a/metamorph-test/src/main/java/org/metafacture/metamorph/test/reader/MarcXmlReader.java
+++ b/metamorph-test/src/main/java/org/metafacture/metamorph/test/reader/MarcXmlReader.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.test.reader;
 
 import org.metafacture.biblio.marc21.MarcXmlHandler;

--- a/metamorph-test/src/main/java/org/metafacture/metamorph/test/reader/MultiFormatReader.java
+++ b/metamorph-test/src/main/java/org/metafacture/metamorph/test/reader/MultiFormatReader.java
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.test.reader;
 
 import org.metafacture.framework.StreamReceiver;
-
 
 /**
  * Dynamically instantiated a reader for a specific data format. This module
@@ -36,9 +36,8 @@ public final class MultiFormatReader implements Reader {
     }
 
     public void setFormat(final String format) {
-        if(!READER_FACTORY.containsKey(format)){
-            throw new IllegalArgumentException("Format '" + format +
-                    "' not regognized");
+        if (!READER_FACTORY.containsKey(format)) {
+            throw new IllegalArgumentException("Format '" + format + "' not regognized");
         }
         currentReader = READER_FACTORY.newInstance(format);
         currentReader.setReceiver(downstreamReceiver);

--- a/metamorph-test/src/main/java/org/metafacture/metamorph/test/reader/PicaReader.java
+++ b/metamorph-test/src/main/java/org/metafacture/metamorph/test/reader/PicaReader.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.test.reader;
 
 import org.metafacture.biblio.pica.PicaDecoder;

--- a/metamorph-test/src/main/java/org/metafacture/metamorph/test/reader/Reader.java
+++ b/metamorph-test/src/main/java/org/metafacture/metamorph/test/reader/Reader.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.test.reader;
 
 import org.metafacture.framework.ObjectPipe;

--- a/metamorph-test/src/main/java/org/metafacture/metamorph/test/reader/ReaderBase.java
+++ b/metamorph-test/src/main/java/org/metafacture/metamorph/test/reader/ReaderBase.java
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.test.reader;
 
 import org.metafacture.framework.ObjectPipe;
 import org.metafacture.framework.ObjectReceiver;
 import org.metafacture.framework.StreamReceiver;
-
 
 /**
  * Base class for {@link Reader}s that are constructed from a record reader and

--- a/metamorph-test/src/main/java/org/metafacture/metamorph/test/reader/ReaderFactory.java
+++ b/metamorph-test/src/main/java/org/metafacture/metamorph/test/reader/ReaderFactory.java
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.metamorph.test.reader;
 
-import java.io.IOException;
+package org.metafacture.metamorph.test.reader;
 
 import org.metafacture.commons.ResourceUtil;
 import org.metafacture.commons.reflection.ObjectFactory;
 import org.metafacture.framework.MetafactureException;
+
+import java.io.IOException;
 
 /**
  * Instantiates instances of the {@link Reader} interface.
@@ -31,9 +32,9 @@ final class ReaderFactory extends ObjectFactory<Reader> {
 
     ReaderFactory() {
         try {
-            loadClassesFromMap(ResourceUtil.loadProperties(
-                    "test-readers.properties"), Reader.class);
-        } catch (IOException e) {
+            loadClassesFromMap(ResourceUtil.loadProperties("test-readers.properties"), Reader.class);
+        }
+        catch (final IOException e) {
             throw new MetafactureException("Failed to load readers list", e);
         }
     }

--- a/metamorph-test/src/main/java/org/metafacture/metamorph/test/reader/XmlReaderBase.java
+++ b/metamorph-test/src/main/java/org/metafacture/metamorph/test/reader/XmlReaderBase.java
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.test.reader;
 
 import org.metafacture.framework.StreamReceiver;
 import org.metafacture.framework.XmlPipe;
 import org.metafacture.xml.XmlDecoder;
-
 
 /**
  * Base class for {@link Reader}s for xml formats.

--- a/metamorph-test/src/main/java/org/metafacture/metamorph/test/validators/StreamValidator.java
+++ b/metamorph-test/src/main/java/org/metafacture/metamorph/test/validators/StreamValidator.java
@@ -13,7 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.test.validators;
+
+import org.metafacture.framework.StreamReceiver;
+import org.metafacture.javaintegration.EventList.Event;
+import org.metafacture.javaintegration.EventList;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -21,13 +29,6 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Consumer;
-
-import org.metafacture.framework.StreamReceiver;
-import org.metafacture.javaintegration.EventList;
-import org.metafacture.javaintegration.EventList.Event;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 /**
  * Validates a stream of events using a list of expected stream events.
@@ -43,23 +44,18 @@ import org.slf4j.LoggerFactory;
  */
 public final class StreamValidator implements StreamReceiver {
 
-    public static final Consumer<String> DEFAULT_ERROR_HANDLER =
-            msg -> { /* do nothing */ };
+    public static final Consumer<String> DEFAULT_ERROR_HANDLER = msg -> { /* do nothing */ };
 
-    private static final Logger LOG =
-            LoggerFactory.getLogger(StreamValidator.class);
+    private static final Logger LOG = LoggerFactory.getLogger(StreamValidator.class);
 
-    private static final String CANNOT_CHANGE_OPTIONS =
-            "Cannot change options during validation";
-    private static final String VALIDATION_FAILED =
-            "Validation failed. Please reset the validator";
+    private static final String CANNOT_CHANGE_OPTIONS = "Cannot change options during validation";
+    private static final String VALIDATION_FAILED = "Validation failed. Please reset the validator";
 
     private static final String NO_RECORD_FOUND = "No record found: ";
     private static final String NO_ENTITY_FOUND = "No entity found: ";
     private static final String NO_LITERAL_FOUND = "No literal found: ";
 
-    private static final String UNCONSUMED_RECORDS_FOUND =
-            "Unconsumed records found";
+    private static final String UNCONSUMED_RECORDS_FOUND = "Unconsumed records found";
 
     private final Deque<List<EventNode>> stack = new ArrayDeque<>();
     private final EventNode eventStream;
@@ -72,8 +68,7 @@ public final class StreamValidator implements StreamReceiver {
     private boolean strictKeyOrder;
     private boolean strictValueOrder;
 
-    private final WellformednessChecker wellformednessChecker =
-            new WellformednessChecker();
+    private final WellformednessChecker wellformednessChecker = new WellformednessChecker();
 
     public StreamValidator(final List<Event> expectedStream) {
         this.eventStream = new EventNode(null, null);
@@ -167,8 +162,7 @@ public final class StreamValidator implements StreamReceiver {
         if (!closeGroups()) {
             validationFailed = true;
             logEventStream();
-            errorHandler.accept(NO_RECORD_FOUND +
-                    "No record matched the sequence of stream events");
+            errorHandler.accept(NO_RECORD_FOUND + "No record matched the sequence of stream events");
         }
     }
 
@@ -199,8 +193,7 @@ public final class StreamValidator implements StreamReceiver {
         if (!closeGroups()) {
             validationFailed = true;
             logEventStream();
-            errorHandler.accept(NO_ENTITY_FOUND +
-                    "No entity matched the sequence of stream events");
+            errorHandler.accept(NO_ENTITY_FOUND + "No entity matched the sequence of stream events");
         }
     }
 
@@ -258,40 +251,39 @@ public final class StreamValidator implements StreamReceiver {
 
         if (isGroupConsumed(eventStream)) {
             eventStream.setConsumed(true);
-        } else {
+        }
+        else {
             validationFailed = true;
             logEventStream();
             errorHandler.accept(UNCONSUMED_RECORDS_FOUND);
         }
     }
 
-    private void foldEventStream(final EventNode parent,
-            final Iterator<Event> eventStream) {
-        while (eventStream.hasNext()) {
-            final Event event = eventStream.next();
+    private void foldEventStream(final EventNode parent, final Iterator<Event> currentEventStream) {
+        while (currentEventStream.hasNext()) {
+            final Event event = currentEventStream.next();
             if (event.getType() == Event.Type.LITERAL) {
                 parent.getChildren().add(new EventNode(event, parent));
-            } else if (event.getType() == Event.Type.START_RECORD
-                    || event.getType() == Event.Type.START_ENTITY) {
+            }
+            else if (event.getType() == Event.Type.START_RECORD || event.getType() == Event.Type.START_ENTITY) {
                 final EventNode newNode = new EventNode(event, parent);
                 parent.getChildren().add(newNode);
-                foldEventStream(newNode, eventStream);
-            } else if (event.getType() == Event.Type.END_RECORD
-                    || event.getType() == Event.Type.END_ENTITY) {
+                foldEventStream(newNode, currentEventStream);
+            }
+            else if (event.getType() == Event.Type.END_RECORD || event.getType() == Event.Type.END_ENTITY) {
                 return;
             }
         }
     }
 
-    private boolean openGroups(final Event.Type type, final String name,
-            final boolean strictKeyOrder, final boolean strictValueOrder) {
+    private boolean openGroups(final Event.Type type, final String name, final boolean currentStrictKeyOrder, final boolean currentStrictValueOrder) {
         final List<EventNode> stackFrame = stack.peek();
         stack.push(new LinkedList<>());
 
         final Iterator<EventNode> iter = stackFrame.iterator();
         while (iter.hasNext()) {
             final EventNode eventNode = iter.next();
-            if (!consumeGroups(eventNode, type, name, strictKeyOrder, strictValueOrder)) {
+            if (!consumeGroups(eventNode, type, name, currentStrictKeyOrder, currentStrictValueOrder)) {
                 resetGroup(eventNode);
                 iter.remove();
             }
@@ -303,11 +295,11 @@ public final class StreamValidator implements StreamReceiver {
     private boolean closeGroups() {
         EventNode lastMatchParent = null;
         for (final EventNode eventNode : stack.pop()) {
-            if (eventNode.getParent() != lastMatchParent
-                    && isGroupConsumed(eventNode)) {
+            if (eventNode.getParent() != lastMatchParent && isGroupConsumed(eventNode)) {
                 eventNode.setConsumed(true);
                 lastMatchParent = eventNode.getParent();
-            } else {
+            }
+            else {
                 resetGroup(eventNode);
             }
         }
@@ -316,8 +308,8 @@ public final class StreamValidator implements StreamReceiver {
     }
 
     private boolean consumeGroups(final EventNode group, final Event.Type type,
-            final String name, final boolean strictKeyOrder,
-            final boolean strictValueOrder) {
+            final String name, final boolean currentStrictKeyOrder,
+            final boolean currentStrictValueOrder) {
         boolean foundMatch = false;
         for (final EventNode c : group.getChildren()) {
             if (!c.isConsumed()) {
@@ -326,11 +318,12 @@ public final class StreamValidator implements StreamReceiver {
                     if (event.getType() == type) {
                         stack.peek().add(c);
                         foundMatch = true;
-                    } else if (strictValueOrder) {
+                    }
+                    else if (currentStrictValueOrder) {
                         break;
                     }
                 }
-                if (strictKeyOrder) {
+                if (currentStrictKeyOrder) {
                     break;
                 }
             }
@@ -338,22 +331,22 @@ public final class StreamValidator implements StreamReceiver {
         return foundMatch;
     }
 
-    private boolean consumeLiteral(final EventNode group, final String name,
-            final String value) {
+    private boolean consumeLiteral(final EventNode group, final String name, final String value) {
         boolean foundMatch = false;
         for (final EventNode eventNode : group.getChildren()) {
             if (!eventNode.isConsumed()) {
                 final Event event = eventNode.getEvent();
                 if (compare(name, event.getName())) {
-                    if (event.getType() == Event.Type.LITERAL
-                            && compare(value, event.getValue())) {
+                    if (event.getType() == Event.Type.LITERAL && compare(value, event.getValue())) {
                         eventNode.setConsumed(true);
                         foundMatch = true;
                         break;
-                    } else if (strictValueOrder) {
+                    }
+                    else if (strictValueOrder) {
                         break;
                     }
-                } else if (strictKeyOrder) {
+                }
+                else if (strictKeyOrder) {
                     break;
                 }
             }
@@ -407,10 +400,10 @@ public final class StreamValidator implements StreamReceiver {
             this.event = event;
             this.parent = parent;
             // The null-event is used to indicate the stream-start:
-            if (this.event == null || this.event.getType() == Event.Type.START_RECORD
-                    || this.event.getType() == Event.Type.START_ENTITY) {
+            if (this.event == null || this.event.getType() == Event.Type.START_RECORD || this.event.getType() == Event.Type.START_ENTITY) {
                 children = new LinkedList<>();
-            } else {
+            }
+            else {
                 children = null;
             }
 
@@ -443,31 +436,29 @@ public final class StreamValidator implements StreamReceiver {
             final String consumedIndicator;
             if (consumed) {
                 consumedIndicator = CONSUMED_INDICATOR;
-            } else {
+            }
+            else {
                 consumedIndicator = "";
             }
 
             if (event == null) {
                 appendChildren(builder);
-            } else {
+            }
+            else {
                 switch (event.getType()) {
                     case START_RECORD:
                         builder.append(event.getName()).append(consumedIndicator).append("{");
                         appendChildren(builder);
                         builder.append("}");
                         break;
-
                     case START_ENTITY:
                         builder.append(event.getName()).append(consumedIndicator).append("[");
                         appendChildren(builder);
                         builder.append("]");
                         break;
-
                     case LITERAL:
-                        builder.append(event.getName()).append("=").append(event.getValue())
-                                .append(consumedIndicator);
+                        builder.append(event.getName()).append("=").append(event.getValue()).append(consumedIndicator);
                         break;
-
                     default:
                         break;
                 }

--- a/metamorph-test/src/main/java/org/metafacture/metamorph/test/validators/WellformednessChecker.java
+++ b/metamorph-test/src/main/java/org/metafacture/metamorph/test/validators/WellformednessChecker.java
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.test.validators;
 
-import java.util.function.Consumer;
-
 import org.metafacture.framework.StreamReceiver;
+
+import java.util.function.Consumer;
 
 /**
  * Checks that the received stream events are in the correct order and contain
@@ -43,8 +44,7 @@ public final class WellformednessChecker implements StreamReceiver {
      * The default error handler which is used if no other error handler was set
      * via {@link #setErrorHandler(Consumer)}. It does nothing.
      */
-    public static final Consumer<String> DEFAULT_ERROR_HANDLER =
-            msg -> { /* do nothing */ };
+    public static final Consumer<String> DEFAULT_ERROR_HANDLER = msg -> { /* do nothing */ };
 
     private static final String ID_MUST_NOT_BE_NULL = "id must not be null";
     private static final String NAME_MUST_NOT_BE_NULL = "name must not be null";
@@ -57,6 +57,9 @@ public final class WellformednessChecker implements StreamReceiver {
     private Consumer<String> errorHandler = DEFAULT_ERROR_HANDLER;
 
     private int nestingLevel;
+
+    public WellformednessChecker() {
+    }
 
     /**
      * Sets the error handler which is called when a invalid event stream is
@@ -78,7 +81,8 @@ public final class WellformednessChecker implements StreamReceiver {
     public void startRecord(final String identifier) {
         if (nestingLevel > 0) {
             errorHandler.accept(IN_RECORD);
-        } else {
+        }
+        else {
             nestingLevel += 1;
         }
         if (identifier == null) {
@@ -90,9 +94,11 @@ public final class WellformednessChecker implements StreamReceiver {
     public void endRecord() {
         if (nestingLevel < 1) {
             errorHandler.accept(NOT_IN_RECORD);
-        } else if (nestingLevel > 1) {
+        }
+        else if (nestingLevel > 1) {
             errorHandler.accept(IN_ENTITY);
-        } else {
+        }
+        else {
             nestingLevel -= 1;
         }
     }
@@ -101,7 +107,8 @@ public final class WellformednessChecker implements StreamReceiver {
     public void startEntity(final String name) {
         if (nestingLevel < 1) {
             errorHandler.accept(NOT_IN_RECORD);
-        } else {
+        }
+        else {
             nestingLevel += 1;
         }
         if (name == null) {
@@ -113,7 +120,8 @@ public final class WellformednessChecker implements StreamReceiver {
     public void endEntity() {
         if (nestingLevel < 2) {
             errorHandler.accept(NOT_IN_ENTITY);
-        } else {
+        }
+        else {
             nestingLevel -= 1;
         }
     }

--- a/metamorph-test/src/test/java/org/metafacture/metamorph/test/FrameworkTest.java
+++ b/metamorph-test/src/test/java/org/metafacture/metamorph/test/FrameworkTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.test;
 
 import org.junit.runner.RunWith;

--- a/metamorph-test/src/test/java/org/metafacture/metamorph/test/MetamorphTestCaseTest.java
+++ b/metamorph-test/src/test/java/org/metafacture/metamorph/test/MetamorphTestCaseTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.test;
 
 import javax.xml.parsers.DocumentBuilder;

--- a/metamorph-test/src/test/java/org/metafacture/metamorph/test/TestCaseRunnerMetamorphTest.java
+++ b/metamorph-test/src/test/java/org/metafacture/metamorph/test/TestCaseRunnerMetamorphTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.test;
 
 import static org.junit.Assert.assertNotNull;

--- a/metamorph-test/src/test/java/org/metafacture/metamorph/test/validators/StreamValidatorTest.java
+++ b/metamorph-test/src/test/java/org/metafacture/metamorph/test/validators/StreamValidatorTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.test.validators;
 
 import static org.mockito.ArgumentMatchers.any;

--- a/metamorph-test/src/test/java/org/metafacture/metamorph/test/validators/WellformednessCheckerTest.java
+++ b/metamorph-test/src/test/java/org/metafacture/metamorph/test/validators/WellformednessCheckerTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.test.validators;
 
 import static org.mockito.ArgumentMatchers.any;

--- a/metamorph/src/main/java/org/metafacture/metamorph/CollectFactory.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/CollectFactory.java
@@ -13,15 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph;
-
-
-import java.io.IOException;
 
 import org.metafacture.commons.ResourceUtil;
 import org.metafacture.commons.reflection.ObjectFactory;
 import org.metafacture.framework.MetafactureException;
 import org.metafacture.metamorph.api.Collect;
+
+import java.io.IOException;
 
 /**
  * Creates the collectors available in Metamorph.
@@ -33,9 +33,9 @@ final class CollectFactory extends ObjectFactory<Collect> {
 
     CollectFactory() {
         try {
-            loadClassesFromMap(ResourceUtil.loadProperties(
-                    "morph-collectors.properties"), Collect.class);
-        } catch (IOException e) {
+            loadClassesFromMap(ResourceUtil.loadProperties("morph-collectors.properties"), Collect.class);
+        }
+        catch (final IOException e) {
             throw new MetafactureException("Failed to load collectors list", e);
         }
     }

--- a/metamorph/src/main/java/org/metafacture/metamorph/Data.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/Data.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph;
 
 import org.metafacture.commons.StringUtil;
@@ -28,13 +29,12 @@ final class Data extends AbstractNamedValuePipe {
 
     private String name;
 
-    @Override
-    public void receive(final String recName, final String recValue,
-            final NamedValueSource source, final int recordCount,
-            final int entityCount) {
+    Data() {
+    }
 
-        getNamedValueReceiver().receive(StringUtil.fallback(name, recName),
-                recValue, this, recordCount, entityCount);
+    @Override
+    public void receive(final String recName, final String recValue, final NamedValueSource source, final int recordCount, final int entityCount) {
+        getNamedValueReceiver().receive(StringUtil.fallback(name, recName), recValue, this, recordCount, entityCount);
     }
 
     public void setName(final String name) {

--- a/metamorph/src/main/java/org/metafacture/metamorph/DefaultErrorHandler.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/DefaultErrorHandler.java
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.metamorph;
 
+package org.metafacture.metamorph;
 
 import org.metafacture.metamorph.api.MorphErrorHandler;
 
@@ -26,11 +26,12 @@ import org.metafacture.metamorph.api.MorphErrorHandler;
  */
 public final class DefaultErrorHandler implements MorphErrorHandler {
 
+    public DefaultErrorHandler() {
+    }
+
     @Override
     public void error(final Exception exception) {
-        throw new MetamorphException(
-                "Error while executing the Metamorph transformation pipeline: " +
-                        exception.getMessage(), exception);
+        throw new MetamorphException("Error while executing the Metamorph transformation pipeline: " + exception.getMessage(), exception);
     }
 
 }

--- a/metamorph/src/main/java/org/metafacture/metamorph/Entity.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/Entity.java
@@ -13,13 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.metamorph;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.function.Supplier;
+package org.metafacture.metamorph;
 
 import org.metafacture.commons.StringUtil;
 import org.metafacture.flowcontrol.StreamBuffer;
@@ -27,6 +22,12 @@ import org.metafacture.framework.StreamReceiver;
 import org.metafacture.metamorph.api.NamedValueReceiver;
 import org.metafacture.metamorph.api.NamedValueSource;
 import org.metafacture.metamorph.api.helpers.AbstractFlushingCollect;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * Corresponds to the <code>&lt;entity&gt;</code> tag.
@@ -64,29 +65,31 @@ public final class Entity extends AbstractFlushingCollect {
         if (namedValueReceiver instanceof Entity) {
             final Entity parent = (Entity) namedValueReceiver;
             parent.receive(null, null, this, getRecordCount(), getEntityCount());
-        } else {
+        }
+        else {
             write(receiver.get());
         }
     }
 
-    private void write(final StreamReceiver receiver) {
+    private void write(final StreamReceiver currentReceiver) {
         if (!buffer.isEmpty()) {
-            receiver.startEntity(StringUtil.fallback(currentName, getName()));
-            buffer.setReceiver(receiver);
+            currentReceiver.startEntity(StringUtil.fallback(currentName, getName()));
+            buffer.setReceiver(currentReceiver);
             buffer.replay();
-            receiver.endEntity();
+            currentReceiver.endEntity();
         }
     }
 
     @Override
-    protected void receive(final String name, final String value,
-            final NamedValueSource source) {
+    protected void receive(final String name, final String value, final NamedValueSource source) {
         if (source == nameSource) {
             currentName = value;
-        } else if (source instanceof Entity) {
+        }
+        else if (source instanceof Entity) {
             final Entity child = (Entity) source;
             child.write(buffer);
-        } else {
+        }
+        else {
             buffer.literal(name, value);
         }
         sourcesLeft.remove(source);

--- a/metamorph/src/main/java/org/metafacture/metamorph/Filter.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/Filter.java
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.metamorph;
 
+package org.metafacture.metamorph;
 
 import org.metafacture.flowcontrol.StreamBuffer;
 import org.metafacture.framework.FluxCommand;
@@ -45,29 +45,22 @@ public final class Filter extends DefaultStreamPipe<StreamReceiver> {
     private final SingleValue singleValue = new SingleValue();
     private final Metamorph metamorph;
 
-
     public Filter(final String morphDef) {
-        super();
         metamorph = new Metamorph(morphDef);
         metamorph.setReceiver(singleValue);
     }
 
     public Filter(final Metamorph metamorph) {
-        super();
         this.metamorph = metamorph;
         metamorph.setReceiver(singleValue);
     }
 
     public Filter(final String morphDef, final Map<String, String> vars) {
-
-        super();
         metamorph = new Metamorph(morphDef, vars);
         metamorph.setReceiver(singleValue);
     }
 
     public Filter(final String morphDef, final InterceptorFactory interceptorFactory) {
-
-        super();
         metamorph = new Metamorph(morphDef, interceptorFactory);
         metamorph.setReceiver(singleValue);
     }
@@ -77,10 +70,9 @@ public final class Filter extends DefaultStreamPipe<StreamReceiver> {
         buffer.setReceiver(getReceiver());
     }
 
-
-    private void dispatch(){
+    private void dispatch() {
         final String key = singleValue.getValue();
-        if(!key.isEmpty()){
+        if (!key.isEmpty()) {
             buffer.replay();
         }
         buffer.clear();

--- a/metamorph/src/main/java/org/metafacture/metamorph/Flush.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/Flush.java
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph;
 
 import org.metafacture.metamorph.api.FlushListener;
 import org.metafacture.metamorph.api.NamedValueReceiver;
 import org.metafacture.metamorph.api.NamedValueSource;
 import org.metafacture.metamorph.api.SourceLocation;
-
 
 /**
  * Flushes a {@link FlushListener}

--- a/metamorph/src/main/java/org/metafacture/metamorph/FunctionFactory.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/FunctionFactory.java
@@ -13,15 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph;
-
-
-import java.io.IOException;
 
 import org.metafacture.commons.ResourceUtil;
 import org.metafacture.commons.reflection.ObjectFactory;
 import org.metafacture.framework.MetafactureException;
 import org.metafacture.metamorph.api.Function;
+
+import java.io.IOException;
 
 /**
  * Creates the functions available in Metamorph.
@@ -33,9 +33,9 @@ final class FunctionFactory extends ObjectFactory<Function> {
 
     FunctionFactory() {
         try {
-            loadClassesFromMap(ResourceUtil.loadProperties(
-                    "morph-functions.properties"), Function.class);
-        } catch (IOException e) {
+            loadClassesFromMap(ResourceUtil.loadProperties("morph-functions.properties"), Function.class);
+        }
+        catch (final IOException e) {
             throw new MetafactureException("Failed to load functions list", e);
         }
     }

--- a/metamorph/src/main/java/org/metafacture/metamorph/InlineMorph.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/InlineMorph.java
@@ -13,13 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph;
+
+import org.metafacture.framework.StreamReceiver;
+
+import org.xml.sax.InputSource;
 
 import java.io.StringReader;
 import java.net.URL;
-
-import org.metafacture.framework.StreamReceiver;
-import org.xml.sax.InputSource;
 
 /**
  * Helper for including Metamorph scripts directly in Java code.
@@ -72,7 +74,7 @@ public final class InlineMorph {
      * @param owner the object which contains the morph script
      * @return an instance of {@code InlineMorph} for continuation
      */
-    public static InlineMorph in(Object owner) {
+    public static InlineMorph in(final Object owner) {
         return in(owner.getClass());
     }
 
@@ -86,11 +88,11 @@ public final class InlineMorph {
      * @param owner the class which contains the morph script
      * @return an instance of {@code InlineMorph} for continuation
      */
-    public static InlineMorph in(Class<?> owner) {
+    public static InlineMorph in(final Class<?> owner) {
         return new InlineMorph().setClassAsSystemId(owner);
     }
 
-    private InlineMorph setClassAsSystemId(Class<?> owner) {
+    private InlineMorph setClassAsSystemId(final Class<?> owner) {
         final URL baseUrl = owner.getResource("");
         systemId = baseUrl.toExternalForm();
         return this;
@@ -102,7 +104,7 @@ public final class InlineMorph {
      * @param line the next line of the morph script
      * @return a reference to {@code this} for continuation
      */
-    public InlineMorph with(String line) {
+    public InlineMorph with(final String line) {
         if (scriptBuilder.length() == 0) {
             appendBoilerplate(line);
         }
@@ -112,7 +114,7 @@ public final class InlineMorph {
         return this;
     }
 
-    private void appendBoilerplate(String line) {
+    private void appendBoilerplate(final String line) {
         final String trimmedLine = line.trim();
         if (!trimmedLine.startsWith("<?xml ")) {
             appendXmlBoilerplate();
@@ -128,9 +130,7 @@ public final class InlineMorph {
     }
 
     private void appendMetamorphBoilerplate() {
-        scriptBuilder.append(
-                        "<metamorph version='1'\n" +
-                        "    xmlns='http://www.culturegraph.org/metamorph'>");
+        scriptBuilder.append("<metamorph version='1'\n    xmlns='http://www.culturegraph.org/metamorph'>");
     }
 
     /**
@@ -169,7 +169,7 @@ public final class InlineMorph {
      *                  send its output.
      * @return a Metamorph object initialised with the inline script
      */
-    public Metamorph createConnectedTo(StreamReceiver receiver) {
+    public Metamorph createConnectedTo(final StreamReceiver receiver) {
         final Metamorph metamorph = create();
         metamorph.setReceiver(receiver);
         return metamorph;

--- a/metamorph/src/main/java/org/metafacture/metamorph/MapFactory.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/MapFactory.java
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.metamorph;
 
-import java.io.IOException;
-import java.util.Map;
+package org.metafacture.metamorph;
 
 import org.metafacture.commons.ResourceUtil;
 import org.metafacture.commons.reflection.ObjectFactory;
 import org.metafacture.framework.MetafactureException;
+
+import java.io.IOException;
+import java.util.Map;
 
 /**
  * Creates the maps available in Metamorph.
@@ -30,13 +31,13 @@ import org.metafacture.framework.MetafactureException;
  */
 final class MapFactory extends ObjectFactory<Map> {
 
-      MapFactory() {
-          try {
-              loadClassesFromMap(ResourceUtil.loadProperties(
-                      "morph-maps.properties"), Map.class);
-          } catch (IOException e) {
-              throw new MetafactureException("Failed to load maps list", e);
-          }
-      }
+    MapFactory() {
+        try {
+            loadClassesFromMap(ResourceUtil.loadProperties("morph-maps.properties"), Map.class);
+        }
+        catch (final IOException e) {
+            throw new MetafactureException("Failed to load maps list", e);
+        }
+    }
 
 }

--- a/metamorph/src/main/java/org/metafacture/metamorph/Metamorph.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/Metamorph.java
@@ -13,22 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.metamorph;
 
-import java.io.Closeable;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Reader;
-import java.net.MalformedURLException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Deque;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.regex.Pattern;
+package org.metafacture.metamorph;
 
 import org.metafacture.commons.ResourceUtil;
 import org.metafacture.framework.FluxCommand;
@@ -49,32 +35,48 @@ import org.metafacture.metamorph.api.NamedValuePipe;
 import org.metafacture.metamorph.api.NamedValueReceiver;
 import org.metafacture.metamorph.api.NamedValueSource;
 import org.metafacture.metamorph.api.SourceLocation;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.InputSource;
 
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
 /**
- * Transforms a data stream send via the {@link StreamReceiver} interface. Use
- * {@link MorphBuilder} to create an instance based on an xml description
+ * Transforms a data stream sent via the {@link StreamReceiver} interface. Use
+ * {@link MorphBuilder} to create an instance based on an XML description.
  *
  * @author Markus Michael Geipel
  * @author Christoph Böhme
  */
-@Description("applies a metamorph transformation to the event stream. Metamorph "
-        + "definition is given in brackets.")
+@Description("Applies a metamorph transformation to the event stream. Metamorph definition is given in brackets.") // checkstyle-disable-line ClassDataAbstractionCoupling|ClassFanOutComplexity
 @In(StreamReceiver.class)
 @Out(StreamReceiver.class)
 @FluxCommand("morph")
 public final class Metamorph implements StreamPipe<StreamReceiver>, NamedValuePipe, Maps {
 
-    private static final String ELSE_NESTED_KEYWORD = "_elseNested";
     public static final String ELSE_KEYWORD = "_else";
+    public static final String ELSE_NESTED_KEYWORD = "_elseNested";
     public static final String ELSE_FLATTENED_KEYWORD = "_elseFlattened";
     public static final char FEEDBACK_CHAR = '@';
     public static final char ESCAPE_CHAR = '\\';
     public static final String METADATA = "__meta";
     public static final String VAR_START = "$[";
     public static final String VAR_END = "]";
+
+    private static final Logger LOG = LoggerFactory.getLogger(Metamorph.class);
 
     private static final String ENTITIES_NOT_BALANCED = "Entity starts and ends are not balanced";
     private static final String COULD_NOT_LOAD_MORPH_FILE = "Could not load morph file";
@@ -101,7 +103,6 @@ public final class Metamorph implements StreamPipe<StreamReceiver>, NamedValuePi
     private boolean elseNested;
     private boolean elseNestedEntityStarted;
     private String currentLiteralName;
-    private static final Logger LOG = LoggerFactory.getLogger(Metamorph.class);
 
     protected Metamorph() {
         // package private
@@ -177,23 +178,21 @@ public final class Metamorph implements StreamPipe<StreamReceiver>, NamedValuePi
         init();
     }
 
-    private void buildPipeline(InputSource inputSource, Map<String, String> vars,
-            InterceptorFactory interceptorFactory) {
+    private void buildPipeline(final InputSource inputSource, final Map<String, String> vars, final InterceptorFactory interceptorFactory) {
         try {
             final MorphBuilder builder = new MorphBuilder(this, interceptorFactory);
             builder.walk(inputSource, vars);
-        } catch (RuntimeException e) {
-            throw new MetamorphException(
-                    "Error while building the Metamorph transformation pipeline: " +
-                            e.getMessage(), e);
+        }
+        catch (final RuntimeException e) { // checkstyle-disable-line IllegalCatch
+            throw new MetamorphException("Error while building the Metamorph transformation pipeline: " + e.getMessage(), e);
         }
     }
 
     private static InputSource getInputSource(final String morphDef) {
         try {
-            return new InputSource(
-                    ResourceUtil.getUrl(morphDef).toExternalForm());
-        } catch (final MalformedURLException e) {
+            return new InputSource(ResourceUtil.getUrl(morphDef).toExternalForm());
+        }
+        catch (final MalformedURLException e) {
             throw new MorphBuildException(COULD_NOT_LOAD_MORPH_FILE, e);
         }
     }
@@ -231,7 +230,8 @@ public final class Metamorph implements StreamPipe<StreamReceiver>, NamedValuePi
             else {
                 LOG.warn("Only one of '_else', '_elseFlattened' and '_elseNested' is allowed. Ignoring the superflous ones.");
             }
-        } else {
+        }
+        else {
             dataRegistry.register(source, data);
         }
     }
@@ -257,7 +257,7 @@ public final class Metamorph implements StreamPipe<StreamReceiver>, NamedValuePi
 
     @Override
     public void endRecord() {
-        for(final FlushListener listener: recordEndListener){
+        for (final FlushListener listener : recordEndListener) {
             listener.flush(recordCount, currentEntityCount);
         }
 
@@ -290,7 +290,6 @@ public final class Metamorph implements StreamPipe<StreamReceiver>, NamedValuePi
         flattener.endEntity();
     }
 
-
     @Override
     public void literal(final String name, final String value) {
         currentLiteralName = name;
@@ -308,7 +307,8 @@ public final class Metamorph implements StreamPipe<StreamReceiver>, NamedValuePi
         for (final Closeable closeable : resources) {
             try {
                 closeable.close();
-            } catch (final IOException e) {
+            }
+            catch (final IOException e) {
                 errorHandler.error(e);
             }
         }
@@ -357,7 +357,8 @@ public final class Metamorph implements StreamPipe<StreamReceiver>, NamedValuePi
         for (final NamedValueReceiver data : dataList) {
             try {
                 data.receive(path, value, null, recordCount, currentEntityCount);
-            } catch (final RuntimeException e) {
+            }
+            catch (final RuntimeException e) { // checkstyle-disable-line IllegalCatch
                 errorHandler.error(e);
             }
         }
@@ -389,11 +390,9 @@ public final class Metamorph implements StreamPipe<StreamReceiver>, NamedValuePi
     }
 
     @Override
-    public void receive(final String name, final String value, final NamedValueSource source, final int recordCount,
-            final int entityCount) {
+    public void receive(final String name, final String value, final NamedValueSource source, final int unusedRecordCount, final int unusedEntityCount) {
         if (null == name) {
-            throw new IllegalArgumentException(
-                    "encountered literal with name='null'. This indicates a bug in a function or a collector.");
+            throw new IllegalArgumentException("encountered literal with name='null'. This indicates a bug in a function or a collector.");
         }
 
         if (startsWithFeedbackChar(name)) {
@@ -402,8 +401,7 @@ public final class Metamorph implements StreamPipe<StreamReceiver>, NamedValuePi
         }
 
         String unescapedName = name;
-        if(name.length() > 1 && name.charAt(0) == ESCAPE_CHAR
-                && (name.charAt(1) == FEEDBACK_CHAR || name.charAt(1) == ESCAPE_CHAR)) {
+        if (name.length() > 1 && name.charAt(0) == ESCAPE_CHAR && (name.charAt(1) == FEEDBACK_CHAR || name.charAt(1) == ESCAPE_CHAR)) {
             unescapedName = name.substring(1);
         }
         outputStreamReceiver.literal(unescapedName, value);

--- a/metamorph/src/main/java/org/metafacture/metamorph/MetamorphException.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/MetamorphException.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph;
 
 import org.metafacture.framework.MetafactureException;
@@ -27,7 +28,7 @@ public class MetamorphException extends MetafactureException {
 
     private static final long serialVersionUID = 0L;
 
-    public MetamorphException(String message, Throwable cause) {
+    public MetamorphException(final String message, final Throwable cause) {
         super(message, cause);
     }
 

--- a/metamorph/src/main/java/org/metafacture/metamorph/MorphBuilder.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/MorphBuilder.java
@@ -13,12 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.metamorph;
 
-import java.util.Deque;
-import java.util.LinkedList;
-import java.util.Map;
-import java.util.regex.Pattern;
+package org.metafacture.metamorph;
 
 import org.metafacture.commons.reflection.ConfigurableClass;
 import org.metafacture.commons.reflection.ReflectionUtil;
@@ -31,7 +27,13 @@ import org.metafacture.metamorph.api.Maps;
 import org.metafacture.metamorph.api.MorphBuildException;
 import org.metafacture.metamorph.api.NamedValuePipe;
 import org.metafacture.metamorph.xml.Location;
+
 import org.w3c.dom.Node;
+
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * Builds a {@link Metamorph} from an xml description
@@ -53,54 +55,7 @@ public final class MorphBuilder extends AbstractMetamorphDomWalker {
     private final InterceptorFactory interceptorFactory;
     private final Deque<StackFrame> stack = new LinkedList<StackFrame>();
 
-    private static final class StackFrame {
-
-        private final NamedValuePipe headPipe;
-
-        private NamedValuePipe pipe;
-        private boolean inEntityName;
-        private boolean inCondition;
-
-        public StackFrame(final NamedValuePipe headPipe) {
-            this.headPipe = headPipe;
-            this.pipe = headPipe;
-        }
-
-        public NamedValuePipe getHeadPipe() {
-            return headPipe;
-        }
-
-        public void setPipe(final NamedValuePipe pipe) {
-            this.pipe = pipe;
-        }
-
-        public NamedValuePipe getPipe() {
-            return pipe;
-        }
-
-        public void setInEntityName(final boolean inEntityName) {
-            this.inEntityName = inEntityName;
-        }
-
-        public boolean isInEntityName() {
-            return inEntityName;
-        }
-
-        public void setInCondition(final boolean inCondition) {
-            this.inCondition = inCondition;
-        }
-
-        public boolean isInCondition() {
-            return inCondition;
-        }
-
-    }
-
-    protected MorphBuilder(final Metamorph metamorph,
-            final InterceptorFactory interceptorFactory) {
-
-        super();
-
+    protected MorphBuilder(final Metamorph metamorph, final InterceptorFactory interceptorFactory) {
         this.metamorph = metamorph;
         this.interceptorFactory = interceptorFactory;
         stack.push(new StackFrame(metamorph));
@@ -142,9 +97,11 @@ public final class MorphBuilder extends AbstractMetamorphDomWalker {
             final ConfigurableClass<? extends Map> mapClass =
                     ReflectionUtil.loadClass(className, Map.class);
             map = mapClass.newInstance(attributes);
-        } else if (getMapFactory().containsKey(mapNode.getLocalName())) {
+        }
+        else if (getMapFactory().containsKey(mapNode.getLocalName())) {
             map = getMapFactory().newInstance(mapNode.getLocalName(), attributes);
-        } else {
+        }
+        else {
             throw new MorphBuildException("Map " + mapNode.getLocalName() + NOT_FOUND);
         }
 
@@ -159,13 +116,15 @@ public final class MorphBuilder extends AbstractMetamorphDomWalker {
         final String className = resolvedAttribute(functionDefNode, AttributeName.CLASS);
         try {
             clazz = Thread.currentThread().getContextClassLoader().loadClass(className);
-        } catch (final ClassNotFoundException e) {
+        }
+        catch (final ClassNotFoundException e) {
             throw new MorphBuildException("Function " + className + NOT_FOUND, e);
         }
         if (Function.class.isAssignableFrom(clazz)) {
             getFunctionFactory().registerClass(resolvedAttribute(functionDefNode, AttributeName.NAME),
                     (Class<Function>) clazz);
-        } else {
+        }
+        else {
             throw new MorphBuildException(className + " does not implement interface 'Function'");
         }
     }
@@ -195,7 +154,8 @@ public final class MorphBuilder extends AbstractMetamorphDomWalker {
         final NamedValuePipe delegate;
         if (interceptor == null) {
             delegate = data;
-        } else {
+        }
+        else {
             delegate = interceptor;
             data.addNamedValueSource(delegate);
         }
@@ -214,7 +174,8 @@ public final class MorphBuilder extends AbstractMetamorphDomWalker {
         final NamedValuePipe delegate;
         if (interceptor == null) {
             delegate = dataPipe;
-        } else {
+        }
+        else {
             delegate = interceptor;
             delegate.addNamedValueSource(dataPipe);
         }
@@ -223,10 +184,12 @@ public final class MorphBuilder extends AbstractMetamorphDomWalker {
         if (parent.isInEntityName()) {
             // Protected xsd schema and by assertion in enterName:
             ((Entity) parent.getPipe()).setNameSource(delegate);
-        } else if (parent.isInCondition()) {
+        }
+        else if (parent.isInCondition()) {
             // Protected xsd schema and by assertion in enterIf:
             ((ConditionAware) parent.getPipe()).setConditionSource(delegate);
-        } else {
+        }
+        else {
             parent.getPipe().addNamedValueSource(delegate);
         }
     }
@@ -272,7 +235,8 @@ public final class MorphBuilder extends AbstractMetamorphDomWalker {
         if (ENTITY.equals(node.getLocalName())) {
             collect = getCollectFactory().newInstance(node.getLocalName(), attributes,
                     metamorph);
-        } else {
+        }
+        else {
             collect = getCollectFactory().newInstance(node.getLocalName(), attributes);
         }
         collect.setSourceLocation(getSourceLocation(node));
@@ -297,7 +261,8 @@ public final class MorphBuilder extends AbstractMetamorphDomWalker {
             // instances of Entity. If an interceptor is inserted between
             // entity elements this mechanism will break.
             delegate = tailPipe;
-        } else {
+        }
+        else {
             delegate = interceptor;
             delegate.addNamedValueSource(tailPipe);
         }
@@ -306,10 +271,12 @@ public final class MorphBuilder extends AbstractMetamorphDomWalker {
         if (parent.isInEntityName()) {
             // Protected xsd schema and by assertion in enterName:
             ((Entity) parent.getPipe()).setNameSource(delegate);
-        } else if (parent.isInCondition()) {
+        }
+        else if (parent.isInCondition()) {
             // Protected xsd schema and by assertion in enterIf:
             ((ConditionAware) parent.getPipe()).setConditionSource(delegate);
-        } else {
+        }
+        else {
             parent.getPipe().addNamedValueSource(delegate);
         }
 
@@ -328,12 +295,14 @@ public final class MorphBuilder extends AbstractMetamorphDomWalker {
             final FlushListener delegate;
             if (interceptor == null) {
                 delegate = flushListener;
-            } else {
+            }
+            else {
                 delegate = interceptor;
             }
             if (key.equals(RECORD)) {
                 metamorph.registerRecordEndFlush(delegate);
-            } else {
+            }
+            else {
                 metamorph.registerNamedValueReceiver(key, new Flush(delegate));
             }
         }
@@ -350,13 +319,15 @@ public final class MorphBuilder extends AbstractMetamorphDomWalker {
             final ConfigurableClass<? extends Function> functionClass =
                     ReflectionUtil.loadClass(className, Function.class);
             function = functionClass.newInstance(attributes);
-        } else if (getFunctionFactory().containsKey(functionNode.getLocalName())) {
+        }
+        else if (getFunctionFactory().containsKey(functionNode.getLocalName())) {
             final String flushWith = attributes.remove(AttributeName.FLUSH_WITH.getString());
             function = getFunctionFactory().newInstance(functionNode.getLocalName(), attributes);
             if (null != flushWith) {
                 registerFlush(flushWith, function);
             }
-        } else {
+        }
+        else {
             throw new MorphBuildException(functionNode.getLocalName() + NOT_FOUND);
         }
 
@@ -378,7 +349,8 @@ public final class MorphBuilder extends AbstractMetamorphDomWalker {
         final NamedValuePipe delegate;
         if (interceptor == null) {
             delegate = function;
-        } else {
+        }
+        else {
             delegate = interceptor;
             function.addNamedValueSource(delegate);
         }
@@ -390,6 +362,49 @@ public final class MorphBuilder extends AbstractMetamorphDomWalker {
     private XmlSourceLocation getSourceLocation(final Node node) {
         return new XmlSourceLocation((Location) node.getUserData(
                 Location.USER_DATA_ID));
+    }
+
+    private static final class StackFrame {
+
+        private final NamedValuePipe headPipe;
+
+        private NamedValuePipe pipe;
+        private boolean inEntityName;
+        private boolean inCondition;
+
+        StackFrame(final NamedValuePipe headPipe) {
+            this.headPipe = headPipe;
+            this.pipe = headPipe;
+        }
+
+        public NamedValuePipe getHeadPipe() {
+            return headPipe;
+        }
+
+        public void setPipe(final NamedValuePipe pipe) {
+            this.pipe = pipe;
+        }
+
+        public NamedValuePipe getPipe() {
+            return pipe;
+        }
+
+        public void setInEntityName(final boolean inEntityName) {
+            this.inEntityName = inEntityName;
+        }
+
+        public boolean isInEntityName() {
+            return inEntityName;
+        }
+
+        public void setInCondition(final boolean inCondition) {
+            this.inCondition = inCondition;
+        }
+
+        public boolean isInCondition() {
+            return inCondition;
+        }
+
     }
 
 }

--- a/metamorph/src/main/java/org/metafacture/metamorph/NullInterceptorFactory.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/NullInterceptorFactory.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph;
 
 import org.metafacture.metamorph.api.FlushListener;
@@ -28,6 +29,9 @@ import org.metafacture.metamorph.api.NamedValuePipe;
  *
  */
 final class NullInterceptorFactory implements InterceptorFactory {
+
+    NullInterceptorFactory() {
+    }
 
     @Override
     public NamedValuePipe createNamedValueInterceptor() {

--- a/metamorph/src/main/java/org/metafacture/metamorph/Registry.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/Registry.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph;
 
 import java.util.List;

--- a/metamorph/src/main/java/org/metafacture/metamorph/SimpleDataRegistry.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/SimpleDataRegistry.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph;
 
 import java.util.ArrayList;
@@ -30,6 +31,9 @@ import java.util.Map;
 final class SimpleDataRegistry<T> implements Registry<T> {
 
     private final Map<String, List<T>> map = new HashMap<String, List<T>>();
+
+    SimpleDataRegistry() {
+    }
 
     @Override
     public void register(final String path, final T value) {

--- a/metamorph/src/main/java/org/metafacture/metamorph/Splitter.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/Splitter.java
@@ -13,11 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.metamorph;
 
-import java.io.Reader;
-import java.util.HashMap;
-import java.util.Map;
+package org.metafacture.metamorph;
 
 import org.metafacture.flowcontrol.StreamBuffer;
 import org.metafacture.framework.StreamPipe;
@@ -27,7 +24,9 @@ import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.javaintegration.SingleValue;
 
-
+import java.io.Reader;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Splits a stream based on a morph definition.
@@ -71,11 +70,11 @@ public final class Splitter implements StreamPipe<StreamReceiver> {
         return receiver;
     }
 
-    private void dispatch(){
+    private void dispatch() {
         final String key = singleValue.getValue();
         final StreamReceiver receiver = receiverMap.get(key);
 
-        if(null != receiver){
+        if (null != receiver) {
             buffer.setReceiver(receiver);
             buffer.replay();
         }

--- a/metamorph/src/main/java/org/metafacture/metamorph/WildcardRegistry.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/WildcardRegistry.java
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.metamorph;
 
-import java.util.List;
+package org.metafacture.metamorph;
 
 import org.metafacture.commons.tries.SimpleRegexTrie;
 import org.metafacture.commons.tries.WildcardTrie;
+
+import java.util.List;
 
 /**
  * Implements {@link Registry} with a {@link WildcardTrie}.
@@ -29,6 +30,9 @@ import org.metafacture.commons.tries.WildcardTrie;
 final class WildcardRegistry<T> implements Registry<T> {
 
     private final SimpleRegexTrie<T> trie = new SimpleRegexTrie<T>();
+
+    WildcardRegistry() {
+    }
 
     @Override
     public void register(final String path, final T value) {

--- a/metamorph/src/main/java/org/metafacture/metamorph/XmlSourceLocation.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/XmlSourceLocation.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph;
 
 import org.metafacture.metamorph.api.SourceLocation;

--- a/metamorph/src/main/java/org/metafacture/metamorph/collectors/All.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/collectors/All.java
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.metamorph.collectors;
 
-import java.util.HashSet;
-import java.util.Set;
+package org.metafacture.metamorph.collectors;
 
 import org.metafacture.commons.StringUtil;
 import org.metafacture.metamorph.api.NamedValueSource;
 import org.metafacture.metamorph.api.helpers.AbstractFlushingCollect;
+
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Corresponds to the {@code <all>} tag.
@@ -34,6 +35,9 @@ public final class All extends AbstractFlushingCollect {
 
     private final Set<NamedValueSource> sources = new HashSet<NamedValueSource>();
     private final Set<NamedValueSource> sourcesLeft = new HashSet<NamedValueSource>();
+
+    public All() {
+    }
 
     @Override
     protected void receive(final String name, final String value, final NamedValueSource source) {

--- a/metamorph/src/main/java/org/metafacture/metamorph/collectors/Any.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/collectors/Any.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.collectors;
 
 import org.metafacture.commons.StringUtil;
@@ -31,6 +32,9 @@ public final class Any extends AbstractCollect {
 
     private boolean receivedInput;
     private boolean emittedResult;
+
+    public Any() {
+    }
 
     @Override
     protected void receive(final String name, final String value, final NamedValueSource source) {

--- a/metamorph/src/main/java/org/metafacture/metamorph/collectors/Choose.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/collectors/Choose.java
@@ -13,16 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.metamorph.collectors;
 
-import java.util.HashMap;
-import java.util.Map;
+package org.metafacture.metamorph.collectors;
 
 import org.metafacture.commons.StringUtil;
 import org.metafacture.metamorph.api.NamedValueSource;
 import org.metafacture.metamorph.api.helpers.AbstractFlushingCollect;
 
-
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Corresponds to the {@code <choose>} tag.
@@ -35,13 +34,15 @@ public final class Choose extends AbstractFlushingCollect {
     private String value;
     private String name;
     private int priority = Integer.MAX_VALUE;
-    private final Map<NamedValueSource, Integer> priorities =
-            new HashMap<NamedValueSource, Integer>();
+    private final Map<NamedValueSource, Integer> priorities = new HashMap<NamedValueSource, Integer>();
     private int nextPriority;
+
+    public Choose() {
+    }
 
     @Override
     protected void emit() {
-        if(!isEmpty()){
+        if (!isEmpty()) {
             getNamedValueReceiver().receive(StringUtil.fallback(getName(), name),
                     StringUtil.fallback(getValue(), value), this, getRecordCount(),
                     getEntityCount());
@@ -65,13 +66,12 @@ public final class Choose extends AbstractFlushingCollect {
     }
 
     @Override
-    protected void receive(final String name, final String value,
-            final NamedValueSource source) {
+    protected void receive(final String newName, final String newValue, final NamedValueSource source) {
         final int sourcePriority = priorities.get(source).intValue();
         if (sourcePriority <= priority) {
-            this.value = value;
-            this.name = name;
-            this.priority = sourcePriority;
+            name = newName;
+            value = newValue;
+            priority = sourcePriority;
         }
     }
 

--- a/metamorph/src/main/java/org/metafacture/metamorph/collectors/Combine.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/collectors/Combine.java
@@ -13,16 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.collectors;
+
+import org.metafacture.commons.StringUtil;
+import org.metafacture.metamorph.api.NamedValueSource;
+import org.metafacture.metamorph.api.helpers.AbstractFlushingCollect;
 
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import org.metafacture.commons.StringUtil;
-import org.metafacture.metamorph.api.NamedValueSource;
-import org.metafacture.metamorph.api.helpers.AbstractFlushingCollect;
 
 /**
  * Corresponds to the <code>&lt;collect&gt;</code> tag.
@@ -35,12 +36,14 @@ public final class Combine extends AbstractFlushingCollect {
     private final Set<NamedValueSource> sources = new HashSet<NamedValueSource>();
     private final Set<NamedValueSource> sourcesLeft = new HashSet<NamedValueSource>();
 
+    public Combine() {
+    }
+
     @Override
     protected void emit() {
         final String name = StringUtil.format(getName(), variables);
         final String value = StringUtil.format(getValue(), variables);
-        getNamedValueReceiver().receive(name, value, this, getRecordCount(),
-                getEntityCount());
+        getNamedValueReceiver().receive(name, value, this, getRecordCount(), getEntityCount());
     }
 
     @Override
@@ -49,8 +52,7 @@ public final class Combine extends AbstractFlushingCollect {
     }
 
     @Override
-    protected void receive(final String name, final String value,
-            final NamedValueSource source) {
+    protected void receive(final String name, final String value, final NamedValueSource source) {
         variables.put(name, value);
         sourcesLeft.remove(source);
     }

--- a/metamorph/src/main/java/org/metafacture/metamorph/collectors/Concat.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/collectors/Concat.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.collectors;
 
 import org.metafacture.metamorph.api.NamedValueSource;
@@ -30,9 +31,11 @@ public final class Concat extends AbstractFlushingCollect {
     private String prefix = "";
     private String postfix = "";
     private String delimiter = "";
-    private boolean reverse = false;
-
     private String currentDelimiter = "";
+    private boolean reverse;
+
+    public Concat() {
+    }
 
     public void setPrefix(final String prefix) {
         this.prefix = prefix;
@@ -71,7 +74,8 @@ public final class Concat extends AbstractFlushingCollect {
         if (reverse) {
             builder.insert(0, currentDelimiter);
             builder.insert(0, value);
-        } else {
+        }
+        else {
             builder.append(currentDelimiter);
             builder.append(value);
         }

--- a/metamorph/src/main/java/org/metafacture/metamorph/collectors/EqualsFilter.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/collectors/EqualsFilter.java
@@ -13,16 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.collectors;
+
+import org.metafacture.commons.StringUtil;
+import org.metafacture.metamorph.api.NamedValueSource;
+import org.metafacture.metamorph.api.helpers.AbstractFlushingCollect;
 
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import org.metafacture.commons.StringUtil;
-import org.metafacture.metamorph.api.NamedValueSource;
-import org.metafacture.metamorph.api.helpers.AbstractFlushingCollect;
 
 /**
  * Corresponds to the <code>&lt;equalsFilter-literal&gt;</code> tag. Emits data
@@ -37,42 +38,43 @@ public final class EqualsFilter extends AbstractFlushingCollect {
     private final Set<NamedValueSource> sourcesLeft = new HashSet<NamedValueSource>();
     private boolean isEqual = true;
 
+    public EqualsFilter() {
+    }
+
     @Override
     protected void emit() {
-        final String name = StringUtil.format(getName(), this.variables);
-        final String value = StringUtil.format(getValue(), this.variables);
-        if (this.isEqual) {
-            getNamedValueReceiver().receive(name, value, this,
-                    getRecordCount(), getEntityCount());
+        final String name = StringUtil.format(getName(), variables);
+        final String value = StringUtil.format(getValue(), variables);
+        if (isEqual) {
+            getNamedValueReceiver().receive(name, value, this, getRecordCount(), getEntityCount());
         }
     }
 
     @Override
     protected boolean isComplete() {
-        return this.sourcesLeft.isEmpty();
+        return sourcesLeft.isEmpty();
     }
 
     @Override
-    protected void receive(final String name, final String value,
-            final NamedValueSource source) {
-        if (this.variables.size() > 0 && !this.variables.containsValue(value)) {
-            this.isEqual = false;
+    protected void receive(final String name, final String value, final NamedValueSource source) {
+        if (variables.size() > 0 && !variables.containsValue(value)) {
+            isEqual = false;
         }
-        this.variables.put(name, value);
-        this.sourcesLeft.remove(source);
+        variables.put(name, value);
+        sourcesLeft.remove(source);
     }
 
     @Override
     public void onNamedValueSourceAdded(final NamedValueSource namedValueSource) {
-        this.sources.add(namedValueSource);
-        this.sourcesLeft.add(namedValueSource);
+        sources.add(namedValueSource);
+        sourcesLeft.add(namedValueSource);
     }
 
     @Override
     protected void clear() {
-        this.sourcesLeft.addAll(this.sources);
-        this.variables.clear();
-        this.isEqual = true;
+        sourcesLeft.addAll(sources);
+        variables.clear();
+        isEqual = true;
     }
 
 }

--- a/metamorph/src/main/java/org/metafacture/metamorph/collectors/Group.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/collectors/Group.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.collectors;
 
 import org.metafacture.commons.StringUtil;
@@ -26,9 +27,11 @@ import org.metafacture.metamorph.api.helpers.AbstractFlushingCollect;
  */
 public final class Group extends AbstractFlushingCollect {
 
+    public Group() {
+    }
+
     @Override
-    protected void receive(final String recName, final String recValue,
-            final NamedValueSource source) {
+    protected void receive(final String recName, final String recValue, final NamedValueSource source) {
         getNamedValueReceiver().receive(
                 StringUtil.fallback(getName(), recName),
                 StringUtil.fallback(getValue(), recValue), this,

--- a/metamorph/src/main/java/org/metafacture/metamorph/collectors/None.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/collectors/None.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.collectors;
 
 import org.metafacture.commons.StringUtil;
@@ -31,6 +32,9 @@ public final class None extends AbstractCollect {
 
     private boolean receivedInput;
     private boolean emittedResult;
+
+    public None() {
+    }
 
     @Override
     protected void receive(final String name, final String value, final NamedValueSource source) {

--- a/metamorph/src/main/java/org/metafacture/metamorph/collectors/Range.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/collectors/Range.java
@@ -13,15 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.metamorph.collectors;
 
-import java.util.Comparator;
-import java.util.SortedSet;
-import java.util.TreeSet;
+package org.metafacture.metamorph.collectors;
 
 import org.metafacture.metamorph.api.NamedValueSource;
 import org.metafacture.metamorph.api.helpers.AbstractFlushingCollect;
 
+import java.util.Comparator;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 /**
  * Corresponds to the <code>&lt;range&gt;</code> tag.
@@ -35,17 +35,7 @@ public final class Range extends AbstractFlushingCollect {
     private int increment;
     private Integer first;
 
-    /**
-     * A comparator which defines the sort order of the values in the range
-     * depending on the increment.
-     */
-    private class IncrementDependingComparator implements Comparator<Integer> {
-
-        @Override
-        public int compare(final Integer o1, final Integer o2) {
-            return Integer.signum(increment) * (o1 - o2);
-        }
-
+    public Range() {
     }
 
     public int getIncrement() {
@@ -72,7 +62,8 @@ public final class Range extends AbstractFlushingCollect {
     protected void receive(final String name, final String value, final NamedValueSource source) {
         if (first == null) {
             first = Integer.valueOf(value);
-        } else {
+        }
+        else {
             final int last = Integer.valueOf(value).intValue();
             for (int i = first.intValue(); (increment > 0 && i <= last) || (increment < 0 && i >= last); i += increment) {
                 values.add(Integer.valueOf(i));
@@ -85,6 +76,22 @@ public final class Range extends AbstractFlushingCollect {
     protected void clear() {
         values.clear();
         first = null;
+    }
+
+    /**
+     * A comparator which defines the sort order of the values in the range
+     * depending on the increment.
+     */
+    private class IncrementDependingComparator implements Comparator<Integer> {
+
+        IncrementDependingComparator() {
+        }
+
+        @Override
+        public int compare(final Integer o1, final Integer o2) {
+            return Integer.signum(increment) * (o1 - o2);
+        }
+
     }
 
 }

--- a/metamorph/src/main/java/org/metafacture/metamorph/collectors/Square.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/collectors/Square.java
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.collectors;
+
+import org.metafacture.metamorph.api.NamedValueSource;
+import org.metafacture.metamorph.api.helpers.AbstractFlushingCollect;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import org.metafacture.metamorph.api.NamedValueSource;
-import org.metafacture.metamorph.api.helpers.AbstractFlushingCollect;
 
 /**
  * Corresponds to the <code>&lt;collect-literal&gt;</code> tag.
@@ -30,9 +31,13 @@ import org.metafacture.metamorph.api.helpers.AbstractFlushingCollect;
 public final class Square extends AbstractFlushingCollect {
 
     private final List<String> values = new ArrayList<String>();
+
     private String prefix = "";
     private String postfix = "";
     private String delimiter = "";
+
+    public Square() {
+    }
 
     public void setPrefix(final String prefix) {
         this.prefix = prefix;
@@ -50,7 +55,7 @@ public final class Square extends AbstractFlushingCollect {
     protected void emit() {
         Collections.sort(values);
         final int size = values.size();
-        for (int i = 0; i < size; i++) {
+        for (int i = 0; i < size; ++i) {
             final String last = values.remove(values.size() - 1);
             for (final String value : values) {
                 getNamedValueReceiver().receive(getName(),
@@ -66,8 +71,7 @@ public final class Square extends AbstractFlushingCollect {
     }
 
     @Override
-    protected void receive(final String name, final String value,
-            final NamedValueSource source) {
+    protected void receive(final String name, final String value, final NamedValueSource source) {
         values.add(value);
     }
 

--- a/metamorph/src/main/java/org/metafacture/metamorph/collectors/Tuples.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/collectors/Tuples.java
@@ -13,15 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.metamorph.collectors;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+package org.metafacture.metamorph.collectors;
 
 import org.metafacture.commons.types.ListMap;
 import org.metafacture.metamorph.api.NamedValueSource;
 import org.metafacture.metamorph.api.helpers.AbstractFlushingCollect;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Builds the cross product of the data sources.
@@ -32,8 +33,12 @@ import org.metafacture.metamorph.api.helpers.AbstractFlushingCollect;
 public final class Tuples extends AbstractFlushingCollect {
 
     private final ListMap<String, String> listMap = new ListMap<String, String>();
+
     private int minN = 1;
     private String separator = "";
+
+    public Tuples() {
+    }
 
     public void setMinN(final int minN) {
         this.minN = minN;

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/AbstractCompose.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/AbstractCompose.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
 
 import org.metafacture.metamorph.api.Function;

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/AbstractLookup.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/AbstractLookup.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
 
 import org.metafacture.metamorph.api.helpers.AbstractSimpleStatelessFunction;
@@ -28,7 +29,8 @@ abstract class AbstractLookup extends AbstractSimpleStatelessFunction {
         final String returnValue;
         if (getMapName() == null) {
             returnValue = getLocalValue(key);
-        } else {
+        }
+        else {
             returnValue = getValue(getMapName(), key);
         }
         return returnValue;

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/BlackList.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/BlackList.java
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
-
-
 
 /**
  * A function which checks whether the received value
@@ -25,10 +24,13 @@ package org.metafacture.metamorph.functions;
  */
 public final class BlackList extends AbstractLookup {
 
+    public BlackList() {
+    }
+
     @Override
     public String process(final String key) {
         final String returnValue = lookup(key);
-        if(returnValue==null){
+        if (returnValue == null) {
             return key;
         }
         return null;

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/Buffer.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/Buffer.java
@@ -13,15 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.metamorph.functions;
 
-import java.util.ArrayList;
-import java.util.List;
+package org.metafacture.metamorph.functions;
 
 import org.metafacture.metamorph.api.NamedValueReceiver;
 import org.metafacture.metamorph.api.NamedValueSource;
 import org.metafacture.metamorph.api.helpers.AbstractFunction;
 
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Stores all received values and only releases them on flush.
@@ -34,23 +34,21 @@ public final class Buffer extends AbstractFunction {
     private final List<Receipt> receipts = new ArrayList<Receipt>();
     private int currentRecord;
 
-    @Override
-    public void receive(final String name, final String value,
-            final NamedValueSource source, final int recordCount,
-            final int entityCount) {
+    public Buffer() {
+    }
 
+    @Override
+    public void receive(final String name, final String value, final NamedValueSource source, final int recordCount, final int entityCount) {
         if (currentRecord != recordCount) {
             receipts.clear();
             currentRecord = recordCount;
         }
 
         receipts.add(new Receipt(name, value, this, recordCount, entityCount));
-
     }
 
     @Override
     public void flush(final int recordCount, final int entityCount) {
-
         for (final Receipt receipt : receipts) {
             receipt.send(getNamedValueReceiver());
         }

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/Case.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/Case.java
@@ -13,15 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
+
+import org.metafacture.metamorph.api.MorphBuildException;
+import org.metafacture.metamorph.api.helpers.AbstractSimpleStatelessFunction;
 
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
-
-import org.metafacture.metamorph.api.MorphBuildException;
-import org.metafacture.metamorph.api.helpers.AbstractSimpleStatelessFunction;
 
 /**
  * Changes the the received value from upper to lower case
@@ -42,6 +43,9 @@ public final class Case extends AbstractSimpleStatelessFunction {
         LANGUAGES = Collections.unmodifiableSet(set);
     }
 
+    public Case() {
+    }
+
     @Override
     public String process(final String value) {
         if (toUpper) {
@@ -56,8 +60,7 @@ public final class Case extends AbstractSimpleStatelessFunction {
 
     public void setLanguage(final String language) {
         if (!LANGUAGES.contains(language)) {
-            throw new MorphBuildException("Language " + language
-                    + " not supported.");
+            throw new MorphBuildException("Language " + language + " not supported.");
         }
         this.locale = new Locale(language);
     }

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/Compose.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/Compose.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
 
 /**
@@ -21,6 +22,9 @@ package org.metafacture.metamorph.functions;
  * @author Markus Michael Geipel
  */
 public final class Compose extends AbstractCompose {
+
+    public Compose() {
+    }
 
     @Override
     public String process(final String value) {

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/Constant.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/Constant.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
 
 import org.metafacture.metamorph.api.helpers.AbstractSimpleStatelessFunction;
@@ -25,6 +26,9 @@ import org.metafacture.metamorph.api.helpers.AbstractSimpleStatelessFunction;
 public final class Constant extends AbstractSimpleStatelessFunction {
 
     private String constValue;
+
+    public Constant() {
+    }
 
     @Override
     public String process(final String value) {

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/Contains.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/Contains.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
 
 import org.metafacture.metamorph.api.helpers.AbstractFilter;
@@ -23,6 +24,9 @@ import org.metafacture.metamorph.api.helpers.AbstractFilter;
  * @author Hans-Georg Becker
  */
 public final class Contains extends AbstractFilter {
+
+    public Contains() {
+    }
 
     @Override
     protected boolean accept(final String value) {

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/Count.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/Count.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
 
 import org.metafacture.metamorph.api.helpers.AbstractStatefulFunction;
@@ -26,6 +27,9 @@ import org.metafacture.metamorph.api.helpers.AbstractStatefulFunction;
 public final class Count extends AbstractStatefulFunction {
 
     private int count;
+
+    public Count() {
+    }
 
     @Override
     public String process(final String value) {

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/DateFormat.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/DateFormat.java
@@ -13,7 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
+
+import org.metafacture.metamorph.api.MorphBuildException;
+import org.metafacture.metamorph.api.helpers.AbstractSimpleStatelessFunction;
 
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -22,9 +26,6 @@ import java.util.GregorianCalendar;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
-
-import org.metafacture.metamorph.api.MorphBuildException;
-import org.metafacture.metamorph.api.helpers.AbstractSimpleStatelessFunction;
 
 /**
  * Format date/time strings in Metamorph. By default the input format is
@@ -121,6 +122,9 @@ public class DateFormat extends AbstractSimpleStatelessFunction {
         SUPPORTED_LANGUAGES = Collections.unmodifiableSet(set);
     }
 
+    public DateFormat() {
+    }
+
     @Override
     public final String process(final String value) {
         String result;
@@ -130,7 +134,8 @@ public class DateFormat extends AbstractSimpleStatelessFunction {
             c.setTime(sdf.parse(value));
             if (era == Era.BC) {
                 c.set(Calendar.ERA, GregorianCalendar.BC);
-            } else if (era == Era.AD) {
+            }
+            else if (era == Era.AD) {
                 c.set(Calendar.ERA, GregorianCalendar.AD);
             }
 
@@ -147,9 +152,11 @@ public class DateFormat extends AbstractSimpleStatelessFunction {
                 result = result.replaceAll("([0]{1,})([0-9]{1,})", "$2");
             }
 
-        } catch (final IllegalArgumentException e) {
+        }
+        catch (final IllegalArgumentException e) {
             throw new MorphBuildException("The date/time format is not supported.", e);
-        } catch (final Exception e) {
+        }
+        catch (final Exception e) { // checkstyle-disable-line IllegalCatch
             result = value;
         }
         return result;

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/Equals.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/Equals.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
 
 import org.metafacture.metamorph.api.helpers.AbstractFilter;
@@ -23,6 +24,9 @@ import org.metafacture.metamorph.api.helpers.AbstractFilter;
  * @author Markus Michael Geipel
  */
 public final class Equals extends AbstractFilter {
+
+    public Equals() {
+    }
 
     @Override
     protected boolean accept(final String value) {

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/HtmlAnchor.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/HtmlAnchor.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
 
 /**
@@ -25,21 +26,17 @@ public final class HtmlAnchor extends AbstractCompose {
 
     private String title;
 
+    public HtmlAnchor() {
+    }
+
     public void setTitle(final String title) {
         this.title = title;
     }
 
     @Override
     public String process(final String value) {
-        final String title;
-        if (this.title == null) {
-            title = value;
-        } else {
-            title = this.title;
-        }
-
-        return "<a href=\"" + getPrefix() + value + getPostfix() + "\">"
-                + title + "</a>";
+        final String text = title == null ? value : title;
+        return "<a href=\"" + getPrefix() + value + getPostfix() + "\">" + text + "</a>";
     }
 
 }

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/ISBN.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/ISBN.java
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
+
+import org.metafacture.metamorph.api.helpers.AbstractSimpleStatelessFunction;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import org.metafacture.metamorph.api.helpers.AbstractSimpleStatelessFunction;
 
 /**
  * Offers ISBN conversions.
@@ -45,6 +46,9 @@ public final class ISBN extends AbstractSimpleStatelessFunction {
     private boolean verifyCheckDigit;
     private String errorString;
 
+    public ISBN() {
+    }
+
     public void setErrorString(final String errorString) {
         this.errorString = errorString;
     }
@@ -56,12 +60,15 @@ public final class ISBN extends AbstractSimpleStatelessFunction {
 
         if (verifyCheckDigit && !isValid(result)) {
             result = errorString;
-        } else if (!(size == ISBN10_SIZE || size == ISBN13_SIZE)) {
+        }
+        else if (!(size == ISBN10_SIZE || size == ISBN13_SIZE)) {
             result = errorString;
-        } else {
+        }
+        else {
             if (to10 && ISBN13_SIZE == size) {
                 result = isbn13to10(result);
-            } else if (to13 && ISBN10_SIZE == size) {
+            }
+            else if (to13 && ISBN10_SIZE == size) {
                 result = isbn10to13(result);
             }
         }
@@ -103,7 +110,8 @@ public final class ISBN extends AbstractSimpleStatelessFunction {
             final int digit = charToInt(isbn13Data.charAt(i));
             if ((i % 2) == 0) {
                 accumulator = accumulator + digit;
-            } else {
+            }
+            else {
                 accumulator = accumulator + ISBN13_MAGIC * digit;
             }
         }
@@ -146,7 +154,8 @@ public final class ISBN extends AbstractSimpleStatelessFunction {
         if (isbn.length() == ISBN10_SIZE) {
             result = check10(isbn.substring(0, ISBN10_SIZE - 1)) == isbn
                     .charAt(ISBN10_SIZE - 1);
-        } else if (isbn.length() == ISBN13_SIZE) {
+        }
+        else if (isbn.length() == ISBN13_SIZE) {
             result = check13(isbn.substring(0, ISBN13_SIZE - 1)) == isbn
                     .charAt(ISBN13_SIZE - 1);
         }

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/Lookup.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/Lookup.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
 
 /**
@@ -25,8 +26,11 @@ public final class Lookup extends AbstractLookup {
 
     private String defaultValue;
 
-    public void setDefault(final String defaultValue) {
-        this.defaultValue = defaultValue;
+    public Lookup() {
+    }
+
+    public void setDefault(final String newDefaultValue) {
+        defaultValue = newDefaultValue;
     }
 
     @Override

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/NormalizeUTF8.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/NormalizeUTF8.java
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
 
-import java.text.Normalizer;
-import java.text.Normalizer.Form;
-
 import org.metafacture.metamorph.api.helpers.AbstractSimpleStatelessFunction;
+
+import java.text.Normalizer.Form;
+import java.text.Normalizer;
 
 /**
  * Performs normalization of diacritics in utf-8 encoded strings.
@@ -26,6 +27,9 @@ import org.metafacture.metamorph.api.helpers.AbstractSimpleStatelessFunction;
  * @author Christoph Böhme
  */
 public final class NormalizeUTF8 extends AbstractSimpleStatelessFunction {
+
+    public NormalizeUTF8() {
+    }
 
     @Override
     public String process(final String value) {

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/NotContains.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/NotContains.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
 
 import org.metafacture.metamorph.api.helpers.AbstractFilter;
@@ -24,6 +25,9 @@ import org.metafacture.metamorph.api.helpers.AbstractFilter;
  * @author Hans-Georg Becker
  */
 public final class NotContains extends AbstractFilter {
+
+    public NotContains() {
+    }
 
     @Override
     protected boolean accept(final String value) {

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/NotEquals.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/NotEquals.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
 
 import org.metafacture.metamorph.api.helpers.AbstractFilter;
@@ -24,6 +25,9 @@ import org.metafacture.metamorph.api.helpers.AbstractFilter;
  * @author Markus Michael Geipel
  */
 public final class NotEquals extends AbstractFilter {
+
+    public NotEquals() {
+    }
 
     @Override
     protected boolean accept(final String value) {

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/Occurrence.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/Occurrence.java
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.metamorph.functions;
 
-import java.util.HashMap;
-import java.util.Map;
+package org.metafacture.metamorph.functions;
 
 import org.metafacture.commons.StringUtil;
 import org.metafacture.metamorph.api.MorphBuildException;
 import org.metafacture.metamorph.api.helpers.AbstractStatefulFunction;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Only outputs the received values in a certain range.
@@ -46,6 +47,9 @@ public final class Occurrence extends AbstractStatefulFunction {
 
     private final Map<String, String> variables = new HashMap<String, String>();
     private boolean sameEntity;
+
+    public Occurrence() {
+    }
 
     @Override
     public String process(final String value) {
@@ -92,9 +96,11 @@ public final class Occurrence extends AbstractStatefulFunction {
 
         if (only.startsWith(LESS_THAN)) {
             filter = createLessThanFilter(extractNumberFrom(only));
-        } else if (only.startsWith(MORE_THAN)) {
+        }
+        else if (only.startsWith(MORE_THAN)) {
             filter = createGreaterThanFilter(extractNumberFrom(only));
-        } else {
+        }
+        else {
             final int number = Integer.parseInt(only);
             filter = createEqualsFilter(number);
         }

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/Regexp.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/Regexp.java
@@ -13,16 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
+
+import org.metafacture.commons.StringUtil;
+import org.metafacture.metamorph.api.NamedValueSource;
+import org.metafacture.metamorph.api.helpers.AbstractFunction;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import org.metafacture.commons.StringUtil;
-import org.metafacture.metamorph.api.NamedValueSource;
-import org.metafacture.metamorph.api.helpers.AbstractFunction;
 
 /**
  * Performs regexp matching.
@@ -35,10 +36,11 @@ public final class Regexp extends AbstractFunction {
     private String format;
     private final Map<String, String> tempVars = new HashMap<String, String>();
 
+    public Regexp() {
+    }
+
     @Override
-    public void receive(final String name, final String value,
-            final NamedValueSource source, final int recordCount,
-            final int entityCount) {
+    public void receive(final String name, final String value, final NamedValueSource source, final int recordCount, final int entityCount) {
         if (null == value) {
             return;
         }
@@ -51,7 +53,8 @@ public final class Regexp extends AbstractFunction {
                             recordCount, entityCount);
                 }
             }
-        } else {
+        }
+        else {
             while (matcher.find()) {
                 populateVars();
                 if (!tempVars.isEmpty()) {
@@ -74,7 +77,7 @@ public final class Regexp extends AbstractFunction {
     }
 
     public void setMatch(final String match) {
-        this.matcher = Pattern.compile(match).matcher("");
+        matcher = Pattern.compile(match).matcher("");
     }
 
     public void setFormat(final String format) {

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/Replace.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/Replace.java
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
 
-import java.util.regex.Pattern;
-
 import org.metafacture.metamorph.api.helpers.AbstractSimpleStatelessFunction;
+
+import java.util.regex.Pattern;
 
 /**
  * Replaces the matches of pattern with a set value.
@@ -29,13 +30,16 @@ public final class Replace extends AbstractSimpleStatelessFunction {
     private Pattern pattern;
     private String with;
 
+    public Replace() {
+    }
+
     @Override
     public String process(final String value) {
         return pattern.matcher(value).replaceAll(with);
     }
 
     public void setPattern(final String string) {
-        this.pattern = Pattern.compile(string);
+        pattern = Pattern.compile(string);
     }
 
     public void setWith(final String with) {

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/Script.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/Script.java
@@ -13,19 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
-
-import java.io.FileNotFoundException;
-
-import javax.script.Invocable;
-import javax.script.ScriptEngine;
-import javax.script.ScriptEngineManager;
-import javax.script.ScriptException;
 
 import org.metafacture.commons.ResourceUtil;
 import org.metafacture.metamorph.api.MorphBuildException;
 import org.metafacture.metamorph.api.MorphExecutionException;
 import org.metafacture.metamorph.api.helpers.AbstractSimpleStatelessFunction;
+
+import java.io.FileNotFoundException;
+import javax.script.Invocable;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
 
 /**
  * A function which executes a javascript function.
@@ -36,6 +36,9 @@ public final class Script extends AbstractSimpleStatelessFunction {
 
     private Invocable invocable;
     private String invoke;
+
+    public Script() {
+    }
 
     public void setInvoke(final String invoke) {
         this.invoke = invoke;
@@ -48,9 +51,11 @@ public final class Script extends AbstractSimpleStatelessFunction {
         try {
             // TODO: The script file should be loaded relatively to the base URI
             engine.eval(ResourceUtil.getReader(file));
-        } catch (final ScriptException e) {
+        }
+        catch (final ScriptException e) {
             throw new MorphBuildException("Error in script", e);
-        } catch (final FileNotFoundException e) {
+        }
+        catch (final FileNotFoundException e) {
             throw new MorphBuildException("Error loading script '" + file + "'",
                     e);
         }
@@ -63,10 +68,12 @@ public final class Script extends AbstractSimpleStatelessFunction {
         try {
             obj = invocable.invokeFunction(invoke, value);
             return obj.toString();
-        } catch (final ScriptException e) {
+        }
+        catch (final ScriptException e) {
             throw new MorphExecutionException(
                     "Error in script while evaluating 'process' method", e);
-        } catch (final NoSuchMethodException e) {
+        }
+        catch (final NoSuchMethodException e) {
             throw new MorphExecutionException("'process' method is missing in script", e);
         }
     }

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/SetReplace.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/SetReplace.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
 
 import org.metafacture.commons.tries.SetReplacer;
@@ -25,6 +26,9 @@ public final class SetReplace extends AbstractSimpleStatelessFunction {
 
     private final SetReplacer setReplacer = new SetReplacer();
     private boolean prepared;
+
+    public SetReplace() {
+    }
 
     @Override
     public String process(final String text) {

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/Split.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/Split.java
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.metamorph.functions;
 
-import java.util.regex.Pattern;
+package org.metafacture.metamorph.functions;
 
 import org.metafacture.metamorph.api.NamedValueSource;
 import org.metafacture.metamorph.api.helpers.AbstractFunction;
+
+import java.util.regex.Pattern;
 
 /**
  * Splits the received value and output each part separately.
@@ -29,10 +30,11 @@ public final class Split extends AbstractFunction {
 
     private Pattern delimiterPattern;
 
+    public Split() {
+    }
+
     @Override
-    public void receive(final String name, final String value,
-            final NamedValueSource source, final int recordCount,
-            final int entityCount) {
+    public void receive(final String name, final String value, final NamedValueSource source, final int recordCount, final int entityCount) {
         final String[] parts = delimiterPattern.split(value);
         for (final String part : parts) {
             getNamedValueReceiver().receive(name, part, this, recordCount,

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/Substring.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/Substring.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
 
 import org.metafacture.metamorph.api.helpers.AbstractSimpleStatelessFunction;
@@ -27,6 +28,9 @@ public final class Substring extends AbstractSimpleStatelessFunction {
     private int start;
     private int end;
 
+    public Substring() {
+    }
+
     @Override
     public String process(final String value) {
         final int length = value.length();
@@ -37,7 +41,8 @@ public final class Substring extends AbstractSimpleStatelessFunction {
         final int adjEnd;
         if (end == 0  || end > length) {
             adjEnd = length;
-        } else {
+        }
+        else {
             adjEnd = end;
         }
 

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/SwitchNameValue.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/SwitchNameValue.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
 
 import org.metafacture.metamorph.api.NamedValueSource;
@@ -25,14 +26,12 @@ import org.metafacture.metamorph.api.helpers.AbstractFunction;
  */
 public final class SwitchNameValue extends AbstractFunction {
 
+    public SwitchNameValue() {
+    }
+
     @Override
-    public void receive(final String name, final String value,
-            final NamedValueSource source, final int recordCount,
-            final int entityCount) {
-
-        getNamedValueReceiver().receive(value, name, this, recordCount,
-                entityCount);
-
+    public void receive(final String name, final String value, final NamedValueSource source, final int recordCount, final int entityCount) {
+        getNamedValueReceiver().receive(value, name, this, recordCount, entityCount);
     }
 
 }

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/Timestamp.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/Timestamp.java
@@ -13,7 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
+
+import org.metafacture.metamorph.api.MorphBuildException;
+import org.metafacture.metamorph.api.helpers.AbstractSimpleStatelessFunction;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -23,9 +27,6 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 import java.util.TimeZone;
-
-import org.metafacture.metamorph.api.MorphBuildException;
-import org.metafacture.metamorph.api.helpers.AbstractSimpleStatelessFunction;
 
 /**
  * This function creates a timestamp. By default it returns a unix
@@ -61,6 +62,9 @@ public final class Timestamp extends AbstractSimpleStatelessFunction {
         SUPPORTED_LANGUAGES = Collections.unmodifiableSet(set);
     }
 
+    public Timestamp() {
+    }
+
     @Override
     public String process(final String value) {
         if (FORMAT_TIMESTAMP.equals(format)) {
@@ -69,7 +73,8 @@ public final class Timestamp extends AbstractSimpleStatelessFunction {
         final DateFormat dateFormat;
         try {
             dateFormat = new SimpleDateFormat(format, locale);
-        } catch (final IllegalArgumentException e) {
+        }
+        catch (final IllegalArgumentException e) {
             throw new MorphBuildException("The date/time format '" + format + "' is not supported. ", e);
         }
         dateFormat.setTimeZone(TimeZone.getTimeZone(timezone));

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/Trim.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/Trim.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
 
 import org.metafacture.metamorph.api.helpers.AbstractSimpleStatelessFunction;
@@ -23,6 +24,9 @@ import org.metafacture.metamorph.api.helpers.AbstractSimpleStatelessFunction;
  * @author Markus Michael Geipel
  */
 public final class Trim extends AbstractSimpleStatelessFunction {
+
+    public Trim() {
+    }
 
     @Override
     public String process(final String value) {

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/URLEncode.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/URLEncode.java
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.metamorph.functions;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
+package org.metafacture.metamorph.functions;
 
 import org.metafacture.metamorph.api.MorphExecutionException;
 import org.metafacture.metamorph.api.helpers.AbstractSimpleStatelessFunction;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 
 /**
  * URL encodes the received value.
@@ -29,13 +30,16 @@ import org.metafacture.metamorph.api.helpers.AbstractSimpleStatelessFunction;
  */
 public final class URLEncode extends AbstractSimpleStatelessFunction {
 
+    public URLEncode() {
+    }
+
     @Override
     public String process(final String value) {
         try {
             return URLEncoder.encode(value, "UTF-8");
-        } catch (final UnsupportedEncodingException e) {
-            throw new MorphExecutionException("urlencode: unsupported encoding UTF-8",
-                    e);
+        }
+        catch (final UnsupportedEncodingException e) {
+            throw new MorphExecutionException("urlencode: unsupported encoding UTF-8", e);
         }
     }
 

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/Unique.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/Unique.java
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
+
+import org.metafacture.metamorph.api.helpers.AbstractStatefulFunction;
 
 import java.util.HashSet;
 import java.util.Set;
-
-import org.metafacture.metamorph.api.helpers.AbstractStatefulFunction;
 
 /**
  * Checks whether the received value was not received before.
@@ -42,6 +43,9 @@ public final class Unique extends AbstractStatefulFunction {
             return name + "\0" + value;
         }
     };
+
+    public Unique() {
+    }
 
     @Override
     public String process(final String value) {
@@ -75,7 +79,8 @@ public final class Unique extends AbstractStatefulFunction {
                     return name;
                 }
             };
-        } else if (VALUE.equals(part)) {
+        }
+        else if (VALUE.equals(part)) {
             keyGenerator = new KeyGenerator() {
                 @Override
                 public String createKey(final String name, final String value) {

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/WhiteList.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/WhiteList.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
 
 /**
@@ -22,14 +23,13 @@ package org.metafacture.metamorph.functions;
  */
 public final class WhiteList extends AbstractLookup {
 
+    public WhiteList() {
+    }
+
     @Override
     public String process(final String key) {
         final String returnValue = lookup(key);
-
-        if (returnValue != null) {
-            return key;
-        }
-        return null;
+        return returnValue != null ? key : null;
     }
 
 }

--- a/metamorph/src/main/java/org/metafacture/metamorph/maps/FileMap.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/maps/FileMap.java
@@ -13,7 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.maps;
+
+import org.metafacture.metamorph.api.MorphExecutionException;
+import org.metafacture.metamorph.api.helpers.AbstractReadOnlyMap;
 
 import java.io.BufferedReader;
 import java.io.FileInputStream;
@@ -30,9 +34,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
-import org.metafacture.metamorph.api.MorphExecutionException;
-import org.metafacture.metamorph.api.helpers.AbstractReadOnlyMap;
-
 /**
  * Provides a {@link Map} based on a file. The file is supposed to be UTF-8
  * encoded. The separator is by default \t. <strong>Important:</strong> Lines
@@ -46,6 +47,9 @@ public final class FileMap extends AbstractReadOnlyMap<String, String> {
 
     private Pattern split = Pattern.compile("\t", Pattern.LITERAL);
 
+    public FileMap() {
+    }
+
     public void setFiles(final String files) {
         final String[] parts = files.split("\\s*,\\s*");
         for (final String part : parts) {
@@ -55,9 +59,8 @@ public final class FileMap extends AbstractReadOnlyMap<String, String> {
 
     public void setFile(final String file) {
         try (
-                final InputStream stream = openStream(file);
-                final BufferedReader reader = new BufferedReader(
-                        new InputStreamReader(stream, StandardCharsets.UTF_8))
+                InputStream stream = openStream(file);
+                BufferedReader reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))
         ) {
             String line;
             while ((line = reader.readLine()) != null) {
@@ -69,12 +72,13 @@ public final class FileMap extends AbstractReadOnlyMap<String, String> {
                     map.put(parts[0], parts[1]);
                 }
             }
-        } catch (final IOException | UncheckedIOException e) {
+        }
+        catch (final IOException | UncheckedIOException e) {
             throw new MorphExecutionException("filemap: cannot read map file", e);
         }
     }
 
-    private InputStream openStream(String file) {
+    private InputStream openStream(final String file) {
         return openAsFile(file)
                 .orElseGet(() -> openAsResource(file)
                         .orElseGet(() -> openAsUrl(file)
@@ -82,29 +86,32 @@ public final class FileMap extends AbstractReadOnlyMap<String, String> {
                                         "File not found: " + file))));
     }
 
-    private Optional<InputStream> openAsFile(String file) {
+    private Optional<InputStream> openAsFile(final String file) {
         try {
             return Optional.of(new FileInputStream(file));
-        } catch (FileNotFoundException e) {
+        }
+        catch (final FileNotFoundException e) {
             return Optional.empty();
         }
     }
 
-    private Optional<InputStream> openAsResource(String file) {
+    private Optional<InputStream> openAsResource(final String file) {
         return Optional.ofNullable(Thread.currentThread()
                 .getContextClassLoader().getResourceAsStream(file));
     }
 
-    private Optional<InputStream> openAsUrl(String file) {
+    private Optional<InputStream> openAsUrl(final String file) {
         final URL url;
         try {
             url = new URL(file);
-        } catch (MalformedURLException e) {
+        }
+        catch (final MalformedURLException e) {
             return Optional.empty();
         }
         try {
             return Optional.of(url.openStream());
-        } catch (IOException e) {
+        }
+        catch (final IOException e) {
             throw new UncheckedIOException(e);
         }
     }

--- a/metamorph/src/main/java/org/metafacture/metamorph/maps/JndiSqlMap.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/maps/JndiSqlMap.java
@@ -13,7 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.maps;
+
+import org.metafacture.metamorph.api.MorphExecutionException;
+import org.metafacture.metamorph.api.helpers.AbstractReadOnlyMap;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -21,13 +25,9 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.sql.DataSource;
-
-import org.metafacture.metamorph.api.MorphExecutionException;
-import org.metafacture.metamorph.api.helpers.AbstractReadOnlyMap;
 
 /**
  * A map which queries an sql database provided as jndi
@@ -36,18 +36,20 @@ import org.metafacture.metamorph.api.helpers.AbstractReadOnlyMap;
  * @author Daniel Schäfer
  *
  */
-public final class JndiSqlMap extends AbstractReadOnlyMap<String, String>
-        implements Closeable {
+public final class JndiSqlMap extends AbstractReadOnlyMap<String, String> implements Closeable {
 
     private DataSource datasource;
     private String query;
 
+    public JndiSqlMap() {
+    }
+
     public void setDatasource(final String name) {
         try {
-            this.datasource = (DataSource) new InitialContext().lookup(name);
-        } catch (final NamingException e) {
-            throw new MorphExecutionException(
-                    "jndisqlmap: lookup of data source failed", e);
+            datasource = (DataSource) new InitialContext().lookup(name);
+        }
+        catch (final NamingException e) {
+            throw new MorphExecutionException("jndisqlmap: lookup of data source failed", e);
         }
     }
 
@@ -58,20 +60,19 @@ public final class JndiSqlMap extends AbstractReadOnlyMap<String, String>
     @Override
     public String get(final Object key) {
         String resultString = null;
-        try(
-                final Connection connection = datasource.getConnection();
-                final PreparedStatement statement =
-                        connection.prepareStatement(query);
+        try (
+                Connection connection = datasource.getConnection();
+                PreparedStatement statement = connection.prepareStatement(query)
         ) {
             statement.setString(1, key.toString());
-            try(final ResultSet resultSet = statement.executeQuery()) {
+            try (ResultSet resultSet = statement.executeQuery()) {
                 if (resultSet.first()) {
                     resultString = resultSet.getString(1);
                 }
             }
-        } catch (final SQLException e) {
-            throw new MorphExecutionException(
-                    "jndisqlmap: execution of sql query failed", e);
+        }
+        catch (final SQLException e) {
+            throw new MorphExecutionException("jndisqlmap: execution of sql query failed", e);
         }
         return resultString;
     }

--- a/metamorph/src/main/java/org/metafacture/metamorph/maps/RestMap.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/maps/RestMap.java
@@ -13,7 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.maps;
+
+import org.metafacture.metamorph.api.helpers.AbstractReadOnlyMap;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -25,8 +28,6 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import org.metafacture.metamorph.api.helpers.AbstractReadOnlyMap;
 
 /**
  * A map which resolves its keys by doing a REST request and returning the
@@ -44,7 +45,7 @@ public final class RestMap extends AbstractReadOnlyMap<String, String> {
     public RestMap() {
     }
 
-    public RestMap(String url) {
+    public RestMap(final String url) {
         this.url = url;
     }
 
@@ -52,27 +53,28 @@ public final class RestMap extends AbstractReadOnlyMap<String, String> {
     public String get(final Object key) {
         final Matcher matcher = VAR_PATTERN.matcher(url);
         try {
-            String urlString = matcher.replaceAll(key.toString());
+            final String urlString = matcher.replaceAll(key.toString());
             return readFromUrl(urlString);
-        } catch (IOException | URISyntaxException e) {
+        }
+        catch (final IOException | URISyntaxException e) {
             // There was no data result for the given URL
             return null;
         }
     }
 
-    private String readFromUrl(final String url) throws IOException, URISyntaxException {
-        InputStream inputStream = new URL(new URI(url.replace(" ", "%20")).toASCIIString()).openConnection()
+    private String readFromUrl(final String targetUrl) throws IOException, URISyntaxException {
+        final InputStream inputStream = new URL(new URI(targetUrl.replace(" ", "%20")).toASCIIString()).openConnection()
                 .getInputStream();
         try {
-            BufferedReader reader = new BufferedReader(
-                    new InputStreamReader(inputStream, Charset.forName(charsetName)));
-            StringBuilder stringBuffer = new StringBuilder();
+            final BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, Charset.forName(charsetName)));
+            final StringBuilder stringBuffer = new StringBuilder();
             int value;
             while ((value = reader.read()) != -1) {
                 stringBuffer.append((char) value);
             }
             return stringBuffer.toString();
-        } finally {
+        }
+        finally {
             inputStream.close();
         }
     }
@@ -81,7 +83,7 @@ public final class RestMap extends AbstractReadOnlyMap<String, String> {
         this.url = url;
     }
 
-    public void setCharsetName(String name) {
+    public void setCharsetName(final String name) {
         charsetName = name;
     }
 

--- a/metamorph/src/main/java/org/metafacture/metamorph/maps/SqlMap.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/maps/SqlMap.java
@@ -13,7 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.maps;
+
+import org.metafacture.metamorph.api.MorphExecutionException;
+import org.metafacture.metamorph.api.helpers.AbstractReadOnlyMap;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -23,9 +27,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import org.metafacture.metamorph.api.MorphExecutionException;
-import org.metafacture.metamorph.api.helpers.AbstractReadOnlyMap;
-
 /**
  * A map implementation that queries an sql database.
  *
@@ -33,8 +34,7 @@ import org.metafacture.metamorph.api.helpers.AbstractReadOnlyMap;
  * @author Markus Michael Geipel
  *
  */
-public final class SqlMap extends AbstractReadOnlyMap<String, String> implements
-        Closeable {
+public final class SqlMap extends AbstractReadOnlyMap<String, String> implements Closeable {
 
     private boolean isUninitialized = true;
 
@@ -48,13 +48,15 @@ public final class SqlMap extends AbstractReadOnlyMap<String, String> implements
 
     private PreparedStatement preparedStatement;
 
-    public void init() {
+    public SqlMap() {
+    }
 
+    public void init() {
         try {
             preparedStatement = getMySqlConnection().prepareStatement(query);
-        } catch (final SQLException e) {
-            throw new MorphExecutionException(
-                    "sqlmap: could not create prepared statement for query", e);
+        }
+        catch (final SQLException e) {
+            throw new MorphExecutionException("sqlmap: could not create prepared statement for query", e);
         }
         isUninitialized = false;
     }
@@ -62,13 +64,12 @@ public final class SqlMap extends AbstractReadOnlyMap<String, String> implements
     @Override
     public void close() throws IOException {
         try {
-
             if (conn != null) {
                 conn.close();
             }
-        } catch (final SQLException e) {
-            throw new MorphExecutionException("sqlmap: could not close db connection",
-                    e);
+        }
+        catch (final SQLException e) {
+            throw new MorphExecutionException("sqlmap: could not close db connection", e);
         }
     }
 
@@ -76,12 +77,11 @@ public final class SqlMap extends AbstractReadOnlyMap<String, String> implements
         try {
             Class.forName(driver);
 
-            conn = DriverManager.getConnection("jdbc:mysql://" + host + "/"
-                    + database + "?" + "user=" + login + "&" + "password="
-                    + password);
-        } catch (final ClassNotFoundException | SQLException e) {
-            throw new MorphExecutionException("sqlmap: cannot create db connection",
-                    e);
+            conn = DriverManager.getConnection("jdbc:mysql://" + host + "/" +
+                    database + "?" + "user=" + login + "&" + "password=" + password);
+        }
+        catch (final ClassNotFoundException | SQLException e) {
+            throw new MorphExecutionException("sqlmap: cannot create db connection", e);
         }
         return conn;
     }
@@ -100,9 +100,9 @@ public final class SqlMap extends AbstractReadOnlyMap<String, String> implements
                 resultString = resultSet.getString(1);
             }
             resultSet.close();
-        } catch (final SQLException e) {
-            throw new MorphExecutionException(
-                    "sqlmap: execution of prepared statement failed", e);
+        }
+        catch (final SQLException e) {
+            throw new MorphExecutionException("sqlmap: execution of prepared statement failed", e);
         }
         return resultString;
     }

--- a/metamorph/src/main/java/org/metafacture/metamorph/xml/CDataFilter.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/xml/CDataFilter.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.xml;
 
 import org.xml.sax.SAXException;

--- a/metamorph/src/main/java/org/metafacture/metamorph/xml/CommentsFilter.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/xml/CommentsFilter.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.xml;
 
 import org.xml.sax.SAXException;

--- a/metamorph/src/main/java/org/metafacture/metamorph/xml/DomLoader.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/xml/DomLoader.java
@@ -13,11 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.xml;
+
+import org.metafacture.commons.ResourceUtil;
+import org.metafacture.framework.MetafactureException;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+import org.xml.sax.XMLReader;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -34,17 +45,6 @@ import javax.xml.transform.sax.SAXSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 
-import org.metafacture.commons.ResourceUtil;
-import org.metafacture.framework.MetafactureException;
-import org.w3c.dom.Document;
-import org.w3c.dom.Node;
-import org.xml.sax.ErrorHandler;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
-import org.xml.sax.SAXParseException;
-import org.xml.sax.XMLReader;
-
-
 /**
  * Helper to load DOM {@link Document}s.
  *
@@ -52,19 +52,17 @@ import org.xml.sax.XMLReader;
  * @author Christoph Böhme
  *
  */
-public final class DomLoader {
+public final class DomLoader { // checkstyle-disable-line ClassDataAbstractionCoupling|ClassFanOutComplexity
 
-    private static final ErrorHandler SAX_ERROR_HANDLER =
-            new SaxErrorHandler();
+    private static final ErrorHandler SAX_ERROR_HANDLER = new SaxErrorHandler();
 
-    private static final ErrorListener TRANSFORMER_ERROR_HANDLER =
-            new TransformerErrorHandler();
+    private static final ErrorListener TRANSFORMER_ERROR_HANDLER = new TransformerErrorHandler();
 
     private DomLoader() {
         throw new AssertionError("No instances allowed");
     }
 
-    public static Document parse(String schemaFile, InputSource input) {
+    public static Document parse(final String schemaFile, final InputSource input) {
         final Document document = createEmptyDocument();
         final XMLReader pipeline = createXmlFilterPipeline(schemaFile, document);
         process(new SAXSource(pipeline, input), new DOMResult(document));
@@ -81,15 +79,14 @@ public final class DomLoader {
 
     private static Document createEmptyDocument() {
         try {
-            return DocumentBuilderFactory.newInstance().newDocumentBuilder()
-                    .newDocument();
-        } catch (ParserConfigurationException e) {
+            return DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        }
+        catch (final ParserConfigurationException e) {
             throw new MetafactureException(e);
         }
     }
 
-    private static XMLReader createXmlFilterPipeline(String schemaFile,
-            Document document) {
+    private static XMLReader createXmlFilterPipeline(final String schemaFile, final Document document) {
         XMLReader pipelineHead = createSaxReader(loadSchema(schemaFile));
         pipelineHead = new LocationAnnotator(pipelineHead, document);
         pipelineHead = new IgnorableWhitespaceFilter(pipelineHead);
@@ -99,51 +96,54 @@ public final class DomLoader {
         return pipelineHead;
     }
 
-    private static Schema loadSchema(String schemaFile) {
+    private static Schema loadSchema(final String schemaFile) {
         try {
-            return SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
-                    .newSchema(getSchemaUrl(schemaFile));
-        } catch (SAXException e) {
+            return SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI).newSchema(getSchemaUrl(schemaFile));
+        }
+        catch (final SAXException e) {
             throw new MetafactureException(e);
         }
     }
 
-    private static URL getSchemaUrl(String schemaFile) {
+    private static URL getSchemaUrl(final String schemaFile) {
         try {
             return ResourceUtil.getUrl(schemaFile);
-        } catch (final MalformedURLException e) {
+        }
+        catch (final MalformedURLException e) {
             throw new MetafactureException("'" + schemaFile + "' not found:", e);
         }
     }
 
-    private static XMLReader createSaxReader(Schema schema) {
+    private static XMLReader createSaxReader(final Schema schema) {
         final SAXParserFactory parserFactory = SAXParserFactory.newInstance();
         parserFactory.setSchema(schema);
         parserFactory.setNamespaceAware(true);
         parserFactory.setXIncludeAware(true);
         try {
             return parserFactory.newSAXParser().getXMLReader();
-        } catch (ParserConfigurationException | SAXException e) {
+        }
+        catch (final ParserConfigurationException | SAXException e) {
             throw new MetafactureException(e);
         }
     }
 
-    private static void process(Source source, Result result) {
+    private static void process(final Source source, final Result result) {
         final Transformer transformer = createTransformer();
         try {
             transformer.transform(source, result);
-        } catch (TransformerException e) {
+        }
+        catch (final TransformerException e) {
             throw new MetafactureException(e);
         }
     }
 
     private static Transformer createTransformer() {
         try {
-            final Transformer transformer = TransformerFactory.newInstance()
-                    .newTransformer();
+            final Transformer transformer = TransformerFactory.newInstance().newTransformer();
             transformer.setErrorListener(TRANSFORMER_ERROR_HANDLER);
             return transformer;
-        } catch (TransformerConfigurationException e) {
+        }
+        catch (final TransformerConfigurationException e) {
             throw new MetafactureException(e);
         }
     }
@@ -155,10 +155,11 @@ public final class DomLoader {
                 final Node old = child;
                 child = child.getNextSibling();
 
-                if(old.getNodeValue().trim().isEmpty()) {
+                if (old.getNodeValue().trim().isEmpty()) {
                     node.removeChild(old);
                 }
-            } else {
+            }
+            else {
                 removeEmptyTextNodes(child);
                 child = child.getNextSibling();
             }
@@ -191,8 +192,7 @@ public final class DomLoader {
         }
 
         private void handle(final SAXParseException exception) {
-            throw new MetafactureException("Error parsing xml: " +
-                    exception.getMessage(), exception);
+            throw new MetafactureException("Error parsing xml: " + exception.getMessage(), exception);
         }
 
     }
@@ -208,26 +208,22 @@ public final class DomLoader {
         }
 
         @Override
-        public void warning(final TransformerException exception)
-                throws TransformerException {
+        public void warning(final TransformerException exception) throws TransformerException {
             handle(exception);
         }
 
         @Override
-        public void error(final TransformerException exception)
-                throws TransformerException {
+        public void error(final TransformerException exception) throws TransformerException {
             handle(exception);
         }
 
         @Override
-        public void fatalError(final TransformerException exception)
-                throws TransformerException {
+        public void fatalError(final TransformerException exception) throws TransformerException {
             handle(exception);
         }
 
         private void handle(final TransformerException exception) {
-            throw new MetafactureException("Error during DOM creation: " +
-                    exception.getMessage(), exception);
+            throw new MetafactureException("Error during DOM creation: " + exception.getMessage(), exception);
         }
 
     }

--- a/metamorph/src/main/java/org/metafacture/metamorph/xml/IgnorableWhitespaceFilter.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/xml/IgnorableWhitespaceFilter.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.xml;
 
 import org.xml.sax.SAXException;

--- a/metamorph/src/main/java/org/metafacture/metamorph/xml/LexicalHandlerXmlFilter.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/xml/LexicalHandlerXmlFilter.java
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.metamorph.xml;
 
-import java.io.IOException;
+package org.metafacture.metamorph.xml;
 
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -24,6 +23,8 @@ import org.xml.sax.SAXNotSupportedException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.ext.LexicalHandler;
 import org.xml.sax.helpers.XMLFilterImpl;
+
+import java.io.IOException;
 
 /**
  * Extends {@link XMLFilterImpl} to also intercept events defined
@@ -34,8 +35,7 @@ import org.xml.sax.helpers.XMLFilterImpl;
  */
 class LexicalHandlerXmlFilter extends XMLFilterImpl implements LexicalHandler {
 
-    private static final String LEXICAL_HANDLER_PROPERTY =
-            "http://xml.org/sax/properties/lexical-handler";
+    private static final String LEXICAL_HANDLER_PROPERTY = "http://xml.org/sax/properties/lexical-handler";
 
     private LexicalHandler lexicalHandler;
 
@@ -60,20 +60,17 @@ class LexicalHandlerXmlFilter extends XMLFilterImpl implements LexicalHandler {
     }
 
     @Override
-    public void setProperty(final String name, final Object value)
-            throws SAXNotRecognizedException, SAXNotSupportedException {
-
+    public void setProperty(final String name, final Object value) throws SAXNotRecognizedException, SAXNotSupportedException {
         if (LEXICAL_HANDLER_PROPERTY.equals(name)) {
             lexicalHandler = (LexicalHandler) value;
-        } else {
+        }
+        else {
             super.setProperty(name, value);
         }
     }
 
     @Override
-    public void startDTD(final String name, final String publicId, final String systemId)
-            throws SAXException {
-
+    public void startDTD(final String name, final String publicId, final String systemId) throws SAXException {
         if (lexicalHandler != null) {
             lexicalHandler.startDTD(name, publicId, systemId);
         }
@@ -115,9 +112,7 @@ class LexicalHandlerXmlFilter extends XMLFilterImpl implements LexicalHandler {
     }
 
     @Override
-    public void comment(final char[] ch, final int start, final int length)
-            throws SAXException {
-
+    public void comment(final char[] ch, final int start, final int length) throws SAXException {
         if (lexicalHandler != null) {
             lexicalHandler.comment(ch, start, length);
         }

--- a/metamorph/src/main/java/org/metafacture/metamorph/xml/Location.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/xml/Location.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.xml;
 
 import org.w3c.dom.Node;

--- a/metamorph/src/main/java/org/metafacture/metamorph/xml/LocationAnnotator.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/xml/LocationAnnotator.java
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.metafacture.metamorph.xml;
 
-import java.util.Deque;
-import java.util.LinkedList;
+package org.metafacture.metamorph.xml;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
@@ -29,6 +27,9 @@ import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.LocatorImpl;
 import org.xml.sax.helpers.XMLFilterImpl;
+
+import java.util.Deque;
+import java.util.LinkedList;
 
 /**
  * Annotates a DOM with information about the location of
@@ -49,7 +50,7 @@ final class LocationAnnotator extends XMLFilterImpl {
 
     private Locator locator;
 
-    public LocationAnnotator(final XMLReader xmlReader, final Document document) {
+    LocationAnnotator(final XMLReader xmlReader, final Document document) {
         super(xmlReader);
 
         final EventListener listener = new EventListener() {
@@ -68,28 +69,22 @@ final class LocationAnnotator extends XMLFilterImpl {
     }
 
     @Override
-    public void setDocumentLocator(final Locator locator) {
-        super.setDocumentLocator(locator);
-        this.locator = locator;
+    public void setDocumentLocator(final Locator newLocator) {
+        super.setDocumentLocator(newLocator);
+        locator = newLocator;
     }
 
     @Override
-    public void startElement(final String uri, final String localName, final String qName,
-            final Attributes atts) throws SAXException {
-
+    public void startElement(final String uri, final String localName, final String qName, final Attributes atts) throws SAXException {
         super.startElement(uri, localName, qName, atts);
-
         locatorsAtElementStart.push(new LocatorImpl(locator));
     }
 
     @Override
-    public void endElement(final String uri, final String localName, final String qName)
-            throws SAXException {
-
+    public void endElement(final String uri, final String localName, final String qName) throws SAXException {
         super.endElement(uri, localName, qName);
 
         final Locator elementStartLocator = locatorsAtElementStart.pop();
-
         final Location location = new Location(elementStartLocator, locator);
 
         final Node domNode = domNodes.pop();

--- a/metamorph/src/test/java/org/metafacture/metamorph/MetamorphTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/MetamorphTest.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph;
 
 import static org.junit.Assert.assertEquals;

--- a/metamorph/src/test/java/org/metafacture/metamorph/SplitterTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/SplitterTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph;
 
 import static org.mockito.Mockito.inOrder;

--- a/metamorph/src/test/java/org/metafacture/metamorph/TestHelpers.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/TestHelpers.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph;
 
 import org.metafacture.framework.StreamReceiver;

--- a/metamorph/src/test/java/org/metafacture/metamorph/TestMetamorphBasics.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/TestMetamorphBasics.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph;
 
 import static org.metafacture.metamorph.TestHelpers.assertMorph;

--- a/metamorph/src/test/java/org/metafacture/metamorph/TestMetamorphMacros.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/TestMetamorphMacros.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph;
 
 import static org.metafacture.metamorph.TestHelpers.assertMorph;

--- a/metamorph/src/test/java/org/metafacture/metamorph/collectors/AllTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/collectors/AllTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.collectors;
 
 import static org.mockito.Mockito.inOrder;

--- a/metamorph/src/test/java/org/metafacture/metamorph/collectors/AnyTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/collectors/AnyTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.collectors;
 
 import static org.mockito.Mockito.inOrder;

--- a/metamorph/src/test/java/org/metafacture/metamorph/collectors/ChooseTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/collectors/ChooseTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.collectors;
 
 import static org.mockito.Mockito.inOrder;

--- a/metamorph/src/test/java/org/metafacture/metamorph/collectors/CombineTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/collectors/CombineTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.collectors;
 
 import static org.mockito.Mockito.inOrder;

--- a/metamorph/src/test/java/org/metafacture/metamorph/collectors/ConcatTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/collectors/ConcatTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.collectors;
 
 import static org.mockito.Mockito.inOrder;

--- a/metamorph/src/test/java/org/metafacture/metamorph/collectors/EntityTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/collectors/EntityTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.collectors;
 
 import static org.mockito.Mockito.inOrder;

--- a/metamorph/src/test/java/org/metafacture/metamorph/collectors/EqualsFilterTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/collectors/EqualsFilterTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.collectors;
 
 import static org.mockito.ArgumentMatchers.any;

--- a/metamorph/src/test/java/org/metafacture/metamorph/collectors/GroupTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/collectors/GroupTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.collectors;
 
 import static org.mockito.Mockito.inOrder;

--- a/metamorph/src/test/java/org/metafacture/metamorph/collectors/NoneTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/collectors/NoneTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.collectors;
 
 import static org.mockito.Mockito.inOrder;

--- a/metamorph/src/test/java/org/metafacture/metamorph/collectors/RangeTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/collectors/RangeTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.collectors;
 
 import static org.mockito.Mockito.inOrder;

--- a/metamorph/src/test/java/org/metafacture/metamorph/collectors/SquareTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/collectors/SquareTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.collectors;
 
 import static org.mockito.Mockito.inOrder;

--- a/metamorph/src/test/java/org/metafacture/metamorph/collectors/TestCollectorBasics.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/collectors/TestCollectorBasics.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.collectors;
 
 import static org.mockito.Mockito.inOrder;

--- a/metamorph/src/test/java/org/metafacture/metamorph/collectors/TestCollectorIf.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/collectors/TestCollectorIf.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.collectors;
 
 import static org.mockito.Mockito.inOrder;

--- a/metamorph/src/test/java/org/metafacture/metamorph/collectors/TuplesTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/collectors/TuplesTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.collectors;
 
 import static org.metafacture.metamorph.TestHelpers.assertMorph;

--- a/metamorph/src/test/java/org/metafacture/metamorph/functions/DateFormatTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/functions/DateFormatTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
 
 import static org.mockito.Mockito.inOrder;

--- a/metamorph/src/test/java/org/metafacture/metamorph/functions/ISBNTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/functions/ISBNTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
 
 import static org.junit.Assert.assertEquals;

--- a/metamorph/src/test/java/org/metafacture/metamorph/functions/LookupTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/functions/LookupTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
 
 import static org.junit.Assert.assertEquals;

--- a/metamorph/src/test/java/org/metafacture/metamorph/functions/NormalizeUTF8Test.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/functions/NormalizeUTF8Test.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
 
 import static org.junit.Assert.assertEquals;

--- a/metamorph/src/test/java/org/metafacture/metamorph/functions/RegexpTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/functions/RegexpTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
 
 import static org.mockito.Mockito.inOrder;

--- a/metamorph/src/test/java/org/metafacture/metamorph/functions/ScriptTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/functions/ScriptTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
 
 import static org.mockito.Mockito.inOrder;

--- a/metamorph/src/test/java/org/metafacture/metamorph/functions/SplitTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/functions/SplitTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
 
 import static org.mockito.Mockito.verify;

--- a/metamorph/src/test/java/org/metafacture/metamorph/functions/StringOperationsTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/functions/StringOperationsTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
 
 import static org.junit.Assert.assertEquals;

--- a/metamorph/src/test/java/org/metafacture/metamorph/functions/SwitchNameValueTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/functions/SwitchNameValueTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
 
 import static org.mockito.Mockito.verify;

--- a/metamorph/src/test/java/org/metafacture/metamorph/functions/TestFunctionBasics.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/functions/TestFunctionBasics.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
 
 import static org.mockito.Mockito.inOrder;

--- a/metamorph/src/test/java/org/metafacture/metamorph/functions/TestVariousFunctions.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/functions/TestVariousFunctions.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
 
 import static org.mockito.Mockito.inOrder;

--- a/metamorph/src/test/java/org/metafacture/metamorph/functions/UniqueTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/functions/UniqueTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.functions;
 
 import static org.metafacture.metamorph.TestHelpers.assertMorph;

--- a/metamorph/src/test/java/org/metafacture/metamorph/maps/FileMapTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/maps/FileMapTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.maps;
 
 import static org.metafacture.metamorph.TestHelpers.assertMorph;

--- a/metamorph/src/test/java/org/metafacture/metamorph/maps/JavaMapTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/maps/JavaMapTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.maps;
 
 import static org.metafacture.metamorph.TestHelpers.assertMorph;

--- a/metamorph/src/test/java/org/metafacture/metamorph/xml/DomLoaderTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/xml/DomLoaderTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.metafacture.metamorph.xml;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
Based on https://github.com/metafacture/metafacture-fix/blob/master/config/checkstyle/checkstyle.xml (metafacture/metafacture-fix#11).

> We need those (annoying) checks from metafacture-fix here :-)

_Originally posted by @fsteeg in https://github.com/metafacture/metafacture-core/pull/387#discussion_r701908944_

This would be part 2 (see #388 for part 1).

Notes:

* Checks have been disabled for test sources; maybe they should be enabled at a later stage?
* Suppressed rules (`checkstyle-disable-line`) should be evaluated; maybe adjust the Checkstyle config.
* Most obvious nuisances: `MagicNumber`, `MissingCtor`, `ReturnCount`
* metafacture/metafacture-fix@d70d5d3 introduced suppression via annotations in addition to comments; maybe we should stick to one method.