### PR TITLE
Add `FileMap` option to ignore lines matching pattern.

### DIFF
--- a/metamorph/src/main/resources/schemata/metamorph.xsd
+++ b/metamorph/src/main/resources/schemata/metamorph.xsd
@@ -660,6 +660,12 @@
                     </restriction>
                 </simpleType>
             </attribute>
+            <attribute name="ignorePattern" type="string" use="optional">
+                <annotation>
+                    <documentation>Sets the pattern which determines whether a line should
+                        be ignored.</documentation>
+                </annotation>
+            </attribute>
             <attribute ref="xml:base" />
         </complexType>
     </element>

--- a/metamorph/src/test/java/org/metafacture/metamorph/maps/FileMapTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/maps/FileMapTest.java
@@ -91,6 +91,25 @@ public final class FileMapTest {
     }
 
     @Test
+    public void shouldLookupValuesInFileBasedMapWithIgnorePattern() {
+        assertMorph(receiver, buildMorph("lookup in", "ignorePattern=\"g.*\""),
+                i -> {
+                    i.startRecord("1");
+                    i.literal("1", "gw");
+                    i.literal("1", "fj");
+                    i.literal("1", "hk");
+                    i.endRecord();
+                },
+                o -> {
+                    o.get().startRecord("1");
+                    o.get().literal("1", "Fiji");
+                    o.get().literal("1", "HongKong");
+                    o.get().endRecord();
+                }
+        );
+    }
+
+    @Test
     public void shouldWhitelistValuesInFileBasedMap() {
         assertMorph(receiver, buildMorph("whitelist map", ""),
                 i -> {
@@ -305,6 +324,16 @@ public final class FileMapTest {
             i.setExpectedColumns(-1);
 
             Assert.assertEquals("New", i.get("pp\tPapua"));
+        });
+    }
+
+    @Test
+    public void shouldLoadFileWithIgnorePattern() {
+        assertMap(369, i -> {
+            i.setIgnorePattern(".*New.*");
+
+            Assert.assertNull(i.get("pp"));
+            Assert.assertEquals("Puerto Rico", i.get("pr"));
         });
     }
 


### PR DESCRIPTION
Particularly useful for comments (e.g., `ignorePattern="#.*"`).