### PR TITLE
Fix wrong description for StdInOpener.java.

### DIFF
--- a/metafacture-io/src/main/java/org/metafacture/io/StdInOpener.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/StdInOpener.java
@@ -32,7 +32,7 @@ import java.io.UnsupportedEncodingException;
  * @author Markus Michael Geipel
  *
  */
-@Description("Opens a file.")
+@Description("Opens stdIn.")
 @In(String.class)
 @Out(java.io.Reader.class)
 public final class StdInOpener extends DefaultObjectPipe<Object, ObjectReceiver<java.io.Reader>> {


### PR DESCRIPTION
Is a wrong copy of open-file https://github.com/metafacture/metafacture-core/blob/f5cc9dc25155ea0d1664e262f199f3d5f97c1316/metafacture-io/src/main/java/org/metafacture/io/FileOpener.java#L41-L42