### PR TITLE
Optionally let `ObjectFileWriter` append to existing file instead of overwriting.

### DIFF
--- a/metafacture-io/src/main/java/org/metafacture/io/ObjectFileWriter.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/ObjectFileWriter.java
@@ -46,6 +46,7 @@ public final class ObjectFileWriter<T> extends AbstractObjectWriter<T>  {
     private String path;
     private int count;
     private Writer writer;
+    private boolean appendIfFileExists;
     private boolean firstObject = true;
     private boolean closed;
 
@@ -129,11 +130,26 @@ public final class ObjectFileWriter<T> extends AbstractObjectWriter<T>  {
         }
     }
 
+    /**
+     * Controls whether to open files in append mode if they exist.
+     * <p>
+     * The default value is {@code false}.
+     * <p>
+     * This property can be changed anytime during processing. It becomes
+     * effective the next time a new output file is opened.
+     *
+     * @param appendIfFileExists true if new data should be appended,
+     *                           false to overwrite the existing file.
+     */
+    public void setAppendIfFileExists(final boolean appendIfFileExists) {
+        this.appendIfFileExists = appendIfFileExists;
+    }
+
     private void startNewFile() {
         final Matcher matcher = VAR_PATTERN.matcher(this.path);
         final String currentPath = matcher.replaceAll(String.valueOf(count));
         try {
-            final OutputStream file = new FileOutputStream(currentPath);
+            final OutputStream file = new FileOutputStream(currentPath, appendIfFileExists);
             try {
                 final OutputStream compressor = compression.createCompressor(file, currentPath);
                 try {

--- a/metafacture-io/src/test/java/org/metafacture/io/ObjectFileWriterCompressionTest.java
+++ b/metafacture-io/src/test/java/org/metafacture/io/ObjectFileWriterCompressionTest.java
@@ -47,6 +47,7 @@ public final class ObjectFileWriterCompressionTest {
     private static final String FILENAME_BZ2 = "compressed.txt.bz2";
     private static final String FILENAME_BZIP2 = "compressed.txt.bzip2";
     private static final String FILENAME_GZ = "compressed.txt.gz";
+    private static final String FILENAME_GZ_NOAUTO = "compressed.txt.gz.noauto";
     private static final String FILENAME_GZIP = "compressed.txt.gzip";
     private static final String FILENAME_XZ = "compressed.txt.xz";
 
@@ -76,11 +77,13 @@ public final class ObjectFileWriterCompressionTest {
                 { FILENAME_BZ2, FileCompression.AUTO, MAGIC_BYTES_BZIP2 },
                 { FILENAME_BZIP2, FileCompression.AUTO, MAGIC_BYTES_BZIP2 },
                 { FILENAME_GZ, FileCompression.AUTO, MAGIC_BYTES_GZIP },
+                { FILENAME_GZ_NOAUTO, FileCompression.AUTO, MAGIC_BYTES_NONE },
                 { FILENAME_GZIP, FileCompression.AUTO, MAGIC_BYTES_GZIP },
                 { FILENAME_XZ, FileCompression.AUTO, MAGIC_BYTES_XZ },
                 { FILENAME_NONE, FileCompression.NONE, MAGIC_BYTES_NONE },
                 { FILENAME_BZ2, FileCompression.BZIP2, MAGIC_BYTES_BZIP2 },
                 { FILENAME_GZ, FileCompression.GZIP, MAGIC_BYTES_GZIP },
+                { FILENAME_GZ_NOAUTO, FileCompression.GZIP, MAGIC_BYTES_GZIP },
                 { FILENAME_XZ, FileCompression.XZ, MAGIC_BYTES_XZ },
             });
     }


### PR DESCRIPTION
Metafix may write to the same file repeatedly, which should not overwrite previous content.

Related to: metafacture/metafacture-fix#238 and metafacture/metafacture-fix#269