### PR TITLE
Fix "setreplace" using a FileMap (#381)

### DIFF
--- a/metamorph-api/src/main/java/org/metafacture/metamorph/api/helpers/AbstractReadOnlyMap.java
+++ b/metamorph-api/src/main/java/org/metafacture/metamorph/api/helpers/AbstractReadOnlyMap.java
@@ -21,8 +21,8 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Base class for maps which are read only and do not allow access to their
- * full contents.
+ * Base class for maps which are read only and by default doesn't give access to
+ * their full contents.
  *
  * @param <K> type of keys
  * @param <V> type of values
@@ -31,12 +31,12 @@ import java.util.Set;
 public abstract class AbstractReadOnlyMap<K, V> implements Map<K, V> {
 
     @Override
-    public final int size() {
+    public int size() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public final boolean isEmpty() {
+    public boolean isEmpty() {
         throw new UnsupportedOperationException();
     }
 
@@ -46,7 +46,7 @@ public abstract class AbstractReadOnlyMap<K, V> implements Map<K, V> {
     }
 
     @Override
-    public final boolean containsValue(final Object value) {
+    public boolean containsValue(final Object value) {
         throw new UnsupportedOperationException();
     }
 
@@ -63,7 +63,6 @@ public abstract class AbstractReadOnlyMap<K, V> implements Map<K, V> {
     @Override
     public final void putAll(final Map<? extends K, ? extends V> m) {
         throw new UnsupportedOperationException();
-
     }
 
     @Override
@@ -72,17 +71,17 @@ public abstract class AbstractReadOnlyMap<K, V> implements Map<K, V> {
     }
 
     @Override
-    public final Set<K> keySet() {
+    public Set<K> keySet() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public final Collection<V> values() {
+    public Collection<V> values() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public final Set<java.util.Map.Entry<K, V>> entrySet() {
+    public Set<java.util.Map.Entry<K, V>> entrySet() {
         throw new UnsupportedOperationException();
     }
 

--- a/metamorph/src/test/java/org/metafacture/metamorph/maps/FileMapTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/maps/FileMapTest.java
@@ -39,17 +39,20 @@ public final class FileMapTest {
     @Mock
     private StreamReceiver receiver;
 
+    private static String MORPH =
+        "<rules>" +
+        "  <data source='1'>" +
+        "    <%s='map1' />" +
+        "  </data>" +
+        "</rules>" +
+        "<maps>" +
+        "  <filemap name='map1' files='org/metafacture/metamorph/maps/" +
+        "file-map-test.txt' />" +
+        "</maps>";
+
     @Test
     public void shouldLookupValuesInFileBasedMap() {
-        assertMorph(receiver,
-                "<rules>" +
-                "  <data source='1'>" +
-                "    <lookup in='map1' />" +
-                "  </data>" +
-                "</rules>" +
-                "<maps>" +
-                "  <filemap name='map1' files='org/metafacture/metamorph/maps/file-map-test.txt' />" +
-                "</maps>",
+        assertMorph(receiver, String.format(MORPH, "lookup in"),
                 i -> {
                     i.startRecord("1");
                     i.literal("1", "gw");
@@ -67,15 +70,7 @@ public final class FileMapTest {
 
     @Test
     public void shouldWhitelistValuesInFileBasedMap() {
-        assertMorph(receiver,
-                "<rules>" +
-                "  <data source='1'>" +
-                "    <whitelist map='map1' />" +
-                "  </data>" +
-                "</rules>" +
-                "<maps>" +
-                "  <filemap name='map1' files='org/metafacture/metamorph/maps/file-map-test.txt' />" +
-                "</maps>",
+        assertMorph(receiver, String.format(MORPH, "whitelist map"),
                 i -> {
                     i.startRecord("1");
                     i.literal("1", "gw");
@@ -87,6 +82,24 @@ public final class FileMapTest {
                     o.get().startRecord("1");
                     o.get().literal("1", "gw");
                     o.get().literal("1", "fj");
+                    o.get().endRecord();
+                }
+        );
+    }
+
+    @Test
+    public void shouldReplaceValuesUsingFileBasedMap() {
+        assertMorph(receiver, String.format(MORPH, "setreplace map"),
+                i -> {
+                    i.startRecord("1");
+                    i.literal("1", "gw-fj: 1:2");
+                    i.literal("1", "fj-gw: 4:0");
+                    i.endRecord();
+                },
+                o -> {
+                    o.get().startRecord("1");
+                    o.get().literal("1", "Germany-Fiji: 1:2");
+                    o.get().literal("1", "Fiji-Germany: 4:0");
                     o.get().endRecord();
                 }
         );


### PR DESCRIPTION
"AbstractReadOnlyMap" didn't allow access to the full contents of Maps. It allowed
only access by giving a key. While this makes sense when e.g. querying (big) databases
this broke the "setreplace" function where the whole Map is loaded first to be able
to replace (parts of) the input string.
Allowing access to the entrySet allows the writing of the Set(Entry). To disallow this
the map used in FileMap is made into an "unmodifiable Map".