### PR TITLE
Allow empty values in setreplace map (#420)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -34,5 +34,8 @@ indent_size = 2
 [metafacture-io/src/test/resources/org/metafacture/io/compressed.txt]
 insert_final_newline = false
 
+[metamorph/src/test/resources/org/metafacture/metamorph/maps/file-map-test.txt]
+trim_trailing_whitespace = false
+
 [metafacture-runner/src/main/dist/config/java-options.conf]
 end_of_line = crlf

--- a/metamorph/src/main/resources/schemata/metamorph.xsd
+++ b/metamorph/src/main/resources/schemata/metamorph.xsd
@@ -587,7 +587,6 @@
         </complexType>
     </element>
 
-
     <element name="filemap">
         <annotation>
             <documentation>Lookup table defined by text files</documentation>
@@ -598,16 +597,21 @@
                     <documentation>Unique name of the lookup table</documentation>
                 </annotation>
             </attribute>
-            <attribute name="files" type="string" use="required">
+            <attribute name="allowEmptyValues" type="boolean" use="optional" default="false">
                 <annotation>
-                    <documentation>Filenames</documentation>
+                    <documentation>Allow empty values in Map.</documentation>
                 </annotation>
             </attribute>
-            <attribute name="separator" type="string" use="optional"
-                default="\t">
+            <attribute name="files" type="string" use="required">
                 <annotation>
-                    <documentation>String used in the files to separate key from value.
-                    </documentation>
+                    <documentation>Filename(s) referencing the lookup table(s). Can be one
+                        filename or a comma separated list of filenames.</documentation>
+                </annotation>
+            </attribute>
+            <attribute name="separator" type="string" use="optional" default="&#09;">
+                <annotation>
+                    <documentation>String used in the files to separate keys from values.
+                        The default separator is the tabulator. </documentation>
                 </annotation>
             </attribute>
             <attribute ref="xml:base" />
@@ -795,7 +799,7 @@
 
     <element name="setreplace">
         <annotation>
-            <documentation>Relace strings based on a replacement table.
+            <documentation>Replace strings based on a replacement table.
             </documentation>
         </annotation>
         <complexType>

--- a/metamorph/src/test/java/org/metafacture/metamorph/maps/FileMapTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/maps/FileMapTest.java
@@ -47,12 +47,12 @@ public final class FileMapTest {
         "</rules>" +
         "<maps>" +
         "  <filemap name='map1' files='org/metafacture/metamorph/maps/" +
-        "file-map-test.txt' />" +
+        "file-map-test.txt' %s/>" +
         "</maps>";
 
     @Test
     public void shouldLookupValuesInFileBasedMap() {
-        assertMorph(receiver, String.format(MORPH, "lookup in"),
+        assertMorph(receiver, String.format(MORPH, "lookup in", ""),
                 i -> {
                     i.startRecord("1");
                     i.literal("1", "gw");
@@ -70,7 +70,7 @@ public final class FileMapTest {
 
     @Test
     public void shouldWhitelistValuesInFileBasedMap() {
-        assertMorph(receiver, String.format(MORPH, "whitelist map"),
+        assertMorph(receiver, String.format(MORPH, "whitelist map", ""),
                 i -> {
                     i.startRecord("1");
                     i.literal("1", "gw");
@@ -89,7 +89,7 @@ public final class FileMapTest {
 
     @Test
     public void shouldReplaceValuesUsingFileBasedMap() {
-        assertMorph(receiver, String.format(MORPH, "setreplace map"),
+        assertMorph(receiver, String.format(MORPH, "setreplace map", ""),
                 i -> {
                     i.startRecord("1");
                     i.literal("1", "gw-fj: 1:1");
@@ -105,4 +105,53 @@ public final class FileMapTest {
         );
     }
 
+    @Test
+    public void shouldReplaceCommaSeparatedValuesUsingFileBasedMapSetting() {
+        assertMorph(receiver, String.format(MORPH, "setreplace map", "separator=\",\""),
+                i -> {
+                    i.startRecord("1");
+                    i.literal("1", "gw");
+                    i.literal("1", "ry\tRyukyuIslands");
+                    i.endRecord();
+                },
+                o -> {
+                    o.get().startRecord("1");
+                    o.get().literal("1", "gw");
+                    o.get().literal("1", "Southern");
+                    o.get().endRecord();
+                }
+        );
+    }
+
+    @Test
+    public void shouldReplaceEmptyValuesUsingFileBasedMapSetting() {
+        assertMorph(receiver, String.format(MORPH, "setreplace map", "allowEmptyValues=\"true\""),
+                i -> {
+                    i.startRecord("1");
+                    i.literal("1", "zz");
+                    i.endRecord();
+                },
+                o -> {
+                    o.get().startRecord("1");
+                    o.get().literal("1", "");
+                    o.get().endRecord();
+                }
+        );
+    }
+
+    @Test
+    public void shouldNotReplaceEmptyValuesUsingFileBasedMapSetting() {
+        assertMorph(receiver, String.format(MORPH, "setreplace map", ""),
+                i -> {
+                    i.startRecord("1");
+                    i.literal("1", "zz");
+                    i.endRecord();
+                },
+                o -> {
+                    o.get().startRecord("1");
+                    o.get().literal("1", "zz");
+                    o.get().endRecord();
+                }
+        );
+    }
 }

--- a/metamorph/src/test/resources/org/metafacture/metamorph/maps/file-map-test.txt
+++ b/metamorph/src/test/resources/org/metafacture/metamorph/maps/file-map-test.txt
@@ -378,3 +378,4 @@ ykc	YukonTerritory
 ys	Yemen(People'sDemocraticRepublic)
 yu	SerbiaandMontenegro
 za	Zambia
+zz	


### PR DESCRIPTION
Allowing empty values in the map enables the SetReplacer to remove matching
keys.

Also fixes setting the separator by using an init() to avoid loading the map
without taking all settings into account.

Adds a rule to .editorconfig to allow the test map having trailing tabs.