### PR TITLE
Emit top-level MARC record leader as single element.

### DIFF
--- a/metafacture-biblio/src/test/java/org/metafacture/biblio/marc21/MarcXmlEncoderTest.java
+++ b/metafacture-biblio/src/test/java/org/metafacture/biblio/marc21/MarcXmlEncoderTest.java
@@ -16,14 +16,14 @@
 
 package org.metafacture.biblio.marc21;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 import org.metafacture.framework.MetafactureException;
 import org.metafacture.framework.helpers.DefaultObjectReceiver;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for class {@link MarcXmlEncoder}.
@@ -63,11 +63,7 @@ public class MarcXmlEncoderTest {
         resultCollector = new StringBuilder();
     }
 
-    @After
-    public void tearDown() {
-    }
-
-    private void addOneRecord(MarcXmlEncoder encoder) {
+    private void addOneRecord(final MarcXmlEncoder encoder) {
         encoder.startRecord(RECORD_ID);
         encoder.literal("001", RECORD_ID);
         encoder.startEntity("010  ");
@@ -201,13 +197,56 @@ public class MarcXmlEncoderTest {
     }
 
     @Test
-    public void issue336_createRecordWithTopLevelLeader() {
+    public void issue336_createRecordWithTopLevelLeader_dummy() {
         encoder.startRecord("1");
         encoder.literal(Marc21EventNames.LEADER_ENTITY, "dummy");
         encoder.endRecord();
         encoder.closeStream();
         String expected = XML_DECLARATION + XML_ROOT_OPEN
                 + "<marc:record><marc:leader>dummy</marc:leader></marc:record>" + XML_MARC_COLLECTION_END_TAG;
+        String actual = resultCollector.toString();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void issue336_createRecordWithTopLevelLeader_defaultMarc21Xml() {
+        issue336_createRecordWithTopLevelLeader(encoder, "00000naa a2200000uc 4500");
+    }
+
+    private void issue336_createRecordWithTopLevelLeader(final MarcXmlEncoder encoder, final String expectedLeader) {
+        encoder.startRecord("1");
+        encoder.literal("001", "8u3287432");
+        encoder.literal(Marc21EventNames.LEADER_ENTITY, "00000naa a2200000uc 4500");
+        encoder.endRecord();
+        encoder.closeStream();
+        String expected = XML_DECLARATION + XML_ROOT_OPEN
+            + "<marc:record><marc:controlfield tag=\"001\">8u3287432</marc:controlfield>" +
+            "<marc:leader>" + expectedLeader + "</marc:leader></marc:record>" + XML_MARC_COLLECTION_END_TAG;
+        String actual = resultCollector.toString();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void issue527_shouldEmitLeaderAlwaysAsWholeString() {
+        issue527_shouldEmitLeaderAlwaysAsWholeString(encoder);
+    }
+
+    private void issue527_shouldEmitLeaderAlwaysAsWholeString(final MarcXmlEncoder encoder) {
+        encoder.startRecord("1");
+        encoder.startEntity(Marc21EventNames.LEADER_ENTITY);
+        encoder.literal(Marc21EventNames.RECORD_STATUS_LITERAL, "a");
+        encoder.literal(Marc21EventNames.RECORD_TYPE_LITERAL, "o");
+        encoder.literal(Marc21EventNames.BIBLIOGRAPHIC_LEVEL_LITERAL, "a");
+        encoder.literal(Marc21EventNames.TYPE_OF_CONTROL_LITERAL, " ");
+        encoder.literal(Marc21EventNames.CHARACTER_CODING_LITERAL, "a");
+        encoder.literal(Marc21EventNames.ENCODING_LEVEL_LITERAL, "z");
+        encoder.literal(Marc21EventNames.CATALOGING_FORM_LITERAL, "u");
+        encoder.literal(Marc21EventNames.MULTIPART_LEVEL_LITERAL, " ");
+        encoder.endEntity();
+        encoder.endRecord();
+        encoder.closeStream();
+        String expected = XML_DECLARATION + XML_ROOT_OPEN
+                + "<marc:record><marc:leader>aoa azu </marc:leader></marc:record>" + XML_MARC_COLLECTION_END_TAG;
         String actual = resultCollector.toString();
         assertEquals(expected, actual);
     }


### PR DESCRIPTION
Resolves #527.

See also previous discussion in #531.