### PR TITLE
Reset `inputUsed` after processing to fix reusing opener

### DIFF
--- a/metafacture-io/src/main/java/org/metafacture/io/HttpOpener.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/HttpOpener.java
@@ -265,6 +265,9 @@ public final class HttpOpener extends DefaultObjectPipe<String, ObjectReceiver<R
         catch (final IOException e) {
             throw new MetafactureException(e);
         }
+        finally {
+            inputUsed = false;
+        }
     }
 
     private String getInput(final String input, final String value) {

--- a/metafacture-io/src/test/java/org/metafacture/io/HttpOpenerTest.java
+++ b/metafacture-io/src/test/java/org/metafacture/io/HttpOpenerTest.java
@@ -39,6 +39,8 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
+import static org.mockito.Mockito.times;
+
 import java.io.IOException;
 import java.io.Reader;
 import java.util.Arrays;
@@ -318,11 +320,15 @@ public final class HttpOpenerTest {
         WireMock.stubFor(stub);
 
         opener.process(String.format(input, baseUrl));
+
+        // use the opener a second time in a workflow:
+        opener.process(String.format(input, baseUrl));
+
         opener.closeStream();
 
         WireMock.verify(request);
 
-        Mockito.verify(receiver).process(processedObject.capture());
+        Mockito.verify(receiver, times(2)).process(processedObject.capture());
         Assert.assertEquals(responseBody, ResourceUtil.readAll(processedObject.getValue()));
     }
 


### PR DESCRIPTION
A second open-http in a flux resulted in MalformedURLException, see: 
https://gitlab.com/oersi/oersi-etl/-/merge_requests/284