### PR TITLE
Encode top-level MARC record leader as proper XML element instead of control field.

### DIFF
--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/marc21/MarcXmlEncoder.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/marc21/MarcXmlEncoder.java
@@ -182,27 +182,22 @@ public final class MarcXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Strin
     @Override
     public void literal(final String name, final String value) {
         if ("".equals(currentEntity)) {
-            prettyPrintIndentation();
-            writeRaw(String.format(CONTROLFIELD_OPEN_TEMPLATE, name));
-            if (value != null) {
-                writeEscaped(value.trim());
+            if (!writeLeader(name, value)) {
+                prettyPrintIndentation();
+                writeRaw(String.format(CONTROLFIELD_OPEN_TEMPLATE, name));
+                if (value != null) {
+                    writeEscaped(value.trim());
+                }
+                writeRaw(CONTROLFIELD_CLOSE);
+                prettyPrintNewLine();
             }
-            writeRaw(CONTROLFIELD_CLOSE);
-            prettyPrintNewLine();
         }
-        else if (!currentEntity.equals(Marc21EventNames.LEADER_ENTITY)) {
+        else if (!writeLeader(currentEntity, value)) {
             prettyPrintIndentation();
             writeRaw(String.format(SUBFIELD_OPEN_TEMPLATE, name));
             writeEscaped(value.trim());
             writeRaw(SUBFIELD_CLOSE);
             prettyPrintNewLine();
-        }
-        else {
-            if (name.equals(Marc21EventNames.LEADER_ENTITY)) {
-                prettyPrintIndentation();
-                writeRaw(LEADER_OPEN_TEMPLATE + value + LEADER_CLOSE_TEMPLATE);
-                prettyPrintNewLine();
-            }
         }
 
     }
@@ -250,6 +245,19 @@ public final class MarcXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Strin
     /** Writes a escaped sequence */
     private void writeEscaped(final String str) {
         builder.append(XmlUtil.escape(str, false));
+    }
+
+    private boolean writeLeader(final String name, final String value) {
+        if (name.equals(Marc21EventNames.LEADER_ENTITY)) {
+            prettyPrintIndentation();
+            writeRaw(LEADER_OPEN_TEMPLATE + value + LEADER_CLOSE_TEMPLATE);
+            prettyPrintNewLine();
+
+            return true;
+        }
+        else {
+            return false;
+        }
     }
 
     private void prettyPrintIndentation() {

--- a/metafacture-biblio/src/test/java/org/metafacture/biblio/marc21/MarcXmlEncoderTest.java
+++ b/metafacture-biblio/src/test/java/org/metafacture/biblio/marc21/MarcXmlEncoderTest.java
@@ -187,6 +187,18 @@ public class MarcXmlEncoderTest {
     }
 
     @Test
+    public void issue336_createRecordWithTopLevelLeader() {
+        encoder.startRecord("1");
+        encoder.literal(Marc21EventNames.LEADER_ENTITY, "dummy");
+        encoder.endRecord();
+        encoder.closeStream();
+        String expected = XML_DECLARATION + XML_ROOT_OPEN
+                + "<marc:record><marc:leader>dummy</marc:leader></marc:record>" + XML_MARC_COLLECTION_END_TAG;
+        String actual = resultCollector.toString();
+        assertEquals(expected, actual);
+    }
+
+    @Test
     public void sendDataAndClearWhenRecordStartedAndStreamResets() {
         encoder.startRecord("1");
         encoder.onResetStream();


### PR DESCRIPTION
The XML decoder (not knowing anything about MARC) emits the leader element as a top-level literal. This is in contrast to the MARC21 decoder which wraps it in an entity.

The latter seems to be a historical artifact, originating from the removal of the `splitLeader` setting in `Marc21Decoder` (6d04d69) and the subsequent introduction of the `emitLeaderAsWhole` setting (76eb9fd).

Fixes #336.