### PR TITLE
Deprecate parameter "prettyPrinting"

### DIFF
--- a/metafacture-yaml/src/main/java/org/metafacture/yaml/YamlEncoder.java
+++ b/metafacture-yaml/src/main/java/org/metafacture/yaml/YamlEncoder.java
@@ -30,7 +30,6 @@ import com.fasterxml.jackson.core.JsonStreamContext;
 import com.fasterxml.jackson.core.SerializableString;
 import com.fasterxml.jackson.core.io.CharacterEscapes;
 import com.fasterxml.jackson.core.io.SerializedString;
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 
@@ -47,7 +46,7 @@ import java.io.StringWriter;
  * @author Jens Wille
  *
  */
-@Description("Serialises an object as YAML")
+@Description("Serialises an object as YAML. The paramter 'prettyprinting (boolean)' is deprecated since it's not possible to not pretty print.")
 @In(StreamReceiver.class)
 @Out(String.class)
 @FluxCommand("encode-yaml")
@@ -95,20 +94,27 @@ public final class YamlEncoder extends DefaultStreamPipe<ObjectReceiver<String>>
 
     /**
      * Flags whether the data should be pretty printed.
+     * @deprecated
+     * Jackson's YAMLGenerator ignores any PrettyPrinter. It's always
+     * pretty printed.
      *
      * @param prettyPrinting true if the data should be pretty printed
      */
+    @Deprecated
     public void setPrettyPrinting(final boolean prettyPrinting) {
-        yamlGenerator.setPrettyPrinter(prettyPrinting ? new DefaultPrettyPrinter((SerializableString) null) : null);
     }
 
     /**
      * Checks whether to pretty print.
+     * @deprecated
+     * Jackson's YAMLGenerator ignores any PrettyPrinter. It's always
+     * pretty printed.
      *
      * @return true if the data should be pretty printed
      */
+    @Deprecated
     public boolean getPrettyPrinting() {
-        return yamlGenerator.getPrettyPrinter() != null;
+        return true;
     }
 
     /**

--- a/metafacture-yaml/src/test/java/org/metafacture/yaml/YamlEncoderTest.java
+++ b/metafacture-yaml/src/test/java/org/metafacture/yaml/YamlEncoderTest.java
@@ -277,8 +277,6 @@ public final class YamlEncoderTest {
     public void testShouldPrefixPrettyPrintedOutputWithNewline() {
         assertEncode(
                 i -> {
-                    i.setPrettyPrinting(true);
-
                     i.startRecord("");
                     i.literal(LITERAL1, VALUE1);
                     i.endRecord();

--- a/metafacture-yaml/src/test/java/org/metafacture/yaml/YamlEncoderTest.java
+++ b/metafacture-yaml/src/test/java/org/metafacture/yaml/YamlEncoderTest.java
@@ -273,25 +273,6 @@ public final class YamlEncoderTest {
         );
     }
 
-    @Test
-    public void testShouldPrefixPrettyPrintedOutputWithNewline() {
-        assertEncode(
-                i -> {
-                    i.startRecord("");
-                    i.literal(LITERAL1, VALUE1);
-                    i.endRecord();
-                    i.startRecord("");
-                    i.literal(LITERAL2, VALUE2);
-                    i.endRecord();
-                },
-                "---\n" +
-                "L1: 'V1'",
-                "\n" +
-                "---\n" +
-                "L2: 'V2'"
-        );
-    }
-
     private void assertEncode(final Consumer<YamlEncoder> in, final String... out) {
         final InOrder ordered = Mockito.inOrder(receiver);
 


### PR DESCRIPTION
Jackson's YAMLGenerator ignores any PrettyPrinter. It's always
pretty printed.

- mark methods as deprecated
- note deprecation in description
- update test

See metafacture/metafacture-documentation#19.