### PR TITLE
Using AutoCloseable doesn't compile and I am stuck:

### DIFF
--- a/metamorph-api/src/main/java/org/metafacture/metamorph/api/helpers/AbstractReadOnlyMap.java
+++ b/metamorph-api/src/main/java/org/metafacture/metamorph/api/helpers/AbstractReadOnlyMap.java
@@ -16,7 +16,6 @@
 
 package org.metafacture.metamorph.api.helpers;
 
-import java.io.Closeable;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -30,7 +29,7 @@ import java.util.Set;
  * @param <V> type of values
  * @author Markus Michael Geipel
  */
-public abstract class AbstractReadOnlyMap<K, V> implements Map<K, V>, Closeable {
+public abstract class AbstractReadOnlyMap<K, V> implements Map<K, V>, AutoCloseable {
 
     @Override
     public final int size() {

--- a/metamorph-api/src/main/java/org/metafacture/metamorph/api/helpers/AbstractReadOnlyMap.java
+++ b/metamorph-api/src/main/java/org/metafacture/metamorph/api/helpers/AbstractReadOnlyMap.java
@@ -16,6 +16,7 @@
 
 package org.metafacture.metamorph.api.helpers;
 
+import java.io.Closeable;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -29,7 +30,7 @@ import java.util.Set;
  * @param <V> type of values
  * @author Markus Michael Geipel
  */
-public abstract class AbstractReadOnlyMap<K, V> implements Map<K, V> {
+public abstract class AbstractReadOnlyMap<K, V> implements Map<K, V>, Closeable {
 
     @Override
     public final int size() {

--- a/metamorph/src/main/java/org/metafacture/metamorph/maps/FileMap.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/maps/FileMap.java
@@ -290,4 +290,9 @@ public final class FileMap extends AbstractReadOnlyMap<String, String> {
         return Collections.unmodifiableSet(map.keySet());
     }
 
+    @Override
+    public void close() throws IOException {
+        map.clear();
+        fileOpener.closeStream();
+    }
 }

--- a/metamorph/src/main/java/org/metafacture/metamorph/maps/RestMap.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/maps/RestMap.java
@@ -107,4 +107,8 @@ public final class RestMap extends AbstractReadOnlyMap<String, String> {
         charsetName = name;
     }
 
+    @Override
+    public void close() throws IOException {
+
+    }
 }


### PR DESCRIPTION
Following https://github.com/metafacture/metafacture-core/pull/667#pullrequestreview-2606627001:
Using AutoCloseable doesn't compile and I am stuck:
  
Compiles with an error:
```
AbstractReadOnlyMap.java:32: warning: [try] auto-closeable resource AbstractReadOnlyMap<K,V> has a member method close() that could throw InterruptedException
    public abstract class AbstractReadOnlyMap<K, V> implements Map<K, V>, AutoCloseable {
                    ^
      where K,V are type-variables:
        K extends Object declared in class AbstractReadOnlyMap
        V extends Object declared in class AbstractReadOnlyMap
```

See #666.
