### PR TITLE
Fix escaping by using RFC compliant parser

### DIFF
--- a/metafacture-csv/build.gradle
+++ b/metafacture-csv/build.gradle
@@ -19,7 +19,7 @@ description = 'Modules for processing comma-separated values'
 
 dependencies {
   api project(':metafacture-framework')
-  implementation 'com.opencsv:opencsv:3.10'
+  implementation 'com.opencsv:opencsv:5.9'
   testImplementation "junit:junit:${versions.junit}"
   testImplementation "org.mockito:mockito-core:${versions.mockito}"
 }

--- a/metafacture-csv/src/test/java/org/metafacture/csv/CsvDecoderTest.java
+++ b/metafacture-csv/src/test/java/org/metafacture/csv/CsvDecoderTest.java
@@ -89,4 +89,22 @@ public final class CsvDecoderTest {
         ordered.verify(receiver).endRecord();
     }
 
+    /**
+     * In: "a","b\t","c\\t","\","\cd\"
+     * Out: a, b	, c\\t, \, \cd\
+     */
+    @Test
+    public void issue496_escaping() {
+        decoder.setHasHeader(false);
+        decoder.process("\"a\",\"b\t\",\"c\\t\",\"\\\",\"\\cd\\\"");
+        final InOrder ordered = inOrder(receiver);
+        ordered.verify(receiver).startRecord("1");
+        ordered.verify(receiver).literal("0", "a");
+        ordered.verify(receiver).literal("1", "b\t");
+        ordered.verify(receiver).literal("2", "c\\t");
+        ordered.verify(receiver).literal("3", "\\");
+        ordered.verify(receiver).literal("4", "\\cd\\");
+        ordered.verify(receiver).endRecord();
+    }
+
 }


### PR DESCRIPTION
By configuring the CSVReader with an RFC-compliant parser the escaping is fixed.

- update opencsv dependency to version 5.9
- add test

Kudos https://stackoverflow.com/questions/6008395/opencsv-in-java-ignores-backslash-in-a-field-value:

Resolves #496.