### PR TITLE
Mark deprecated Flux command options in help output.

### DIFF
--- a/metafacture-commons/src/main/java/org/metafacture/commons/reflection/ConfigurableClass.java
+++ b/metafacture-commons/src/main/java/org/metafacture/commons/reflection/ConfigurableClass.java
@@ -99,15 +99,24 @@ public final class ConfigurableClass<T> {
     }
 
     /**
+     * Gets the parameter type of the setter method.
+     *
+     * @param method the setter method
+     * @return the type
+     */
+    public Class<?> getSetterType(final Method method) {
+        return method.getParameterTypes()[0];
+    }
+
+    /**
      * Gets the parameter types of the setter methods.
      *
      * @return a Map of the setter method names and their types
      */
     public Map<String, Class<?>> getSetterTypes() {
         final Map<String, Class<?>> setterTypes = new HashMap<>();
-        for (final Map.Entry<String, Method> method : getSetters().entrySet()) {
-            final Class<?> setterType = method.getValue().getParameterTypes()[0];
-            setterTypes.put(method.getKey(), setterType);
+        for (final Map.Entry<String, Method> entry : getSetters().entrySet()) {
+            setterTypes.put(entry.getKey(), getSetterType(entry.getValue()));
         }
         return setterTypes;
     }

--- a/metafacture-yaml/src/main/java/org/metafacture/yaml/YamlEncoder.java
+++ b/metafacture-yaml/src/main/java/org/metafacture/yaml/YamlEncoder.java
@@ -46,7 +46,7 @@ import java.io.StringWriter;
  * @author Jens Wille
  *
  */
-@Description("Serialises an object as YAML. The paramter 'prettyprinting (boolean)' is deprecated since it's not possible to not pretty print.")
+@Description("Serialises an object as YAML.")
 @In(StreamReceiver.class)
 @Out(String.class)
 @FluxCommand("encode-yaml")


### PR DESCRIPTION
Amends metafacture/metafacture-documentation#19 and #447.

New output:

```
encode-yaml
-----------
- description:  Serialises an object as YAML.
- options:      arraymarker (String), [deprecated] prettyprinting (boolean)
- signature:    StreamReceiver -> String
- java class:   org.metafacture.yaml.YamlEncoder
```