### PR TITLE
Call LineRecorder receiver's closeStream() (#433)

### DIFF
--- a/metafacture-strings/src/main/java/org/metafacture/strings/LineRecorder.java
+++ b/metafacture-strings/src/main/java/org/metafacture/strings/LineRecorder.java
@@ -81,7 +81,9 @@ public final class LineRecorder implements ObjectPipe<String, ObjectReceiver<Str
 
     @Override
     public void closeStream() {
+        assert !isClosed();
         getReceiver().process(record.toString());
+        getReceiver().closeStream();
         isClosed = true;
     }
 

--- a/metafacture-strings/src/test/java/org/metafacture/strings/LineRecorderTest.java
+++ b/metafacture-strings/src/test/java/org/metafacture/strings/LineRecorderTest.java
@@ -111,6 +111,7 @@ public final class LineRecorderTest {
                 LINE_SEPARATOR +
                 RECORD3_PART2 +
                 LINE_SEPARATOR);
+        ordered.verify(receiver).closeStream();
         ordered.verifyNoMoreInteractions();
     }
 


### PR DESCRIPTION
Under some circumstances (probably if the JVM is not stopped after processing)
the streams of receivers connected to LineRecorder are not closed, resulting
in empty or missing output data.

- complement test

See #433.