### PR TITLE
Increment count before starting new file in ObjectFileWriter

### DIFF
--- a/metafacture-io/src/main/java/org/metafacture/io/ObjectFileWriter.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/ObjectFileWriter.java
@@ -108,8 +108,8 @@ public final class ObjectFileWriter<T> extends AbstractObjectWriter<T>  {
     @Override
     public void resetStream() {
         closeStream();
-        startNewFile();
         ++count;
+        startNewFile();
     }
 
     @Override

--- a/metafacture-io/src/test/java/org/metafacture/io/ObjectFileWriterTest.java
+++ b/metafacture-io/src/test/java/org/metafacture/io/ObjectFileWriterTest.java
@@ -17,6 +17,7 @@
 package org.metafacture.io;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 
 import java.io.File;
@@ -91,6 +92,17 @@ public final class ObjectFileWriterTest
         writer.closeStream();
 
         assertOutput(DATA + "\n" + DATA + "\n");
+    }
+
+    @Test
+    public void shouldIncrementCountOnResetBeforeStartingNewFile() throws IOException {
+        final String pathWithVar = tempFolder.getRoot() + "/test-${i}";
+        writer = new ObjectFileWriter<String>(pathWithVar);
+        writer.process(DATA);
+        assertTrue(new File(tempFolder.getRoot(), "test-0").exists());
+        writer.resetStream(); // increments count, starts new file
+        writer.process(DATA);
+        assertTrue(new File(tempFolder.getRoot(), "test-1").exists());
     }
 
     @Override


### PR DESCRIPTION
To avoid overwriting first output file, e.g. when using `batch-reset` (ObjectBatchResetter).

Noticed in our RPB workflows, where the first batch is overwritten by the second (e.g. [here](https://github.com/hbz/rpb/blob/main/conf/rpb-titel-to-lobid.flux)).