### PR TITLE
Correctly output more than two levels in nested pass-through (_elseNested).

### DIFF
--- a/metamorph/src/test/java/org/metafacture/metamorph/TestMetamorphBasics.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/TestMetamorphBasics.java
@@ -218,6 +218,174 @@ public final class TestMetamorphBasics {
     }
 
     @Test
+    public void issue378_shouldOutputMoreThanTwoLevelsInElseNestedSource() {
+        assertMorph(receiver,
+                "<rules>" +
+                "  <data source='_elseNested' />" +
+                "</rules>",
+                i -> {
+                    i.startRecord("1");
+                    i.startEntity("mods");
+                    i.literal("ID", "duepublico_mods_00074526");
+                    i.startEntity("name");
+                    i.literal("type", "personal");
+                    i.literal("type", "simple");
+                    i.startEntity("displayForm");
+                    i.literal("value", "Armbruster, André");
+                    i.endEntity();
+                    i.startEntity("role");
+                    i.startEntity("roleTerm");
+                    i.literal("authority", "marcrelator");
+                    i.literal("type", "code");
+                    i.literal("value", "aut");
+                    i.endEntity();
+                    i.startEntity("roleTerm");
+                    i.literal("authority", "marcrelator");
+                    i.literal("type", "text");
+                    i.literal("value", "Author");
+                    i.endEntity();
+                    i.endEntity();
+                    i.startEntity("nameIdentifier");
+                    i.literal("type", "gnd");
+                    i.literal("value", "1081830107");
+                    i.endEntity();
+                    i.startEntity("namePart");
+                    i.literal("type", "family");
+                    i.literal("value", "Armbruster");
+                    i.endEntity();
+                    i.startEntity("namePart");
+                    i.literal("type", "given");
+                    i.literal("value", "André");
+                    i.endEntity();
+                    i.endEntity();
+                    i.endEntity();
+                    i.endRecord();
+                },
+                (o, f) -> {
+                    o.get().startRecord("1");
+                    o.get().startEntity("mods");
+                    o.get().literal("ID", "duepublico_mods_00074526");
+                    o.get().startEntity("name");
+                    o.get().literal("type", "personal");
+                    o.get().literal("type", "simple");
+                    o.get().startEntity("displayForm");
+                    o.get().literal("value", "Armbruster, André");
+                    o.get().endEntity();
+                    o.get().startEntity("role");
+                    o.get().startEntity("roleTerm");
+                    o.get().literal("authority", "marcrelator");
+                    o.get().literal("type", "code");
+                    o.get().literal("value", "aut");
+                    o.get().endEntity();
+                    o.get().startEntity("roleTerm");
+                    o.get().literal("authority", "marcrelator");
+                    o.get().literal("type", "text");
+                    o.get().literal("value", "Author");
+                    f.apply(2).endEntity();
+                    o.get().startEntity("nameIdentifier");
+                    o.get().literal("type", "gnd");
+                    o.get().literal("value", "1081830107");
+                    o.get().endEntity();
+                    o.get().startEntity("namePart");
+                    o.get().literal("type", "family");
+                    o.get().literal("value", "Armbruster");
+                    o.get().endEntity();
+                    o.get().startEntity("namePart");
+                    o.get().literal("type", "given");
+                    o.get().literal("value", "André");
+                    f.apply(3).endEntity();
+                    o.get().endRecord();
+                }
+        );
+    }
+
+    @Test
+    public void shouldOutputMoreThanTwoLevelsInElseNestedSourceWithModifications() {
+        assertMorph(receiver,
+                "<rules>" +
+                "  <entity name='name' flushWith='record'>" +
+                "    <data source='mods.name.displayForm.value' name='displayForm' />" +
+                "    <data source='mods.name.namePart.value' />" +
+                "  </entity>" +
+                "  <data source='_elseNested' />" +
+                "</rules>",
+                i -> {
+                    i.startRecord("1");
+                    i.startEntity("mods");
+                    i.literal("ID", "duepublico_mods_00074526");
+                    i.startEntity("name");
+                    i.literal("type", "personal");
+                    i.literal("type", "simple");
+                    i.startEntity("displayForm");
+                    i.literal("value", "Armbruster, André");
+                    i.endEntity();
+                    i.startEntity("role");
+                    i.startEntity("roleTerm");
+                    i.literal("authority", "marcrelator");
+                    i.literal("type", "code");
+                    i.literal("value", "aut");
+                    i.endEntity();
+                    i.startEntity("roleTerm");
+                    i.literal("authority", "marcrelator");
+                    i.literal("type", "text");
+                    i.literal("value", "Author");
+                    i.endEntity();
+                    i.endEntity();
+                    i.startEntity("nameIdentifier");
+                    i.literal("type", "gnd");
+                    i.literal("value", "1081830107");
+                    i.endEntity();
+                    i.startEntity("namePart");
+                    i.literal("type", "family");
+                    i.literal("value", "Armbruster");
+                    i.endEntity();
+                    i.startEntity("namePart");
+                    i.literal("type", "given");
+                    i.literal("value", "André");
+                    i.endEntity();
+                    i.endEntity();
+                    i.endEntity();
+                    i.endRecord();
+                },
+                (o, f) -> {
+                    o.get().startRecord("1");
+                    o.get().startEntity("mods");
+                    o.get().literal("ID", "duepublico_mods_00074526");
+                    o.get().startEntity("name");
+                    o.get().literal("type", "personal");
+                    o.get().literal("type", "simple");
+                    o.get().startEntity("role");
+                    o.get().startEntity("roleTerm");
+                    o.get().literal("authority", "marcrelator");
+                    o.get().literal("type", "code");
+                    o.get().literal("value", "aut");
+                    o.get().endEntity();
+                    o.get().startEntity("roleTerm");
+                    o.get().literal("authority", "marcrelator");
+                    o.get().literal("type", "text");
+                    o.get().literal("value", "Author");
+                    f.apply(2).endEntity();
+                    o.get().startEntity("nameIdentifier");
+                    o.get().literal("type", "gnd");
+                    o.get().literal("value", "1081830107");
+                    o.get().endEntity();
+                    o.get().startEntity("namePart");
+                    o.get().literal("type", "family");
+                    o.get().endEntity();
+                    o.get().startEntity("namePart");
+                    o.get().literal("type", "given");
+                    f.apply(3).endEntity();
+                    o.get().startEntity("name");
+                    o.get().literal("displayForm", "Armbruster, André");
+                    o.get().literal("mods.name.namePart.value", "Armbruster");
+                    o.get().literal("mods.name.namePart.value", "André");
+                    o.get().endEntity();
+                    o.get().endRecord();
+                }
+        );
+    }
+
+    @Test
     public void shouldHandleUnmatchedLiteralsAndEntitiesInElseNestedSource() {
         assertMorph(receiver,
                 "<rules>" +

--- a/metamorph/src/test/java/org/metafacture/metamorph/TestMetamorphBasics.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/TestMetamorphBasics.java
@@ -218,6 +218,58 @@ public final class TestMetamorphBasics {
     }
 
     @Test
+    public void issue374_shouldPropagateArrayMarkersInElseNestedSource() {
+        assertMorph(receiver,
+                "<rules>" +
+                "  <data source='_elseNested' />" +
+                "</rules>",
+                i -> {
+                    i.startRecord("1");
+                    i.startEntity("author[]");
+                    i.startEntity("");
+                    i.literal("@type", "Person");
+                    i.literal("name", "Katja Königstein-Lüdersdorff");
+                    i.endEntity();
+                    i.startEntity("");
+                    i.literal("@type", "Person");
+                    i.literal("name", "Corinna Peters");
+                    i.endEntity();
+                    i.startEntity("");
+                    i.literal("@type", "Person");
+                    i.literal("name", "Oleg Tjulenev");
+                    i.endEntity();
+                    i.startEntity("");
+                    i.literal("@type", "Person");
+                    i.literal("name", "Claudia Vogeler");
+                    i.endEntity();
+                    i.endEntity();
+                    i.endRecord();
+                },
+                (o, f) -> {
+                    o.get().startRecord("1");
+                    o.get().startEntity("author[]");
+                    o.get().startEntity("");
+                    o.get().literal("@type", "Person");
+                    o.get().literal("name", "Katja Königstein-Lüdersdorff");
+                    o.get().endEntity();
+                    o.get().startEntity("");
+                    o.get().literal("@type", "Person");
+                    o.get().literal("name", "Corinna Peters");
+                    o.get().endEntity();
+                    o.get().startEntity("");
+                    o.get().literal("@type", "Person");
+                    o.get().literal("name", "Oleg Tjulenev");
+                    o.get().endEntity();
+                    o.get().startEntity("");
+                    o.get().literal("@type", "Person");
+                    o.get().literal("name", "Claudia Vogeler");
+                    f.apply(2).endEntity();
+                    o.get().endRecord();
+                }
+        );
+    }
+
+    @Test
     public void issue378_shouldOutputMoreThanTwoLevelsInElseNestedSource() {
         assertMorph(receiver,
                 "<rules>" +


### PR DESCRIPTION
Keep track of nested entities and open/close them in the appropriate order.

If anyone has any more edge cases we should test for, please let me know.

Fixes #378.

Related to #107, #338.