### PR TITLE
Enable generic header support in `HttpOpener`.

### DIFF
--- a/metafacture-io/src/main/java/org/metafacture/io/HttpOpener.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/HttpOpener.java
@@ -29,6 +29,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -45,7 +46,8 @@ import java.util.regex.Pattern;
 @FluxCommand("open-http")
 public final class HttpOpener extends DefaultObjectPipe<String, ObjectReceiver<Reader>> {
 
-    private static final Pattern HEADER_PATTERN = Pattern.compile(":\\s*");
+    private static final Pattern HEADER_FIELD_SEPARATOR = Pattern.compile("\n");
+    private static final Pattern HEADER_VALUE_SEPARATOR = Pattern.compile(":");
 
     private static final String ENCODING_HEADER = "accept-charset";
 
@@ -89,13 +91,15 @@ public final class HttpOpener extends DefaultObjectPipe<String, ObjectReceiver<R
      * @param header request property line
      */
     public void setHeader(final String header) {
-        final String[] parts = HEADER_PATTERN.split(header, 2);
-        if (parts.length == 2) {
-            setHeader(parts[0], parts[1]);
-        }
-        else {
-            throw new IllegalArgumentException("Invalid header: " + header);
-        }
+        Arrays.stream(HEADER_FIELD_SEPARATOR.split(header)).forEach(h -> {
+            final String[] parts = HEADER_VALUE_SEPARATOR.split(h, 2);
+            if (parts.length == 2) {
+                setHeader(parts[0], parts[1].trim());
+            }
+            else {
+                throw new IllegalArgumentException("Invalid header: " + h);
+            }
+        });
     }
 
     /**

--- a/metafacture-io/src/main/java/org/metafacture/io/HttpOpener.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/HttpOpener.java
@@ -49,6 +49,7 @@ public final class HttpOpener extends DefaultObjectPipe<String, ObjectReceiver<R
     private static final Pattern HEADER_FIELD_SEPARATOR = Pattern.compile("\n");
     private static final Pattern HEADER_VALUE_SEPARATOR = Pattern.compile(":");
 
+    private static final String ACCEPT_HEADER = "accept";
     private static final String ENCODING_HEADER = "accept-charset";
 
     private final Map<String, String> headers = new HashMap<>();
@@ -69,7 +70,7 @@ public final class HttpOpener extends DefaultObjectPipe<String, ObjectReceiver<R
      * @param accept mime-type to use for the HTTP accept header
      */
     public void setAccept(final String accept) {
-        setHeader("accept", accept);
+        setHeader(ACCEPT_HEADER, accept);
     }
 
     /**

--- a/metafacture-io/src/main/java/org/metafacture/io/HttpOpener.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/HttpOpener.java
@@ -40,9 +40,9 @@ import java.util.regex.Pattern;
  * @author Christoph Böhme
  * @author Jan Schnasse
  */
-@Description("Opens a http resource. Supports the setting of Accept and Accept-Charset as http header fields.")
+@Description("Opens an HTTP resource. Supports the setting of `Accept` and `Accept-Charset` as HTTP header fields, as well as generic headers (separated by `\\n`).")
 @In(String.class)
-@Out(java.io.Reader.class)
+@Out(Reader.class)
 @FluxCommand("open-http")
 public final class HttpOpener extends DefaultObjectPipe<String, ObjectReceiver<Reader>> {
 
@@ -86,7 +86,8 @@ public final class HttpOpener extends DefaultObjectPipe<String, ObjectReceiver<R
     }
 
     /**
-     * Sets a request property.
+     * Sets a request property, or multiple request properties separated by
+     * {@code \n}.
      *
      * @param header request property line
      */

--- a/metafacture-io/src/main/java/org/metafacture/io/HttpOpener.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/HttpOpener.java
@@ -52,14 +52,17 @@ public final class HttpOpener extends DefaultObjectPipe<String, ObjectReceiver<R
     private static final String ACCEPT_HEADER = "accept";
     private static final String ENCODING_HEADER = "accept-charset";
 
+    private static final String ACCEPT_DEFAULT = "*/*";
+    private static final String ENCODING_DEFAULT = "UTF-8";
+
     private final Map<String, String> headers = new HashMap<>();
 
     /**
      * Creates an instance of {@link HttpOpener}.
      */
     public HttpOpener() {
-        setAccept("UTF-8");
-        setEncoding("*/*");
+        setAccept(ACCEPT_DEFAULT);
+        setEncoding(ENCODING_DEFAULT);
     }
 
     /**


### PR DESCRIPTION
Resolves #456.