### PR TITLE
Improve handling of XML attributes and element values.

### DIFF
--- a/metafacture-biblio/build.gradle
+++ b/metafacture-biblio/build.gradle
@@ -31,3 +31,10 @@ dependencies {
   testImplementation 'junit:junit:4.12'
   testImplementation 'org.mockito:mockito-core:2.5.5'
 }
+
+test {
+  testLogging {
+    showStandardStreams = true
+    exceptionFormat = 'full'
+  }
+}

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/marc21/MarcXmlHandler.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/marc21/MarcXmlHandler.java
@@ -38,8 +38,6 @@ import org.xml.sax.SAXException;
 @FluxCommand("handle-marcxml")
 public final class MarcXmlHandler extends DefaultXmlPipe<StreamReceiver> {
 
-    public static final String DEFAULT_ATTRIBUTE_MARKER = "";
-
     private static final String SUBFIELD = "subfield";
     private static final String DATAFIELD = "datafield";
     private static final String CONTROLFIELD = "controlfield";

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/marc21/MarcXmlHandler.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/marc21/MarcXmlHandler.java
@@ -38,6 +38,8 @@ import org.xml.sax.SAXException;
 @FluxCommand("handle-marcxml")
 public final class MarcXmlHandler extends DefaultXmlPipe<StreamReceiver> {
 
+    public static final String DEFAULT_ATTRIBUTE_MARKER = "";
+
     private static final String SUBFIELD = "subfield";
     private static final String DATAFIELD = "datafield";
     private static final String CONTROLFIELD = "controlfield";
@@ -45,6 +47,8 @@ public final class MarcXmlHandler extends DefaultXmlPipe<StreamReceiver> {
     private static final String NAMESPACE = "http://www.loc.gov/MARC21/slim";
     private static final String LEADER = "leader";
     private static final String TYPE = "type";
+
+    private String attributeMarker = DEFAULT_ATTRIBUTE_MARKER;
     private String currentTag = "";
     private String namespace = NAMESPACE;
     private StringBuilder builder = new StringBuilder();
@@ -58,6 +62,14 @@ public final class MarcXmlHandler extends DefaultXmlPipe<StreamReceiver> {
 
     private boolean checkNamespace(final String uri) {
         return namespace == null || namespace.equals(uri);
+    }
+
+    public void setAttributeMarker(final String attributeMarker) {
+        this.attributeMarker = attributeMarker;
+    }
+
+    public String getAttributeMarker() {
+        return attributeMarker;
     }
 
     @Override
@@ -75,7 +87,7 @@ public final class MarcXmlHandler extends DefaultXmlPipe<StreamReceiver> {
         }
         else if (RECORD.equals(localName) && checkNamespace(uri)) {
             getReceiver().startRecord("");
-            getReceiver().literal(TYPE, attributes.getValue(TYPE));
+            getReceiver().literal(attributeMarker + TYPE, attributes.getValue(TYPE));
         }
         else if (LEADER.equals(localName)) {
             builder = new StringBuilder();
@@ -87,18 +99,15 @@ public final class MarcXmlHandler extends DefaultXmlPipe<StreamReceiver> {
     public void endElement(final String uri, final String localName, final String qName) throws SAXException {
         if (SUBFIELD.equals(localName)) {
             getReceiver().literal(currentTag, builder.toString().trim());
-
         }
         else if (DATAFIELD.equals(localName)) {
             getReceiver().endEntity();
         }
         else if (CONTROLFIELD.equals(localName)) {
             getReceiver().literal(currentTag, builder.toString().trim());
-
         }
         else if (RECORD.equals(localName) && checkNamespace(uri)) {
             getReceiver().endRecord();
-
         }
         else if (LEADER.equals(localName)) {
             getReceiver().literal(currentTag, builder.toString());

--- a/metafacture-biblio/src/test/java/org/metafacture/biblio/marc21/MarcXmlHandlerTest.java
+++ b/metafacture-biblio/src/test/java/org/metafacture/biblio/marc21/MarcXmlHandlerTest.java
@@ -23,7 +23,9 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.metafacture.framework.StreamReceiver;
+import org.mockito.InOrder;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.AttributesImpl;
@@ -127,6 +129,41 @@ public final class MarcXmlHandlerTest {
         verify(receiver).literal(TYPE, null);
         verify(receiver).endRecord();
 
+        verifyNoMoreInteractions(receiver);
+    }
+
+    @Test
+    public void shouldNotEncodeTypeAttributeAsMarkedLiteral() throws SAXException {
+        final AttributesImpl attributes = new AttributesImpl();
+        attributes.addAttribute(NAMESPACE, "type", "type", "CDATA", "bibliographic");
+
+        marcXmlHandler.startElement(NAMESPACE, RECORD, "", attributes);
+        marcXmlHandler.endElement(NAMESPACE, RECORD, "");
+
+        final InOrder ordered = Mockito.inOrder(receiver);
+        ordered.verify(receiver).startRecord("");
+        ordered.verify(receiver).literal(TYPE, "bibliographic");
+        ordered.verify(receiver).endRecord();
+        ordered.verifyNoMoreInteractions();
+        verifyNoMoreInteractions(receiver);
+    }
+
+    @Test
+    public void issue336_shouldEncodeTypeAttributeAsLiteralWithConfiguredMarker() throws SAXException {
+        final String marker = "~";
+        marcXmlHandler.setAttributeMarker(marker);
+
+        final AttributesImpl attributes = new AttributesImpl();
+        attributes.addAttribute(NAMESPACE, "type", "type", "CDATA", "bibliographic");
+
+        marcXmlHandler.startElement(NAMESPACE, RECORD, "", attributes);
+        marcXmlHandler.endElement(NAMESPACE, RECORD, "");
+
+        final InOrder ordered = Mockito.inOrder(receiver);
+        ordered.verify(receiver).startRecord("");
+        ordered.verify(receiver).literal(marker + TYPE, "bibliographic");
+        ordered.verify(receiver).endRecord();
+        ordered.verifyNoMoreInteractions();
         verifyNoMoreInteractions(receiver);
     }
 

--- a/metafacture-framework/src/main/java/org/metafacture/framework/helpers/DefaultXmlPipe.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/helpers/DefaultXmlPipe.java
@@ -38,6 +38,11 @@ import java.io.IOException;
  */
 public class DefaultXmlPipe<R extends Receiver> extends DefaultSender<R> implements XmlPipe<R> {
 
+    public static final String DEFAULT_ATTRIBUTE_MARKER = "";
+    public static final String DEFAULT_RECORD_TAG = "record";
+    public static final String DEFAULT_ROOT_TAG = "records";
+    public static final String DEFAULT_VALUE_TAG = "value";
+
     public DefaultXmlPipe() {
     }
 

--- a/metafacture-xml/build.gradle
+++ b/metafacture-xml/build.gradle
@@ -26,3 +26,10 @@ dependencies {
   testImplementation 'org.mockito:mockito-core:2.5.5'
   testRuntimeOnly 'org.slf4j:slf4j-simple:1.7.21'
 }
+
+test {
+  testLogging {
+    showStandardStreams = true
+    exceptionFormat = 'full'
+  }
+}

--- a/metafacture-xml/src/main/java/org/metafacture/xml/GenericXmlHandler.java
+++ b/metafacture-xml/src/main/java/org/metafacture/xml/GenericXmlHandler.java
@@ -44,12 +44,15 @@ public final class GenericXmlHandler extends DefaultXmlPipe<StreamReceiver> {
 
     public static final String DEFAULT_RECORD_TAG = "record";
 
+    public static final String DEFAULT_VALUE_TAG = "value";
+
     public static final boolean EMIT_NAMESPACE = false;
 
     private static final Pattern TABS = Pattern.compile("\t+");
 
     private String attributeMarker = DEFAULT_ATTRIBUTE_MARKER;
     private String recordTagName = DEFAULT_RECORD_TAG;
+    private String valueTagName = DEFAULT_VALUE_TAG;
 
     private boolean inRecord;
     private StringBuilder valueBuffer = new StringBuilder();
@@ -93,6 +96,14 @@ public final class GenericXmlHandler extends DefaultXmlPipe<StreamReceiver> {
 
     public String getRecordTagName() {
         return recordTagName;
+    }
+
+    public void setValueTagName(final String valueTagName) {
+        this.valueTagName = valueTagName;
+    }
+
+    public String getValueTagName() {
+        return valueTagName;
     }
 
     /**
@@ -170,7 +181,7 @@ public final class GenericXmlHandler extends DefaultXmlPipe<StreamReceiver> {
     private void writeValue() {
         final String value = valueBuffer.toString();
         if (!value.trim().isEmpty()) {
-            getReceiver().literal("value", value.replace('\n', ' '));
+            getReceiver().literal(valueTagName, value.replace('\n', ' '));
         }
         valueBuffer = new StringBuilder();
     }

--- a/metafacture-xml/src/main/java/org/metafacture/xml/GenericXmlHandler.java
+++ b/metafacture-xml/src/main/java/org/metafacture/xml/GenericXmlHandler.java
@@ -40,12 +40,15 @@ import java.util.regex.Pattern;
 @FluxCommand("handle-generic-xml")
 public final class GenericXmlHandler extends DefaultXmlPipe<StreamReceiver> {
 
+    public static final String DEFAULT_ATTRIBUTE_MARKER = "";
+
     public static final String DEFAULT_RECORD_TAG = "record";
 
     public static final boolean EMIT_NAMESPACE = false;
 
     private static final Pattern TABS = Pattern.compile("\t+");
 
+    private String attributeMarker = DEFAULT_ATTRIBUTE_MARKER;
     private String recordTagName = DEFAULT_RECORD_TAG;
 
     private boolean inRecord;
@@ -110,6 +113,14 @@ public final class GenericXmlHandler extends DefaultXmlPipe<StreamReceiver> {
         return this.emitNamespace;
     }
 
+    public void setAttributeMarker(final String attributeMarker) {
+        this.attributeMarker = attributeMarker;
+    }
+
+    public String getAttributeMarker() {
+        return attributeMarker;
+    }
+
     @Override
     public void startElement(final String uri, final String localName, final String qName, final Attributes attributes) {
         if (inRecord) {
@@ -170,7 +181,7 @@ public final class GenericXmlHandler extends DefaultXmlPipe<StreamReceiver> {
         for (int i = 0; i < length; ++i) {
             final String name = emitNamespace ? attributes.getQName(i) : attributes.getLocalName(i);
             final String value = attributes.getValue(i);
-            getReceiver().literal(name, value);
+            getReceiver().literal(attributeMarker + name, value);
         }
     }
 

--- a/metafacture-xml/src/main/java/org/metafacture/xml/GenericXmlHandler.java
+++ b/metafacture-xml/src/main/java/org/metafacture/xml/GenericXmlHandler.java
@@ -40,12 +40,6 @@ import java.util.regex.Pattern;
 @FluxCommand("handle-generic-xml")
 public final class GenericXmlHandler extends DefaultXmlPipe<StreamReceiver> {
 
-    public static final String DEFAULT_ATTRIBUTE_MARKER = "";
-
-    public static final String DEFAULT_RECORD_TAG = "record";
-
-    public static final String DEFAULT_VALUE_TAG = "value";
-
     public static final boolean EMIT_NAMESPACE = false;
 
     private static final Pattern TABS = Pattern.compile("\t+");

--- a/metafacture-xml/src/main/java/org/metafacture/xml/SimpleXmlEncoder.java
+++ b/metafacture-xml/src/main/java/org/metafacture/xml/SimpleXmlEncoder.java
@@ -26,6 +26,7 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultStreamPipe;
+import org.metafacture.framework.helpers.DefaultXmlPipe;
 
 import java.io.IOException;
 import java.net.URL;
@@ -53,10 +54,6 @@ public final class SimpleXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Str
 
     public static final String ATTRIBUTE_MARKER = "~";
 
-    public static final String DEFAULT_ROOT_TAG = "records";
-    public static final String DEFAULT_RECORD_TAG = "record";
-    public static final String DEFAULT_VALUE_TAG = "";
-
     private static final String NEW_LINE = "\n";
     private static final String INDENT = "\t";
 
@@ -74,9 +71,9 @@ public final class SimpleXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Str
     private final StringBuilder builder = new StringBuilder();
 
     private String attributeMarker = ATTRIBUTE_MARKER;
-    private String rootTag = DEFAULT_ROOT_TAG;
-    private String recordTag = DEFAULT_RECORD_TAG;
-    private String valueTag = DEFAULT_VALUE_TAG;
+    private String rootTag = DefaultXmlPipe.DEFAULT_ROOT_TAG;
+    private String recordTag = DefaultXmlPipe.DEFAULT_RECORD_TAG;
+    private String valueTag = DefaultXmlPipe.DEFAULT_VALUE_TAG;
     private Map<String, String> namespaces = new HashMap<String, String>();
     private boolean writeRootTag = true;
     private boolean writeXmlHeader = true;

--- a/metafacture-xml/src/main/java/org/metafacture/xml/SimpleXmlEncoder.java
+++ b/metafacture-xml/src/main/java/org/metafacture/xml/SimpleXmlEncoder.java
@@ -72,6 +72,7 @@ public final class SimpleXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Str
 
     private final StringBuilder builder = new StringBuilder();
 
+    private String attributeMarker = ATTRIBUTE_MARKER;
     private String rootTag = DEFAULT_ROOT_TAG;
     private String recordTag = DEFAULT_RECORD_TAG;
     private Map<String, String> namespaces = new HashMap<String, String>();
@@ -146,6 +147,14 @@ public final class SimpleXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Str
         this.namespaces = namespaces;
     }
 
+    public void setAttributeMarker(final String attributeMarker) {
+        this.attributeMarker = attributeMarker;
+    }
+
+    public String getAttributeMarker() {
+        return attributeMarker;
+    }
+
     @Override
     public void startRecord(final String identifier) {
         if (separateRoots) {
@@ -195,8 +204,8 @@ public final class SimpleXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Str
         if (name.isEmpty()) {
             element.setText(value);
         }
-        else if (name.startsWith(ATTRIBUTE_MARKER)) {
-            element.addAttribute(name.substring(1), value);
+        else if (name.startsWith(attributeMarker)) {
+            element.addAttribute(name.substring(attributeMarker.length()), value);
         }
         else {
             element.createChild(name).setText(value);

--- a/metafacture-xml/src/main/java/org/metafacture/xml/SimpleXmlEncoder.java
+++ b/metafacture-xml/src/main/java/org/metafacture/xml/SimpleXmlEncoder.java
@@ -55,6 +55,7 @@ public final class SimpleXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Str
 
     public static final String DEFAULT_ROOT_TAG = "records";
     public static final String DEFAULT_RECORD_TAG = "record";
+    public static final String DEFAULT_VALUE_TAG = null;
 
     private static final String NEW_LINE = "\n";
     private static final String INDENT = "\t";
@@ -75,6 +76,7 @@ public final class SimpleXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Str
     private String attributeMarker = ATTRIBUTE_MARKER;
     private String rootTag = DEFAULT_ROOT_TAG;
     private String recordTag = DEFAULT_RECORD_TAG;
+    private String valueTag = DEFAULT_VALUE_TAG;
     private Map<String, String> namespaces = new HashMap<String, String>();
     private boolean writeRootTag = true;
     private boolean writeXmlHeader = true;
@@ -95,6 +97,14 @@ public final class SimpleXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Str
 
     public void setRecordTag(final String tag) {
         recordTag = tag;
+    }
+
+    public void setValueTag(final String valueTag) {
+        this.valueTag = valueTag;
+    }
+
+    public String getValueTag() {
+        return valueTag;
     }
 
     public void setNamespaceFile(final String file) {
@@ -201,7 +211,7 @@ public final class SimpleXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Str
 
     @Override
     public void literal(final String name, final String value) {
-        if (name.isEmpty()) {
+        if (name.isEmpty() || name.equals(valueTag)) {
             element.setText(value);
         }
         else if (name.startsWith(attributeMarker)) {

--- a/metafacture-xml/src/main/java/org/metafacture/xml/SimpleXmlEncoder.java
+++ b/metafacture-xml/src/main/java/org/metafacture/xml/SimpleXmlEncoder.java
@@ -55,7 +55,7 @@ public final class SimpleXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Str
 
     public static final String DEFAULT_ROOT_TAG = "records";
     public static final String DEFAULT_RECORD_TAG = "record";
-    public static final String DEFAULT_VALUE_TAG = null;
+    public static final String DEFAULT_VALUE_TAG = "";
 
     private static final String NEW_LINE = "\n";
     private static final String INDENT = "\t";
@@ -211,7 +211,7 @@ public final class SimpleXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Str
 
     @Override
     public void literal(final String name, final String value) {
-        if (name.isEmpty() || name.equals(valueTag)) {
+        if (name.equals(valueTag)) {
             element.setText(value);
         }
         else if (name.startsWith(attributeMarker)) {

--- a/metafacture-xml/src/test/java/org/metafacture/xml/GenericXMLHandlerTest.java
+++ b/metafacture-xml/src/test/java/org/metafacture/xml/GenericXMLHandlerTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.metafacture.framework.StreamReceiver;
 import org.mockito.InOrder;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.xml.sax.helpers.AttributesImpl;
 
@@ -141,6 +142,47 @@ public final class GenericXMLHandlerTest {
 
         final InOrder ordered = inOrder(receiver);
         ordered.verify(receiver).startEntity("ns:entity");
-        ordered.verify(receiver).literal("ns:attr","attr-value");
+        ordered.verify(receiver).literal("ns:attr", "attr-value");
     }
+
+    @Test
+    public void shouldNotEncodeAttributesAsMarkedLiterals() {
+        attributes.addAttribute("", "attr", "attr", "CDATA", "attr-value");
+        genericXmlHandler.startElement("", "record", "record", attributes);
+        genericXmlHandler.endElement("", "record", "record");
+
+        final InOrder ordered = inOrder(receiver);
+        ordered.verify(receiver).startRecord("");
+        ordered.verify(receiver).literal("attr", "attr-value");
+        ordered.verify(receiver).endRecord();
+        ordered.verifyNoMoreInteractions();
+        Mockito.verifyNoMoreInteractions(receiver);
+    }
+
+    @Test
+    public void issue379_shouldEncodeAttributesAsLiteralsWithConfiguredMarker() {
+        final String marker = "~";
+        genericXmlHandler.setAttributeMarker(marker);
+
+        genericXmlHandler.startElement("", "record", "record", attributes);
+        attributes.addAttribute("", "authority", "authority", "CDATA", "marcrelator");
+        attributes.addAttribute("", "type", "type", "CDATA", "text");
+        genericXmlHandler.startElement("", "roleTerm", "roleTerm", attributes);
+        final char[] charData = "Author".toCharArray();
+        genericXmlHandler.characters(charData, 0, charData.length);
+        genericXmlHandler.endElement("", "roleTerm", "roleTerm");
+        genericXmlHandler.endElement("", "record", "record");
+
+        final InOrder ordered = inOrder(receiver);
+        ordered.verify(receiver).startRecord("");
+        ordered.verify(receiver).startEntity("roleTerm");
+        ordered.verify(receiver).literal(marker + "authority", "marcrelator");
+        ordered.verify(receiver).literal(marker + "type", "text");
+        ordered.verify(receiver).literal("value", "Author");
+        ordered.verify(receiver).endEntity();
+        ordered.verify(receiver).endRecord();
+        ordered.verifyNoMoreInteractions();
+        Mockito.verifyNoMoreInteractions(receiver);
+    }
+
 }

--- a/metafacture-xml/src/test/java/org/metafacture/xml/GenericXMLHandlerTest.java
+++ b/metafacture-xml/src/test/java/org/metafacture/xml/GenericXMLHandlerTest.java
@@ -134,6 +134,28 @@ public final class GenericXMLHandlerTest {
     }
 
     @Test
+    public void shouldEmitPCDataAsALiteralWithConfiguredValueTagName() {
+        final String name = "data";
+        genericXmlHandler.setValueTagName(name);
+
+        final char[] charData = "char-data".toCharArray();
+        genericXmlHandler.startElement("", "record", "record", attributes);
+        genericXmlHandler.startElement("", "entity", "entity", attributes);
+        genericXmlHandler.characters(charData, 0, charData.length);
+        genericXmlHandler.endElement("", "entity", "entity");
+        genericXmlHandler.endElement("", "record", "record");
+
+        final InOrder ordered = inOrder(receiver);
+        ordered.verify(receiver).startRecord("");
+        ordered.verify(receiver).startEntity("entity");
+        ordered.verify(receiver).literal(name, "char-data");
+        ordered.verify(receiver).endEntity();
+        ordered.verify(receiver).endRecord();
+        ordered.verifyNoMoreInteractions();
+        Mockito.verifyNoMoreInteractions(receiver);
+    }
+
+    @Test
     public void shouldEmitNamespaceOnEntityElementAndAttribute() {
         genericXmlHandler.setEmitNamespace(true);
         attributes.addAttribute("", "attr", "ns:attr", "CDATA", "attr-value");

--- a/metafacture-xml/src/test/java/org/metafacture/xml/SimpleXmlEncoderTest.java
+++ b/metafacture-xml/src/test/java/org/metafacture/xml/SimpleXmlEncoderTest.java
@@ -180,12 +180,31 @@ public final class SimpleXmlEncoderTest {
     }
 
     @Test
-    public void testShouldEncodeEmptyLiteralsAsText() {
+    public void testShouldEncodeUnnamedLiteralsAsText() {
         simpleXmlEncoder.startRecord("");
         simpleXmlEncoder.literal("", VALUE);
         simpleXmlEncoder.endRecord();
         simpleXmlEncoder.closeStream();
 
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<records>" +
+                "<record>" +
+                "value" +
+                "</record>" +
+                "</records>",
+                getResultXml());
+    }
+
+    @Test
+    public void testShouldStillEncodeUnnamedLiteralsAsTextWithConfiguredValueTagName() {
+        simpleXmlEncoder.setValueTag("data");
+
+        simpleXmlEncoder.startRecord("");
+        simpleXmlEncoder.literal("", VALUE);
+        simpleXmlEncoder.endRecord();
+        simpleXmlEncoder.closeStream();
+
+        // SimpleXmlEncoder.Element.writeElement() does not write child elements with empty name
         assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
                 "<records>" +
                 "<record>" +

--- a/metafacture-xml/src/test/java/org/metafacture/xml/SimpleXmlEncoderTest.java
+++ b/metafacture-xml/src/test/java/org/metafacture/xml/SimpleXmlEncoderTest.java
@@ -179,6 +179,85 @@ public final class SimpleXmlEncoderTest {
                 getResultXml());
     }
 
+    @Test
+    public void testShouldEncodeMarkedLiteralsAsAttributes() {
+        simpleXmlEncoder.startRecord("");
+        simpleXmlEncoder.literal(TAG, VALUE);
+        simpleXmlEncoder.literal("~attr", VALUE);
+        simpleXmlEncoder.endRecord();
+        simpleXmlEncoder.closeStream();
+
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<records>" +
+                "<record attr=\"value\">" +
+                "<tag>value</tag>" +
+                "</record>" +
+                "</records>",
+                getResultXml());
+    }
+
+    @Test
+    public void testShouldNotEncodeMarkedEntitiesAsAttributes() {
+        simpleXmlEncoder.setAttributeMarker("*");
+
+        simpleXmlEncoder.startRecord("");
+        simpleXmlEncoder.startEntity("~entity");
+        simpleXmlEncoder.literal(TAG, VALUE);
+        simpleXmlEncoder.endEntity();
+        simpleXmlEncoder.endRecord();
+        simpleXmlEncoder.closeStream();
+
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<records>" +
+                "<record>" +
+                "<~entity>" +
+                "<tag>value</tag>" +
+                "</~entity>" +
+                "</record>" +
+                "</records>",
+                getResultXml());
+    }
+
+    @Test
+    public void testShouldNotEncodeLiteralsWithDifferentMarkerAsAttributes() {
+        simpleXmlEncoder.setAttributeMarker("*");
+
+        simpleXmlEncoder.startRecord("");
+        simpleXmlEncoder.literal(TAG, VALUE);
+        simpleXmlEncoder.literal("~attr", VALUE);
+        simpleXmlEncoder.endRecord();
+        simpleXmlEncoder.closeStream();
+
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<records>" +
+                "<record>" +
+                "<tag>value</tag>" +
+                "<~attr>value</~attr>" +
+                "</record>" +
+                "</records>",
+                getResultXml());
+    }
+
+    @Test
+    public void testShouldEncodeMarkedLiteralsWithConfiguredMarkerAsAttributes() {
+        final String marker = "**";
+        simpleXmlEncoder.setAttributeMarker(marker);
+
+        simpleXmlEncoder.startRecord("");
+        simpleXmlEncoder.literal(TAG, VALUE);
+        simpleXmlEncoder.literal(marker + "attr", VALUE);
+        simpleXmlEncoder.endRecord();
+        simpleXmlEncoder.closeStream();
+
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<records>" +
+                "<record attr=\"value\">" +
+                "<tag>value</tag>" +
+                "</record>" +
+                "</records>",
+                getResultXml());
+    }
+
     private void emitTwoRecords() {
         simpleXmlEncoder.startRecord("X");
         simpleXmlEncoder.literal(TAG, VALUE);

--- a/metafacture-xml/src/test/java/org/metafacture/xml/SimpleXmlEncoderTest.java
+++ b/metafacture-xml/src/test/java/org/metafacture/xml/SimpleXmlEncoderTest.java
@@ -180,6 +180,59 @@ public final class SimpleXmlEncoderTest {
     }
 
     @Test
+    public void testShouldEncodeEmptyLiteralsAsText() {
+        simpleXmlEncoder.startRecord("");
+        simpleXmlEncoder.literal("", VALUE);
+        simpleXmlEncoder.endRecord();
+        simpleXmlEncoder.closeStream();
+
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<records>" +
+                "<record>" +
+                "value" +
+                "</record>" +
+                "</records>",
+                getResultXml());
+    }
+
+    @Test
+    public void testShouldNotEncodeLiteralsWithDifferentValueTagNameAsText() {
+        simpleXmlEncoder.setValueTag("data");
+
+        simpleXmlEncoder.startRecord("");
+        simpleXmlEncoder.literal(TAG, VALUE);
+        simpleXmlEncoder.endRecord();
+        simpleXmlEncoder.closeStream();
+
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<records>" +
+                "<record>" +
+                "<tag>value</tag>" +
+                "</record>" +
+                "</records>",
+                getResultXml());
+    }
+
+    @Test
+    public void issue379_testShouldEncodeConfiguredValueLiteralsAsText() {
+        final String name = "data";
+        simpleXmlEncoder.setValueTag(name);
+
+        simpleXmlEncoder.startRecord("");
+        simpleXmlEncoder.literal(name, VALUE);
+        simpleXmlEncoder.endRecord();
+        simpleXmlEncoder.closeStream();
+
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<records>" +
+                "<record>" +
+                "value" +
+                "</record>" +
+                "</records>",
+                getResultXml());
+    }
+
+    @Test
     public void testShouldEncodeMarkedLiteralsAsAttributes() {
         simpleXmlEncoder.startRecord("");
         simpleXmlEncoder.literal(TAG, VALUE);


### PR DESCRIPTION
Make attribute markers configurable:

- Simple XML encoder
- Generic XML handler; see #379
- MARC21 XML handler; see #336

Make value tag names configurable:

- Simple XML encoder; see #379
- Generic XML handler

Fixes #379.

Related to #336.