### PR TITLE
Emit combined text for mixed content in HtmlDecoder

### DIFF
--- a/metafacture-html/src/main/java/org/metafacture/html/HtmlDecoder.java
+++ b/metafacture-html/src/main/java/org/metafacture/html/HtmlDecoder.java
@@ -131,7 +131,7 @@ public class HtmlDecoder extends DefaultObjectPipe<Reader, StreamReceiver> {
      * @param mapString the attributes to be added as subfields
      */
     public void setAttrValsAsSubfields(final String mapString) {
-        this.attrValsAsSubfields = new HashMap<String, String>();
+        this.attrValsAsSubfields = new HashMap<>();
         final String input = mapString.startsWith("&") ? DEFAULT_ATTR_VALS_AS_SUBFIELDS + mapString : mapString;
         for (final String nameValuePair : input.split("&")) {
             final String[] nameValue = nameValuePair.split("=");

--- a/metafacture-html/src/main/java/org/metafacture/html/HtmlDecoder.java
+++ b/metafacture-html/src/main/java/org/metafacture/html/HtmlDecoder.java
@@ -98,12 +98,10 @@ public class HtmlDecoder extends DefaultObjectPipe<Reader, StreamReceiver> {
                 addedValueAsSubfield = handleAttributeValuesAsSubfields(receiver, element, attributes, attribute);
                 receiver.literal(attribute.getKey(), attribute.getValue());
             }
-            if (element.children().isEmpty()) {
-                final String text = element.text().trim();
-                final String value = text.isEmpty() ? element.data() : text;
-                if (!value.isEmpty() && !addedValueAsSubfield) {
-                    receiver.literal("value", value);
-                }
+            final String text = element.text().trim();
+            final String value = text.isEmpty() ? element.data() : text;
+            if (!value.isEmpty() && !addedValueAsSubfield) {
+                receiver.literal("value", value);
             }
             process(element, receiver);
             receiver.endEntity();

--- a/metafacture-html/src/test/java/org/metafacture/html/HtmlDecoderTest.java
+++ b/metafacture-html/src/test/java/org/metafacture/html/HtmlDecoderTest.java
@@ -78,6 +78,17 @@ public final class HtmlDecoderTest {
     }
 
     @Test
+    public void mixedContent() {
+        htmlDecoder.process(new StringReader("<p>This is the <strong>full</strong> text</p>"));
+        final InOrder ordered = inOrder(receiver);
+        ordered.verify(receiver).startEntity("p");
+        ordered.verify(receiver).literal("value", "This is the full text");
+        // elements above plus body, html
+        ordered.verify(receiver, times(4)).endEntity();
+
+    }
+
+    @Test
     public void htmlAttributesAsLiterals() {
         htmlDecoder.process(new StringReader("<p class=lead>Text"));
         final InOrder ordered = inOrder(receiver);


### PR DESCRIPTION
(Came up processing an HTML source [in OERSI](https://gitlab.com/oersi/oersi-etl/-/merge_requests/156).)

E.g. for `<p>This is the <strong>full</strong> text</p>`, emit `This is the full text`.

Was only emitting the children's text (`full`) before (emitting text only if children were empty).