### PR TITLE
Use "protected" on all "on...()" methods (#435)

### DIFF
--- a/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/PojoEncoder.java
+++ b/metafacture-javaintegration/src/main/java/org/metafacture/javaintegration/pojo/PojoEncoder.java
@@ -107,12 +107,12 @@ public class PojoEncoder<T> extends DefaultStreamPipe<ObjectReceiver<T>> {
     }
 
     @Override
-    public void onCloseStream() {
+    protected void onCloseStream() {
         typeEncoderStack.clear();
     }
 
     @Override
-    public void onResetStream() {
+    protected void onResetStream() {
         typeEncoderStack.clear();
     }
 

--- a/metafacture-mangling/src/main/java/org/metafacture/mangling/RecordIdChanger.java
+++ b/metafacture-mangling/src/main/java/org/metafacture/mangling/RecordIdChanger.java
@@ -217,18 +217,18 @@ public final class RecordIdChanger extends DefaultStreamPipe<StreamReceiver> {
     }
 
     @Override
-    public void onSetReceiver() {
+    protected void onSetReceiver() {
         streamBuffer.setReceiver(getReceiver());
     }
 
     @Override
-    public void onResetStream() {
+    protected void onResetStream() {
         streamBuffer.clear();
         entityPathTracker.resetStream();
     }
 
     @Override
-    public void onCloseStream() {
+    protected void onCloseStream() {
         streamBuffer.clear();
         entityPathTracker.closeStream();
     }

--- a/metafacture-mangling/src/main/java/org/metafacture/mangling/RecordPathFilter.java
+++ b/metafacture-mangling/src/main/java/org/metafacture/mangling/RecordPathFilter.java
@@ -166,13 +166,13 @@ public final class RecordPathFilter extends DefaultStreamPipe<StreamReceiver> {
     }
 
     @Override
-    public void onResetStream() {
+    protected void onResetStream() {
         entityPathTracker.resetStream();
         resetRecord();
     }
 
     @Override
-    public void onCloseStream() {
+    protected void onCloseStream() {
         entityPathTracker.closeStream();
     }
 

--- a/metafacture-statistics/src/main/java/org/metafacture/statistics/Counter.java
+++ b/metafacture-statistics/src/main/java/org/metafacture/statistics/Counter.java
@@ -112,7 +112,7 @@ public final class Counter extends DefaultStreamPipe<StreamReceiver> {
     }
 
     @Override
-    public void onResetStream() {
+    protected void onResetStream() {
         numRecords = 0;
         numEntities = 0;
         numLiterals = 0;

--- a/metafacture-strings/src/main/java/org/metafacture/strings/LineRecorder.java
+++ b/metafacture-strings/src/main/java/org/metafacture/strings/LineRecorder.java
@@ -78,7 +78,7 @@ public final class LineRecorder extends DefaultObjectPipe<String, ObjectReceiver
     }
 
     @Override
-    public void onResetStream() {
+    protected void onResetStream() {
         record = new StringBuilder(SB_CAPACITY);
     }
 

--- a/metafacture-xml/src/main/java/org/metafacture/xml/XmlElementSplitter.java
+++ b/metafacture-xml/src/main/java/org/metafacture/xml/XmlElementSplitter.java
@@ -192,7 +192,7 @@ public final class XmlElementSplitter extends DefaultXmlPipe<StreamReceiver> {
     }
 
     @Override
-    public void onResetStream() {
+    protected void onResetStream() {
         reset();
     }
 

--- a/metamorph/src/main/java/org/metafacture/metamorph/Entity.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/Entity.java
@@ -124,7 +124,7 @@ public final class Entity extends AbstractFlushingCollect {
     }
 
     @Override
-    public void onNamedValueSourceAdded(final NamedValueSource namedValueSource) {
+    protected void onNamedValueSourceAdded(final NamedValueSource namedValueSource) {
         sourceList.add(namedValueSource);
         sourcesLeft.add(namedValueSource);
     }

--- a/metamorph/src/main/java/org/metafacture/metamorph/collectors/All.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/collectors/All.java
@@ -67,7 +67,7 @@ public final class All extends AbstractFlushingCollect {
     }
 
     @Override
-    public void onNamedValueSourceAdded(final NamedValueSource namedValueSource) {
+    protected void onNamedValueSourceAdded(final NamedValueSource namedValueSource) {
         sources.add(namedValueSource);
         sourcesLeft.add(namedValueSource);
     }

--- a/metamorph/src/main/java/org/metafacture/metamorph/collectors/Choose.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/collectors/Choose.java
@@ -79,7 +79,7 @@ public final class Choose extends AbstractFlushingCollect {
     }
 
     @Override
-    public void onNamedValueSourceAdded(final NamedValueSource namedValueSource) {
+    protected void onNamedValueSourceAdded(final NamedValueSource namedValueSource) {
         priorities.put(namedValueSource, Integer.valueOf(nextPriority));
         nextPriority += 1;
     }

--- a/metamorph/src/main/java/org/metafacture/metamorph/collectors/Combine.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/collectors/Combine.java
@@ -61,7 +61,7 @@ public final class Combine extends AbstractFlushingCollect {
     }
 
     @Override
-    public void onNamedValueSourceAdded(final NamedValueSource namedValueSource) {
+    protected void onNamedValueSourceAdded(final NamedValueSource namedValueSource) {
         sources.add(namedValueSource);
         sourcesLeft.add(namedValueSource);
     }

--- a/metamorph/src/main/java/org/metafacture/metamorph/collectors/EqualsFilter.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/collectors/EqualsFilter.java
@@ -68,7 +68,7 @@ public final class EqualsFilter extends AbstractFlushingCollect {
     }
 
     @Override
-    public void onNamedValueSourceAdded(final NamedValueSource namedValueSource) {
+    protected void onNamedValueSourceAdded(final NamedValueSource namedValueSource) {
         sources.add(namedValueSource);
         sourcesLeft.add(namedValueSource);
     }


### PR DESCRIPTION
Came up in https://github.com/metafacture/metafacture-core/pull/435#event-5835411316.

Some "@override" methods used the "public" modifier, which is not necessary. Looking at
the base classes of these classes a "protected" modifier was used, so "protected" seems
to be intentionally.

