### PR TITLE
Add bin/ to .gitingore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ target/
 .gradle
 .gradletasknamecache
 build
+bin/
 
 # Ignore tmp directory
 tmp


### PR DESCRIPTION
When using VS Code with suggested JAVA extensions a lot of class files in bin are created. These should be ignored.