### PR TITLE
Close resources.

### DIFF
--- a/metafacture-commons/src/main/java/org/metafacture/commons/ResourceUtil.java
+++ b/metafacture-commons/src/main/java/org/metafacture/commons/ResourceUtil.java
@@ -30,6 +30,7 @@ import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Properties;
+import java.util.function.Consumer;
 
 /**
  * Various utility methods for working with files, resources and streams.
@@ -241,14 +242,7 @@ public final class ResourceUtil { // checkstyle-disable-line ClassDataAbstractio
      */
     public static String loadTextFile(final String location) throws IOException {
         final StringBuilder builder = new StringBuilder();
-        final BufferedReader reader = new BufferedReader(getReader(location));
-
-        String line = reader.readLine();
-        while (line != null) {
-            builder.append(line);
-            line = reader.readLine();
-        }
-
+        loadTextFile(location, builder::append);
         return builder.toString();
     }
 
@@ -260,17 +254,19 @@ public final class ResourceUtil { // checkstyle-disable-line ClassDataAbstractio
      * @return the List of Strings with the lines of the file appended
      * @throws IOException if an I/O error occurs
      */
-    public static List<String> loadTextFile(final String location,
-            final List<String> list) throws IOException {
-        final BufferedReader reader = new BufferedReader(getReader(location));
-
-        String line = reader.readLine();
-        while (line != null) {
-            list.add(line);
-            line = reader.readLine();
-        }
-
+    public static List<String> loadTextFile(final String location, final List<String> list) throws IOException {
+        loadTextFile(location, list::add);
         return list;
+    }
+
+    private static void loadTextFile(final String location, final Consumer<String> consumer) throws IOException {
+        try (BufferedReader reader = new BufferedReader(getReader(location))) {
+            String line = reader.readLine();
+            while (line != null) {
+                consumer.accept(line);
+                line = reader.readLine();
+            }
+        }
     }
 
     /**

--- a/metafacture-commons/src/main/java/org/metafacture/commons/ResourceUtil.java
+++ b/metafacture-commons/src/main/java/org/metafacture/commons/ResourceUtil.java
@@ -201,7 +201,9 @@ public final class ResourceUtil { // checkstyle-disable-line ClassDataAbstractio
      */
     public static Properties loadProperties(final String location)
             throws IOException {
-        return loadProperties(getStream(location));
+        try (InputStream stream = getStream(location)) {
+            return loadProperties(stream);
+        }
     }
 
     /**

--- a/metafacture-io/src/main/java/org/metafacture/io/FileOpener.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/FileOpener.java
@@ -154,8 +154,8 @@ public final class FileOpener extends DefaultObjectPipe<String, ObjectReceiver<R
 
     @Override
     public void process(final String file) {
-        try {
-            getReceiver().process(open(file));
+        try (Reader reader = open(file)) {
+            getReceiver().process(reader);
         }
         catch (final IOException e) {
             throw new MetafactureException(e);

--- a/metafacture-io/src/main/java/org/metafacture/io/ResourceOpener.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/ResourceOpener.java
@@ -68,8 +68,8 @@ public final class ResourceOpener extends DefaultObjectPipe<String, ObjectReceiv
 
     @Override
     public void process(final String file) {
-        try {
-            getReceiver().process(ResourceUtil.getReader(file, encoding));
+        try (Reader reader = ResourceUtil.getReader(file, encoding)) {
+            getReceiver().process(reader);
         }
         catch (final IOException e) {
             throw new MetafactureException(e);

--- a/metafacture-io/src/test/java/org/metafacture/io/FileOpenerCompressionTest.java
+++ b/metafacture-io/src/test/java/org/metafacture/io/FileOpenerCompressionTest.java
@@ -16,8 +16,17 @@
 
 package org.metafacture.io;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.verify;
+import org.metafacture.framework.ObjectReceiver;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 import java.io.File;
 import java.io.IOException;
@@ -26,20 +35,6 @@ import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
-
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
-import org.metafacture.commons.ResourceUtil;
-import org.metafacture.framework.ObjectReceiver;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
 
 /**
  * Tests for file compression in  class {@link FileOpener}.
@@ -62,13 +57,10 @@ public final class FileOpenerCompressionTest {
     @Mock
     private ObjectReceiver<Reader> receiver;
 
-    private FileOpener fileOpener;
-
     private final String resourcePath;
     private final FileCompression compression;
 
-    public FileOpenerCompressionTest(final String resourcePath,
-            final FileCompression compression) {
+    public FileOpenerCompressionTest(final String resourcePath, final FileCompression compression) {
         this.resourcePath = resourcePath;
         this.compression = compression;
     }
@@ -93,35 +85,15 @@ public final class FileOpenerCompressionTest {
             });
     }
 
-    @Before
-    public void setup() {
-        fileOpener = new FileOpener();
-        fileOpener.setReceiver(receiver);
-    }
-
     @Test
     public void testOpenCompressedFiles() throws IOException {
-        final File file = copyResourceToTempFile();
-
-        fileOpener.setCompression(compression);
-        fileOpener.process(file.getAbsolutePath());
-
-        final ArgumentCaptor<Reader> readerCaptor =
-                ArgumentCaptor.forClass(Reader.class);
-        verify(receiver).process(readerCaptor.capture());
-        final String charsFromFile;
-        try (Reader reader = readerCaptor.getValue()) {
-            charsFromFile = ResourceUtil.readAll(reader);
-        }
-        assertEquals(DATA, charsFromFile);
-    }
-
-    private File copyResourceToTempFile() throws IOException {
         final File file = tempFolder.newFile();
+
         try (InputStream in = getClass().getResourceAsStream(resourcePath)) {
             Files.copy(in, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
         }
-        return file;
+
+        FileOpenerTest.assertData(receiver, DATA, file, o -> o.setCompression(compression));
     }
 
 }

--- a/metafacture-runner/src/main/java/org/metafacture/runner/Flux.java
+++ b/metafacture-runner/src/main/java/org/metafacture/runner/Flux.java
@@ -25,6 +25,7 @@ import org.antlr.runtime.RecognitionException;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -82,7 +83,9 @@ public final class Flux {
             }
 
             // run parser and builder
-            FluxCompiler.compile(ResourceUtil.getStream(fluxFile), vars).start();
+            try (InputStream inputStream = ResourceUtil.getStream(fluxFile)) {
+                FluxCompiler.compile(inputStream, vars).start();
+            }
         }
     }
 

--- a/metafacture-scripting/src/main/java/org/metafacture/scripting/JScriptObjectPipe.java
+++ b/metafacture-scripting/src/main/java/org/metafacture/scripting/JScriptObjectPipe.java
@@ -25,7 +25,8 @@ import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
 
-import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.Reader;
 import javax.script.Invocable;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
@@ -70,14 +71,14 @@ public final class JScriptObjectPipe extends DefaultObjectPipe<Object, ObjectRec
 
         final ScriptEngineManager manager = new ScriptEngineManager();
         final ScriptEngine engine = manager.getEngineByName("JavaScript");
-        try {
+        try (Reader reader = ResourceUtil.getReader(file)) {
             // LOG.info("loading code from '" + file + "'");
-            engine.eval(ResourceUtil.getReader(file));
+            engine.eval(reader);
         }
         catch (final ScriptException e) {
             throw new MetafactureException("Error in script", e);
         }
-        catch (final FileNotFoundException e) {
+        catch (final IOException e) {
             throw new MetafactureException("Error loading script '" + file + "'", e);
         }
         invocable = (Invocable) engine;

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/Script.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/Script.java
@@ -21,7 +21,8 @@ import org.metafacture.metamorph.api.MorphBuildException;
 import org.metafacture.metamorph.api.MorphExecutionException;
 import org.metafacture.metamorph.api.helpers.AbstractSimpleStatelessFunction;
 
-import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.Reader;
 import javax.script.Invocable;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
@@ -60,14 +61,14 @@ public final class Script extends AbstractSimpleStatelessFunction {
     public void setFile(final String file) {
         final ScriptEngineManager manager = new ScriptEngineManager();
         final ScriptEngine engine = manager.getEngineByName("JavaScript");
-        try {
-            // TODO: The script file should be loaded relatively to the base URI
-            engine.eval(ResourceUtil.getReader(file));
+        // TODO: The script file should be loaded relatively to the base URI
+        try (Reader reader = ResourceUtil.getReader(file)) {
+            engine.eval(reader);
         }
         catch (final ScriptException e) {
             throw new MorphBuildException("Error in script", e);
         }
-        catch (final FileNotFoundException e) {
+        catch (final IOException e) {
             throw new MorphBuildException("Error loading script '" + file + "'", e);
         }
         invocable = (Invocable) engine;


### PR DESCRIPTION
Came up in the context of metafacture/metafacture-playground#122; the last commit (478cc73) actually fixes the issue mentioned there (not being able to delete input files).

The only obvious place remaining is `HttpOpener`; might want to close resources as well, but is currently under "construction" (see #513).