### PR TITLE
Add "-SNAPSHOT" to rc branch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -342,7 +342,7 @@ def getSnapshotVersion() {
   }
   if (grgit.branch.current().name.contains('-rc')) {
     logger.lifecycle('Release candidate branch found')
-    return "${grgit.branch.current().name}"
+    return "${grgit.branch.current().name}-SNAPSHOT"
   }
   logger.lifecycle('Feature branch found')
   return "feature-${grgit.branch.current().name}-SNAPSHOT"


### PR DESCRIPTION
Only versions ending with "-SNAPSHOT" are uploaded to sonatype's snapshot repository.