### PR TITLE
Add links to flux-commands.md

### DIFF
--- a/metafacture-flux/src/main/java/org/metafacture/flux/HelpPrinter.java
+++ b/metafacture-flux/src/main/java/org/metafacture/flux/HelpPrinter.java
@@ -33,7 +33,6 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -205,7 +204,7 @@ public final class HelpPrinter {
 
     private static void loadExamples() throws IOException {
         final File f = new File(PATH_TO_EXAMPLES);
-        if (Files.exists(f.toPath())) {
+        if (f.exists()) {
             final BufferedReader bufferedReader = new BufferedReader(new FileReader(f));
             String line;
             while ((line = bufferedReader.readLine()) != null) {

--- a/metafacture-flux/src/main/java/org/metafacture/flux/HelpPrinter.java
+++ b/metafacture-flux/src/main/java/org/metafacture/flux/HelpPrinter.java
@@ -49,11 +49,9 @@ import java.util.Map.Entry;
  * @author Markus Michael Geipel
  */
 public final class HelpPrinter {
+
     private static final String PATH_TO_EXAMPLES = "../metafacture-documentation/linksAndExamples.tsv";
     private static final Map<String, String[]> EXAMPLES_MAP = new HashMap<>();
-    private static final int COLUMN_TO_PG_EXAMPLE = 3;
-    private static final int MAX_COLUMNS_OF_EXAMPLE = COLUMN_TO_PG_EXAMPLE;
-    private static final int MIN_COLUMNS_OF_EXAMPLE = 2;
 
     private HelpPrinter() {
         // no instances
@@ -127,17 +125,10 @@ public final class HelpPrinter {
         printSignature(out, moduleClass);
 
         final String[] examplesEntry = EXAMPLES_MAP.get(name);
-        if (!EXAMPLES_MAP.isEmpty() && (examplesEntry == null || examplesEntry.length < MIN_COLUMNS_OF_EXAMPLE ||
-                examplesEntry.length > MAX_COLUMNS_OF_EXAMPLE)) {
-            throw new MetafactureException(
-                    "Failed to load build infos: tsv with links hasn't at least " + MIN_COLUMNS_OF_EXAMPLE + " " +
-                            "or exceeds the number of allowed columns (i.e. " + MAX_COLUMNS_OF_EXAMPLE + ")" +
-                            " for the entry '" + name + "'");
+        if (examplesEntry != null && examplesEntry.length > 2) {
+            out.println("- [example in Playground]" + "(" + examplesEntry[2] + ")");
         }
-        if (examplesEntry != null && examplesEntry.length == COLUMN_TO_PG_EXAMPLE) {
-            out.println("- [example in Playground]" + "(" + examplesEntry[COLUMN_TO_PG_EXAMPLE - 1] + ")");
-        }
-        if (examplesEntry != null) {
+        if (examplesEntry != null && examplesEntry.length > 1) {
             out.println("- java class:\t[" + moduleClass.getCanonicalName() + "](" + examplesEntry[1] + ")");
         }
         else {
@@ -213,6 +204,10 @@ public final class HelpPrinter {
             while ((line = bufferedReader.readLine()) != null) {
                 final String[] tsv = line.split("\t");
                 EXAMPLES_MAP.put(tsv[0], tsv);
+
+                if (tsv.length < 2) {
+                    System.err.println("Invalid command info: " + line);
+                }
             }
         }
     }

--- a/metafacture-flux/src/main/java/org/metafacture/flux/HelpPrinter.java
+++ b/metafacture-flux/src/main/java/org/metafacture/flux/HelpPrinter.java
@@ -52,7 +52,8 @@ public final class HelpPrinter {
     private static final String PATH_TO_EXAMPLES = "../metafacture-documentation/linksAndExamples.tsv";
     private static final Map<String, String[]> EXAMPLES_MAP = new HashMap<>();
     private static final int COLUMN_TO_PG_EXAMPLE = 3;
-    private static final int REQUIRED_COLUMNS_OF_EXAMPLE = 2;
+    private static final int MAX_COLUMNS_OF_EXAMPLE = COLUMN_TO_PG_EXAMPLE;
+    private static final int MIN_COLUMNS_OF_EXAMPLE = 2;
 
     private HelpPrinter() {
         // no instances
@@ -126,9 +127,11 @@ public final class HelpPrinter {
         printSignature(out, moduleClass);
 
         final String[] examplesEntry = EXAMPLES_MAP.get(name);
-        if (!EXAMPLES_MAP.isEmpty() && (examplesEntry == null || examplesEntry.length < REQUIRED_COLUMNS_OF_EXAMPLE)) {
+        if (!EXAMPLES_MAP.isEmpty() && (examplesEntry == null || examplesEntry.length < MIN_COLUMNS_OF_EXAMPLE ||
+                examplesEntry.length > MAX_COLUMNS_OF_EXAMPLE)) {
             throw new MetafactureException(
-                    "Failed to load build infos: tsv with links hasn't at least " + REQUIRED_COLUMNS_OF_EXAMPLE +
+                    "Failed to load build infos: tsv with links hasn't at least " + MIN_COLUMNS_OF_EXAMPLE + " " +
+                            "or exceeds the number of allowed columns (i.e. " + MAX_COLUMNS_OF_EXAMPLE + ")" +
                             " for the entry '" + name + "'");
         }
         if (examplesEntry != null && examplesEntry.length == COLUMN_TO_PG_EXAMPLE) {

--- a/metafacture-flux/src/main/java/org/metafacture/flux/parser/FluxProgramm.java
+++ b/metafacture-flux/src/main/java/org/metafacture/flux/parser/FluxProgramm.java
@@ -178,9 +178,10 @@ public final class FluxProgramm {
     /**
      * Prints the help to the given PrintStream.
      *
-     * @param out the PrintStream to orint to
+     * @param out the PrintStream to print to
+     * @throws IOException when an I/O error occurs
      */
-    public static void printHelp(final PrintStream out) {
+    public static void printHelp(final PrintStream out) throws IOException {
         HelpPrinter.print(COMMAND_FACTORY, out);
     }
 

--- a/metafacture-flux/src/test/java/org/metafacture/flux/FluxProgrammTest.java
+++ b/metafacture-flux/src/test/java/org/metafacture/flux/FluxProgrammTest.java
@@ -16,12 +16,12 @@
 
 package org.metafacture.flux;
 
+import org.junit.Test;
+import org.metafacture.flux.parser.FluxProgramm;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
-
-import org.junit.Test;
-import org.metafacture.flux.parser.FluxProgramm;
 
 /**
  * Tests {@link FluxProgramm}
@@ -33,7 +33,7 @@ import org.metafacture.flux.parser.FluxProgramm;
 public final class FluxProgrammTest {
 
     @Test
-    public void testCommandRegistration() {
+    public void testCommandRegistration() throws IOException {
         // all commands must properly load to print the help
         FluxProgramm.printHelp(discardOutput());
 


### PR DESCRIPTION
See #488.

The tsv to enrich the flux-commands.md is taken from the repo metafacture/metafacture-documentation.
If the file resides at the proper location the following is produced (snippet):
>
add-oreaggregation
------------------
- description:	adds ore:Aggregation to an Europeana Data Model stream. The aggregation id is set by emitting literal('aggregation_id', id)
- signature:	StreamReceiver -> StreamReceiver
- java class:	[org.metafacture.linkeddata.OreAggregationAdder](https://github.com/metafacture/metafacture-core/blob/master/metafacture-linkeddata/src/main/java/org/metafacture/linkeddata/OreAggregationAdder.java)
>
[add-preamble-epilogue](https://metafacture.org/playground/?flux=inputFile%0A%7C+open-file%0A%7Cas-lines%0A%7Cadd-preamble-epilogue+%28preamble%3D%22This+is+a+preamble%21%22%2C+epilogue%3D%22This+is+a+epilogue%21%22%29%0A%7Cprint%0A%3B&data=1%7Ba%3A+Faust%2C+b+%7Bn%3A+Goethe%2C+v%3A+JW%7D%2C+c%3A+Weimar%7D%0A2%7Ba%3A+R%C3%A4uber%2C+b+%7Bn%3A+Schiller%2C+v%3A+F%7D%2C+c%3A+Weimar%7D)
---------------------
- description:	Adds a String preamle and/or epilogue to the stream
- options:	preamble (String), epilogue (String)
- signature:	String -> String
- java class:	[org.metafacture.formatting.PreambleEpilogueAdder](https://github.com/metafacture/metafacture-core/blob/master/metafacture-formatting/src/main/java/org/metafacture/formatting/PreambleEpilogueAdder.java)

As shown, the link to the Playground example is only inserted if it exists, see https://github.com/metafacture/metafacture-documentation/pull/24.