### PR TITLE
Make emitting MARCXML namespace configurable.

### DIFF
--- a/metafacture-biblio/src/test/java/org/metafacture/biblio/marc21/MarcXmlEncoderTest.java
+++ b/metafacture-biblio/src/test/java/org/metafacture/biblio/marc21/MarcXmlEncoderTest.java
@@ -174,9 +174,10 @@ public class MarcXmlEncoderTest {
         addOneRecord(encoder);
         addOneRecord(encoder);
         encoder.closeStream();
-        String expected = XML_DECLARATION + String.format(MarcXmlEncoder.ROOT_OPEN_TEMPLATE, "", "", "") + XML_RECORD + XML_RECORD + XML_MARC_COLLECTION_END_TAG;
+        String expected = XML_DECLARATION + "<collection xmlns=\"http://www.loc.gov/MARC21/slim\">"
+            + XML_RECORD + XML_RECORD + XML_MARC_COLLECTION_END_TAG;
         String actual = resultCollector.toString();
-        assertEquals(expected.replace(MarcXmlEncoder.NAMESPACE_PREFIX, ""), actual);
+        assertEquals(expected.replace("marc:", ""), actual);
     }
 
     @Test(expected = MetafactureException.class)


### PR DESCRIPTION
This is (presumably) the least disruptive modification to achieve the goal, but there's probably potential to overhaul the XML construction (and to reuse constants in the test class).

Fixes #403.