### PR TITLE
Fix "setreplace" using a FileMap (#381)

### DIFF
--- a/metafacture-commons/src/main/java/org/metafacture/commons/tries/SetReplacer.java
+++ b/metafacture-commons/src/main/java/org/metafacture/commons/tries/SetReplacer.java
@@ -21,7 +21,6 @@ import org.metafacture.commons.tries.SetMatcher.Match;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map.Entry;
 import java.util.Map;
 
 /**
@@ -54,8 +53,8 @@ public final class SetReplacer {
      * @param replacements the Map of Strings to be replaced
      */
     public void addReplacements(final Map<String, String> replacements) {
-        for (final Entry<String, String> entry : replacements.entrySet()) {
-            addReplacement(entry.getKey(), entry.getValue());
+        for (final String k : replacements.keySet()) {
+            addReplacement(k, replacements.get(k));
         }
     }
 

--- a/metamorph-api/src/main/java/org/metafacture/metamorph/api/helpers/AbstractReadOnlyMap.java
+++ b/metamorph-api/src/main/java/org/metafacture/metamorph/api/helpers/AbstractReadOnlyMap.java
@@ -42,7 +42,7 @@ public abstract class AbstractReadOnlyMap<K, V> implements Map<K, V> {
     }
 
     @Override
-    public final boolean containsKey(final Object key) {
+    public boolean containsKey(final Object key) {
         return get(key) != null;
     }
 

--- a/metamorph-api/src/main/java/org/metafacture/metamorph/api/helpers/AbstractReadOnlyMap.java
+++ b/metamorph-api/src/main/java/org/metafacture/metamorph/api/helpers/AbstractReadOnlyMap.java
@@ -21,8 +21,9 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Base class for maps which are read only and do not allow access to their
- * full contents.
+ * Base class for maps which are read only. Allows access to the key set. It's
+ * up to the extending class when overriding {@link #keySet()} to return an
+ * {@link java.util.Collections#unmodifiableSet(Set)}.
  *
  * @param <K> type of keys
  * @param <V> type of values
@@ -71,8 +72,12 @@ public abstract class AbstractReadOnlyMap<K, V> implements Map<K, V> {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * It's up to the extending class to return an
+     * {@link java.util.Collections#unmodifiableSet(Set)} when overriding.
+     */
     @Override
-    public final Set<K> keySet() {
+    public Set<K> keySet() {
         throw new UnsupportedOperationException();
     }
 

--- a/metamorph/src/main/java/org/metafacture/metamorph/maps/FileMap.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/maps/FileMap.java
@@ -29,9 +29,11 @@ import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 /**
@@ -146,6 +148,11 @@ public final class FileMap extends AbstractReadOnlyMap<String, String> {
     @Override
     public String get(final Object key) {
         return map.get(key);
+    }
+
+    @Override
+    public Set<String> keySet() {
+        return Collections.unmodifiableSet(map.keySet());
     }
 
 }

--- a/metamorph/src/test/java/org/metafacture/metamorph/maps/FileMapTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/maps/FileMapTest.java
@@ -39,17 +39,20 @@ public final class FileMapTest {
     @Mock
     private StreamReceiver receiver;
 
+    private static String MORPH =
+        "<rules>" +
+        "  <data source='1'>" +
+        "    <%s='map1' />" +
+        "  </data>" +
+        "</rules>" +
+        "<maps>" +
+        "  <filemap name='map1' files='org/metafacture/metamorph/maps/" +
+        "file-map-test.txt' />" +
+        "</maps>";
+
     @Test
     public void shouldLookupValuesInFileBasedMap() {
-        assertMorph(receiver,
-                "<rules>" +
-                "  <data source='1'>" +
-                "    <lookup in='map1' />" +
-                "  </data>" +
-                "</rules>" +
-                "<maps>" +
-                "  <filemap name='map1' files='org/metafacture/metamorph/maps/file-map-test.txt' />" +
-                "</maps>",
+        assertMorph(receiver, String.format(MORPH, "lookup in"),
                 i -> {
                     i.startRecord("1");
                     i.literal("1", "gw");
@@ -67,15 +70,7 @@ public final class FileMapTest {
 
     @Test
     public void shouldWhitelistValuesInFileBasedMap() {
-        assertMorph(receiver,
-                "<rules>" +
-                "  <data source='1'>" +
-                "    <whitelist map='map1' />" +
-                "  </data>" +
-                "</rules>" +
-                "<maps>" +
-                "  <filemap name='map1' files='org/metafacture/metamorph/maps/file-map-test.txt' />" +
-                "</maps>",
+        assertMorph(receiver, String.format(MORPH, "whitelist map"),
                 i -> {
                     i.startRecord("1");
                     i.literal("1", "gw");
@@ -87,6 +82,24 @@ public final class FileMapTest {
                     o.get().startRecord("1");
                     o.get().literal("1", "gw");
                     o.get().literal("1", "fj");
+                    o.get().endRecord();
+                }
+        );
+    }
+
+    @Test
+    public void shouldReplaceValuesUsingFileBasedMap() {
+        assertMorph(receiver, String.format(MORPH, "setreplace map"),
+                i -> {
+                    i.startRecord("1");
+                    i.literal("1", "gw-fj: 1:1");
+                    i.literal("1", "fj-gw: 0:0");
+                    i.endRecord();
+                },
+                o -> {
+                    o.get().startRecord("1");
+                    o.get().literal("1", "Germany-Fiji: 1:1");
+                    o.get().literal("1", "Fiji-Germany: 0:0");
                     o.get().endRecord();
                 }
         );


### PR DESCRIPTION
"AbstractReadOnlyMap" didn't allow access to the full contents of Maps.
This broke the "setreplace" function where the whole Map is loaded first to be able
to replace (parts of) the input string.