### PR TITLE
Publish to GitHub packages when RC branch is pushed (#473)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish package to GitHub Packages
 on:
   push:
     branches:
-      - 'publish'
+      - '*-rc*'
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -342,6 +342,10 @@ def getSnapshotVersion() {
     logger.lifecycle('Release branch found')
     return "${extractVersionFromBranch(grgit.branch.current().name)}-SNAPSHOT"
   }
+  if (grgit.branch.current().name.contains('-rc')) {
+    logger.lifecycle('Release candidate branch found')
+    return "${grgit.branch.current().name}"
+  }
   logger.lifecycle('Feature branch found')
   return "feature-${grgit.branch.current().name}-SNAPSHOT"
 }


### PR DESCRIPTION
Use plain RC branch name as version during build.

Completes #473.
See https://github.com/metafacture/metafacture-core/issues/356.