### PR TITLE
Throw RuntimeException in FluxParser (#421)

### DIFF
--- a/metafacture-flux/build.gradle
+++ b/metafacture-flux/build.gradle
@@ -23,6 +23,7 @@ dependencies {
   api project(':metafacture-framework')
   implementation project(':metafacture-commons')
   implementation project(':metafacture-io')
+  implementation project(':metafacture-plumbing')
   antlr 'org.antlr:antlr:3.5.2'
   testImplementation 'junit:junit:4.12'
 }

--- a/metafacture-flux/src/main/antlr/org/metafacture/flux/parser/Flux.g
+++ b/metafacture-flux/src/main/antlr/org/metafacture/flux/parser/Flux.g
@@ -60,6 +60,12 @@ varDef
     ->
       ^(ASSIGN Identifier exp)
   ;
+catch [RecognitionException re] {
+    reportError(re);
+    recover(input,re);
+    retval.tree = (CommonTree)adaptor.errorNode(input, retval.start, input.LT(-1), re);
+    throw re;
+}
 
 flow
   :

--- a/metafacture-flux/src/main/antlr/org/metafacture/flux/parser/Flux.g
+++ b/metafacture-flux/src/main/antlr/org/metafacture/flux/parser/Flux.g
@@ -61,9 +61,6 @@ varDef
       ^(ASSIGN Identifier exp)
   ;
 catch [RecognitionException re] {
-    reportError(re);
-    recover(input,re);
-    retval.tree = (CommonTree)adaptor.errorNode(input, retval.start, input.LT(-1), re);
     throw re;
 }
 
@@ -77,9 +74,6 @@ flow
   '|'! flowtail ('|'! Wormhole)? ';'!
   ;
 catch [RecognitionException re] {
-    reportError(re);
-    recover(input,re);
-    retval.tree = (CommonTree)adaptor.errorNode(input, retval.start, input.LT(-1), re);
     throw re;
 }
 

--- a/metafacture-flux/src/main/antlr/org/metafacture/flux/parser/Flux.g
+++ b/metafacture-flux/src/main/antlr/org/metafacture/flux/parser/Flux.g
@@ -43,6 +43,13 @@ flux
   :
   varDef* flow*
   ;
+catch [RecognitionException re] {
+    reportError(re);
+    recover(input,re);
+    retval.tree = (CommonTree)adaptor.errorNode(input, retval.start, input.LT(-1), re);
+    String msg = getErrorMessage(re, this.getTokenNames()) + " in Flux";
+    throw new RuntimeException(msg, re);
+}
 
 varDef
   :
@@ -63,6 +70,12 @@ flow
   )
   '|'! flowtail ('|'! Wormhole)? ';'!
   ;
+catch [RecognitionException re] {
+    reportError(re);
+    recover(input,re);
+    retval.tree = (CommonTree)adaptor.errorNode(input, retval.start, input.LT(-1), re);
+    throw re;
+}
 
 tee
   :

--- a/metafacture-flux/src/main/antlr/org/metafacture/flux/parser/Flux.g
+++ b/metafacture-flux/src/main/antlr/org/metafacture/flux/parser/Flux.g
@@ -33,6 +33,8 @@ tokens {
 
 @header {
 package org.metafacture.flux.parser;
+
+import org.metafacture.flux.FluxParseException;
 }
 
 @lexer::header {
@@ -48,7 +50,7 @@ catch [RecognitionException re] {
     recover(input,re);
     retval.tree = (CommonTree)adaptor.errorNode(input, retval.start, input.LT(-1), re);
     String msg = getErrorMessage(re, this.getTokenNames()) + " in Flux";
-    throw new RuntimeException(msg, re);
+    throw new FluxParseException(msg, re);
 }
 
 varDef

--- a/metafacture-flux/src/main/java/org/metafacture/flux/parser/Flow.java
+++ b/metafacture-flux/src/main/java/org/metafacture/flux/parser/Flow.java
@@ -75,7 +75,7 @@ final class Flow {
             }
         }
         else {
-            throw new FluxParseException(element.getClass().getCanonicalName() + "is not a sender");
+            throw new FluxParseException(element.getClass().getCanonicalName() + " is not a sender");
         }
         element = nextElement;
     }

--- a/metafacture-flux/src/test/java/org/metafacture/flux/FluxGrammarTest.java
+++ b/metafacture-flux/src/test/java/org/metafacture/flux/FluxGrammarTest.java
@@ -89,6 +89,18 @@ public final class FluxGrammarTest {
                 stdoutBuffer.toString());
     }
 
+    @Test(expected = RuntimeException.class)
+    public void issue421_shouldThrowRuntimeExceptionWhenSemicolonIsMissing()
+        throws RecognitionException, IOException {
+        final String script = "\"test\"|print";
+        try {
+            FluxCompiler.compile(createInputStream(script), emptyMap());
+        } catch (RuntimeException re) {
+            assertEquals("mismatched input '<EOF>' expecting ';' in Flux", re.getMessage());
+            throw re;
+        }
+    }
+
     private ByteArrayInputStream createInputStream(String script) {
         return new ByteArrayInputStream(script.getBytes(StandardCharsets.UTF_8));
     }

--- a/metafacture-flux/src/test/java/org/metafacture/flux/FluxGrammarTest.java
+++ b/metafacture-flux/src/test/java/org/metafacture/flux/FluxGrammarTest.java
@@ -54,7 +54,7 @@ public final class FluxGrammarTest {
     @Test
     public void shouldAllowEmptyCommentInLastLineOfFile()
             throws RecognitionException, IOException {
-        final String script = "\"test\"|write(\"stdout\"); //";
+        final String script = "\"test\"|print; //";
 
         FluxCompiler.compile(createInputStream(script), emptyMap());
 
@@ -65,7 +65,7 @@ public final class FluxGrammarTest {
     @Test
     public void shouldAllowEmptyCommentInFile()
             throws RecognitionException, IOException {
-        final String script = "\"test\"|write(\"stdout\"); //\n";
+        final String script = "\"test\"|print; //\n";
 
         FluxCompiler.compile(createInputStream(script), emptyMap());
 
@@ -78,7 +78,7 @@ public final class FluxGrammarTest {
             throws IOException, RecognitionException {
         final String script =
                 "\"quot=\\\" octal1=\\7 octal2=\\60 octal3=\\103 unicode=\\u00f8 tab=[\\t]\"" +
-                        "|write(\"stdout\");";
+                        "|print;";
 
         final FluxProgramm program = FluxCompiler.compile(
                 createInputStream(script), emptyMap());

--- a/metafacture-flux/src/test/java/org/metafacture/flux/FluxGrammarTest.java
+++ b/metafacture-flux/src/test/java/org/metafacture/flux/FluxGrammarTest.java
@@ -29,6 +29,7 @@ import org.antlr.runtime.RecognitionException;
 import org.junit.Before;
 import org.junit.Test;
 import org.metafacture.flux.parser.FluxProgramm;
+import org.metafacture.framework.MetafactureException;
 
 /**
  * Tests for the Flux grammar.
@@ -89,15 +90,15 @@ public final class FluxGrammarTest {
                 stdoutBuffer.toString());
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = FluxParseException.class)
     public void issue421_shouldThrowRuntimeExceptionWhenSemicolonInFlowIsMissing()
         throws RecognitionException, IOException {
         final String script = "\"test\"|print";
         try {
             FluxCompiler.compile(createInputStream(script), emptyMap());
-        } catch (RuntimeException re) {
-            assertEquals("mismatched input '<EOF>' expecting ';' in Flux", re.getMessage());
-            throw re;
+        } catch (FluxParseException fpe) {
+            assertEquals("mismatched input '<EOF>' expecting ';' in Flux", fpe.getMessage());
+            throw fpe;
         }
     }
 

--- a/metafacture-flux/src/test/java/org/metafacture/flux/FluxGrammarTest.java
+++ b/metafacture-flux/src/test/java/org/metafacture/flux/FluxGrammarTest.java
@@ -90,9 +90,21 @@ public final class FluxGrammarTest {
     }
 
     @Test(expected = RuntimeException.class)
-    public void issue421_shouldThrowRuntimeExceptionWhenSemicolonIsMissing()
+    public void issue421_shouldThrowRuntimeExceptionWhenSemicolonInFlowIsMissing()
         throws RecognitionException, IOException {
         final String script = "\"test\"|print";
+        try {
+            FluxCompiler.compile(createInputStream(script), emptyMap());
+        } catch (RuntimeException re) {
+            assertEquals("mismatched input '<EOF>' expecting ';' in Flux", re.getMessage());
+            throw re;
+        }
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void issue421_shouldThrowRuntimeExceptionWhenSemicolonInVarDefIsMissing()
+        throws RecognitionException, IOException {
+        final String script = "foo=42";
         try {
             FluxCompiler.compile(createInputStream(script), emptyMap());
         } catch (RuntimeException re) {


### PR DESCRIPTION
If a `RecognitionException` occurs in `FluxParser` it was catched. So callers had
no chance to be aware of the Exception.
As it's not possible to create a new `RecognitionException` with a customized
error message (and throw this new `RecognitionException`) and also to be
backwards compatibel (`RuntimeExceptions` are referred to as unchecked exceptions
and the code would compile just as before) no checked Exception is thrown but
a `RuntimeException` with the customized error message.

Resolves #421.