### PR TITLE
Fix rendering

### DIFF
--- a/metafacture-formatting/src/main/java/org/metafacture/formatting/ObjectTemplate.java
+++ b/metafacture-formatting/src/main/java/org/metafacture/formatting/ObjectTemplate.java
@@ -31,9 +31,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Builds a {@link String} from a template and an {@link Object}. ${o} marks
- * the place where the object is to be inserted. If the received object in an
- * instance of Triple ${s}, ${p} and ${o} are used instead.
+ * Builds a {@link String} from a template and an {@link Object}. `${o}` marks
+ * the place where the object is to be inserted. If the received object is an
+ * instance of Triple`${s}`, `${p}` and `${o}` are used instead.
  *
  * @param <T>
  *            object type
@@ -41,8 +41,8 @@ import java.util.regex.Pattern;
  * @author Markus Geipel
  *
  */
-@Description("Builds a String from a template and an Object. Provide template in brackets. ${o} marks the place where the object is to be inserted. " +
-        "If the object is an instance of Triple ${s}, ${p} and ${o} are used instead.")
+@Description("Builds a String from a template and an Object. Provide template in brackets. `${o}` marks the place where the object is to be inserted. " +
+        "If the object is an instance of Triple `${s}`, `${p}` and `${o}` are used instead.")
 @In(Object.class)
 @Out(String.class)
 @FluxCommand("template")


### PR DESCRIPTION
Newly introduced math support for rendering markdown in github breaks
the rendering for things like '{}'. Escaping fixes this.

Fixes https://github.com/metafacture/metafacture-documentation/issues/17.