### PR TITLE
Fix URLEncode to be backwards compatible

### DIFF
--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/URLEncode.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/URLEncode.java
@@ -25,13 +25,15 @@ import com.google.common.net.PercentEscaper;
  * Default is to convert a whitespace " "to a plus sign "+". This can be set so that a whitespace " " is escaped to
  * "%20".
  * Safe characters for this escaper are the ranges 0..9, a..z and A..Z. These are always safe and should not be
- * specified.
+ * specified. Default safe characters are also ".", "-", "*", and "_", following URLEncoder.
+ *
+ * @see java.net.URLEncoder
  *
  * @author Markus Michael Geipel
  * @author Pascal Christoph (dr0i)
  */
 public final class URLEncode extends AbstractSimpleStatelessFunction {
-    private String safeChars = "";
+    private String safeChars = ".-*_";
     private Boolean plusForSpace = true;
     private PercentEscaper percentEscaper = new PercentEscaper(safeChars, plusForSpace);
 
@@ -49,6 +51,8 @@ public final class URLEncode extends AbstractSimpleStatelessFunction {
     /**
      * Sets a URI escaper with the specified safe characters. The ranges 0..9, a..z and A..Z are always safe
      * and should not be specified.
+     *
+     * Default is also ".", "-", "*", and "_" , mimicking {@link java.net.URLEncoder}.
      *
      * @param safeChars the chars which will not be escaped
      */

--- a/metamorph/src/test/java/org/metafacture/metamorph/functions/URLEncodeTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/functions/URLEncodeTest.java
@@ -16,6 +16,9 @@
 
 package org.metafacture.metamorph.functions;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
 import static org.junit.Assert.*;
 import org.junit.Test;
 
@@ -31,10 +34,15 @@ public final class URLEncodeTest {
     private static final String CAFE_ENCODED = "caf%C3%A9";
     private static final String SOME_CHARS = "/&%\\+";
     private static final String SOME_CHARS_ENCODED = "%2F%26%25%5C%2B";
+    private static final String SPECIAL_CHARACTERS = ".-*_";
+    private static final String URL =
+            "http://lobid.org/resources/search?q=hasItem.hasItem.heldBy.id:\"http://lobid" +
+                    ".org/organisations/DE-290#!\"&format=json";
     private static final String WHITESPACE = " ";
     private static final String WHITESPACE_AS_PLUS_ENCODED = "+";
     private static final String WHITESPACE_PERCENT_ENCODED = "%20";
 
+URLEncoder urlEncoder;
     @Test
     public void testUtf8(){
         final URLEncode urlEncode = new URLEncode();
@@ -63,6 +71,16 @@ public final class URLEncodeTest {
         final URLEncode urlEncode = new URLEncode();
         urlEncode.setSafeChars(SOME_CHARS);
         assertEquals(SOME_CHARS, urlEncode.process(SOME_CHARS));
+    }
+    @Test
+    public void testSpecialChars(){
+        final URLEncode urlEncode = new URLEncode();
+        assertEquals(SPECIAL_CHARACTERS, urlEncode.process(SPECIAL_CHARACTERS));
+    }
+    @Test
+    public void testBackwardsCompatibility() throws UnsupportedEncodingException {
+        final URLEncode urlEncode = new URLEncode();
+        assertEquals(urlEncode.process(URL), URLEncoder.encode(URL, "UTF-8"));
     }
 
 }

--- a/metamorph/src/test/java/org/metafacture/metamorph/functions/URLEncodeTest.java
+++ b/metamorph/src/test/java/org/metafacture/metamorph/functions/URLEncodeTest.java
@@ -42,7 +42,6 @@ public final class URLEncodeTest {
     private static final String WHITESPACE_AS_PLUS_ENCODED = "+";
     private static final String WHITESPACE_PERCENT_ENCODED = "%20";
 
-URLEncoder urlEncoder;
     @Test
     public void testUtf8(){
         final URLEncode urlEncode = new URLEncode();


### PR DESCRIPTION
Following https://github.com/metafacture/metafacture-fix/issues/273#issuecomment-1620336833.

Sets default safe characters  ".", "-", "*", and "_", following URLEncode.

Prerequisite for https://github.com/metafacture/metafacture-fix/issues/273 and https://github.com/metafacture/metafacture-core/issues/502.