### PR TITLE
Make JSON encoder array marker configurable.

### DIFF
--- a/metafacture-json/src/main/java/org/metafacture/json/JsonEncoder.java
+++ b/metafacture-json/src/main/java/org/metafacture/json/JsonEncoder.java
@@ -50,8 +50,7 @@ import java.io.StringWriter;
 @In(StreamReceiver.class)
 @Out(String.class)
 @FluxCommand("encode-json")
-public final class JsonEncoder extends
-        DefaultStreamPipe<ObjectReceiver<String>> {
+public final class JsonEncoder extends DefaultStreamPipe<ObjectReceiver<String>> {
 
     public static final String ARRAY_MARKER = "[]";
 
@@ -61,6 +60,8 @@ public final class JsonEncoder extends
     private final JsonGenerator jsonGenerator;
     private final StringWriter writer = new StringWriter();
 
+    private String arrayMarker = ARRAY_MARKER;
+
     public JsonEncoder() {
         try {
             jsonGenerator = new JsonFactory().createGenerator(writer);
@@ -69,6 +70,14 @@ public final class JsonEncoder extends
         catch (final IOException e) {
             throw new MetafactureException(e);
         }
+    }
+
+    public void setArrayMarker(final String arrayMarker) {
+        this.arrayMarker = arrayMarker;
+    }
+
+    public String getArrayMarker() {
+        return arrayMarker;
     }
 
     public void setPrettyPrinting(final boolean prettyPrinting) {
@@ -173,9 +182,9 @@ public final class JsonEncoder extends
     private void startGroup(final String name) {
         try {
             final JsonStreamContext ctx = jsonGenerator.getOutputContext();
-            if (name.endsWith(ARRAY_MARKER)) {
+            if (name.endsWith(arrayMarker)) {
                 if (ctx.inObject()) {
-                    jsonGenerator.writeFieldName(name.substring(0, name.length() - ARRAY_MARKER.length()));
+                    jsonGenerator.writeFieldName(name.substring(0, name.length() - arrayMarker.length()));
                 }
                 jsonGenerator.writeStartArray();
             }

--- a/metafacture-json/src/test/java/org/metafacture/json/JsonEncoderTest.java
+++ b/metafacture-json/src/test/java/org/metafacture/json/JsonEncoderTest.java
@@ -159,6 +159,37 @@ public final class JsonEncoderTest {
     }
 
     @Test
+    public void testShouldNotEncodeEntitiesWithDifferentMarkerAsList() {
+        encoder.setArrayMarker("*");
+
+        encoder.startRecord("");
+        encoder.startEntity(LIST1);
+        encoder.literal(LITERAL1, VALUE1);
+        encoder.literal(LITERAL2, VALUE2);
+        encoder.literal(LITERAL3, VALUE3);
+        encoder.endEntity();
+        encoder.endRecord();
+
+        verify(receiver).process(fixQuotes("{'Li1[]':{'L1':'V1','L2':'V2','L3':'V3'}}"));
+    }
+
+    @Test
+    public void testShouldEncodeMarkedEntitiesWithConfiguredMarkerAsList() {
+        final String marker = "*";
+        encoder.setArrayMarker(marker);
+
+        encoder.startRecord("");
+        encoder.startEntity(LIST1.replace(JsonEncoder.ARRAY_MARKER, marker));
+        encoder.literal(LITERAL1, VALUE1);
+        encoder.literal(LITERAL2, VALUE2);
+        encoder.literal(LITERAL3, VALUE3);
+        encoder.endEntity();
+        encoder.endRecord();
+
+        verify(receiver).process(fixQuotes("{'Li1':['V1','V2','V3']}"));
+    }
+
+    @Test
     public void testShouldOutputDuplicateNames() {
         encoder.startRecord("");
         encoder.literal(LITERAL1, VALUE1);


### PR DESCRIPTION
Allows pass-through in combination with JSON decoder array marker.