### PR TITLE
Metafacture core 5.3.1rc

### DIFF
--- a/metafacture-biblio/build.gradle
+++ b/metafacture-biblio/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     exclude group: 'xercesImpl', module: 'xercesImpl'
     exclude group: 'xml-apis', module: 'xml-apis'
   }
-  implementation 'org.apache.logging.log4j:log4j-core:2.14.1'
+  implementation 'log4j:log4j:1.2.17'
   testImplementation 'junit:junit:4.12'
   testImplementation 'org.mockito:mockito-core:2.5.5'
 }

--- a/metafacture-xml/src/main/java/org/metafacture/xml/FilenameExtractor.java
+++ b/metafacture-xml/src/main/java/org/metafacture/xml/FilenameExtractor.java
@@ -92,72 +92,158 @@ public interface FilenameExtractor extends RecordIdentifier {
         private int endIndex;
         private int startIndex;
 
-        FilenameUtil() {
+        /**
+         * Default constructor
+         */
+        public FilenameUtil() {
         }
 
         /**
          * Ensures that path exists. If not, make it.
          *
          * @param path
-         *            the path of the to be stored file.
+         *            the path of the to be stored file
          */
         public void ensurePathExists(final File path) {
             final File parent = path.getAbsoluteFile().getParentFile();
             parent.mkdirs();
         }
 
+        /**
+         * Sets the encoding used to open the resource.
+         *
+         * @param encoding
+         *            new encoding
+         */
         public void setEncoding(final String encoding) {
             this.encoding = encoding;
         }
 
+        /**
+         * Returns the encoding used to open the resource.
+         *
+         * @return current default setting
+         */
         public String getEncoding() {
             return encoding;
         }
 
+        /**
+         * Sets the suffix of the files.
+         *
+         * @param fileSuffix
+         *              the suffix of the files
+         */
         public void setFileSuffix(final String fileSuffix) {
             this.fileSuffix = fileSuffix;
         }
 
+        /**
+         * Gets the suffix of the file.
+         *
+         * @return the suffix of the file
+         */
         public String getFileSuffix() {
             return fileSuffix;
         }
 
+        /**
+         * Sets the filename.
+         *
+         * @param filename
+         *              the name of the file
+         */
         public void setFilename(final String filename) {
             this.filename = filename;
         }
 
+        /**
+         * Gets the filename.
+         *
+         * @return the name of the file
+         *
+         */
         public String getFilename() {
             return filename;
         }
 
+        /**
+         * Sets the property which is used as the base of the filename.
+         * Recommended properties are identifiers.
+         *
+         * @param property
+         *              the property which will be used for the base name of the file
+         */
         public void setProperty(final String property) {
             this.property = property;
         }
 
+        /**
+         * Gets the property which is the base of the filename.
+         *
+         * @return the property which is the base name of the file
+         */
         public String getProperty() {
             return property;
         }
 
+        /**
+         * Sets the target path.
+         *
+         * @param target
+         *            the basis directory in which the files are stored
+         */
         public void setTarget(final String target) {
             this.target = target;
         }
 
+        /**
+         * Gets the target path.
+         *
+         * @return the basis directory in which the files are stored
+         */
         public String getTarget() {
             return target;
         }
 
+        /**
+         * Sets the end of the index in the filename to extract the name of a
+         * subfolder.
+         *
+         * @param endIndex
+         *            this marks the index' end
+         */
         public void setEndIndex(final int endIndex) {
             this.endIndex = endIndex;
         }
 
+        /**
+         * Gets the end of the index in the filename to extract the name of a
+         * subfolder.
+         *
+         * @return the marker of the index' end
+         */
         public int getEndIndex() {
             return endIndex;
         }
 
+        /**
+         * Sets the beginning of the index in the filename to extract the name of
+         * the subfolder.
+         *
+         * @param startIndex
+         *            This marks the index' beginning
+         */
         public void setStartIndex(final int startIndex) {
             this.startIndex = startIndex;
         }
 
+        /**
+         * Gets the beginning of the index in the filename to extract the name of
+         * the subfolder.
+         *
+         * @return the marker of the index' beginning
+         */
         public int getStartIndex() {
             return startIndex;
         }


### PR DESCRIPTION
This is the branch for testing metafacture-core release candidate 5.3.1.
It follows up https://github.com/metafacture/metafacture-core/issues/397.

Based on the experience we've made with the release of [metafacture-core 5.3.0](https://github.com/metafacture/metafacture-core/releases/tag/metafacture-core-5.3.0) (which is deprecated resp. not recommended for usage) it was  [discussed with @blackwinter ](https://chat.gwdg.de/channel/Metafacture) the need to better test release candidates before actually releasing them (this is also reflected now in the [Maintainer Guidelines](https://github.com/metafacture/metafacture-core/wiki/Maintainer-Guidelines#making-a-release)).

@blackwinter found the dependency upgrade of `log4j:1.2.12'` to `log4j-core:2.14.` problematic, so this is reverted in 36ed96920c70a0173abb75f39ed28ca8bbba7bab.

I have tested `5.3.0` against [lobid-resources](https://github.com/hbz/lobid-resources/) and found an incompatibility which I reverted in 7c1ea04c6012fbea661a86d73e6c0ef8f8f53ff8.

Furthermore, I found out that if you are using a `metamorph.xsd` of your own and make use of `FileMap` you have to also update your locally `metamorph.xsd` (like the one at https://github.com/hbz/lobid-resources/blob/master/src/main/resources/schemata/metamorph.xsd):
```
-      <attribute name="separator" type="string" use="optional" default="\t">
+      <attribute name="separator" type="string" use="optional" default="&#09;">
```
As this will occur only quite rarely (is there anybody out there using a local duplicate of `metamorph.xsd` ?) and this is the result of a bug fix (d528ac973a7b6a1bb0b846a6d90950ace9553742) (in effect the default separator defined (falsely) in `metamorph.xsd` has had no effect at all) this "breaking" fix will be part of the release (or is anyone against this?) but the release would come with the here mentioned note.
