### PR TITLE
Add open-stdin to flux-commands.properties #574

### DIFF
--- a/metafacture-io/src/main/resources/flux-commands.properties
+++ b/metafacture-io/src/main/resources/flux-commands.properties
@@ -22,3 +22,4 @@ write org.metafacture.io.ObjectWriter
 as-records org.metafacture.io.RecordReader
 open-resource org.metafacture.io.ResourceOpener
 open-tar org.metafacture.io.TarReader
+open-stdin org.metafacture.io.StdInOpener


### PR DESCRIPTION
See #574

Builds but not working yet:

Flux 1:
```
open-stdin
| as-records
| print
;
```

Results in:
```
Exception in thread "main" org.metafacture.flux.FluxParseException: Variable open-stdin not assigned.
        at org.metafacture.flux.parser.FlowBuilder.exp(FlowBuilder.java:604)
        at org.metafacture.flux.parser.FlowBuilder.flow(FlowBuilder.java:205)
        at org.metafacture.flux.parser.FlowBuilder.flux(FlowBuilder.java:122)
        at org.metafacture.flux.FluxCompiler.compileFlow(FluxCompiler.java:66)
        at org.metafacture.flux.FluxCompiler.compile(FluxCompiler.java:54)
        at org.metafacture.runner.Flux.main(Flux.java:87)
```

Flux2:
```
"" // as well as "stdIn"
| open-stdin
| as-records
| print
;
```

Results in:

```
Exception in thread "main" java.lang.IllegalArgumentException: Parameter not used. Must be null
        at org.metafacture.io.StdInOpener.process(StdInOpener.java:59)
        at org.metafacture.flux.parser.StringSender.process(StringSender.java:43)
        at org.metafacture.flux.parser.Flow.start(Flow.java:118)
        at org.metafacture.flux.parser.FluxProgramm.start(FluxProgramm.java:168)
        at org.metafacture.runner.Flux.main(Flux.java:87)
```

Flux3:
```
| open-stdin
| as-records
| print
;
```

Results in:
```
Exception in thread "main" java.lang.NullPointerException
        at org.antlr.runtime.tree.BaseTreeAdaptor.isNil(BaseTreeAdaptor.java:70)
        at org.antlr.runtime.tree.CommonTreeNodeStream.nextElement(CommonTreeNodeStream.java:93)
        at org.antlr.runtime.misc.LookaheadStream.fill(LookaheadStream.java:94)
        at org.antlr.runtime.misc.LookaheadStream.sync(LookaheadStream.java:88)
        at org.antlr.runtime.misc.LookaheadStream.LT(LookaheadStream.java:119)
        at org.antlr.runtime.tree.CommonTreeNodeStream.LA(CommonTreeNodeStream.java:116)
        at org.metafacture.flux.parser.FlowBuilder.varDefs(FlowBuilder.java:277)
        at org.metafacture.flux.parser.FlowBuilder.flux(FlowBuilder.java:105)
        at org.metafacture.flux.FluxCompiler.compileFlow(FluxCompiler.java:66)
        at org.metafacture.flux.FluxCompiler.compile(FluxCompiler.java:54)
        at org.metafacture.runner.Flux.main(Flux.java:87)
```


@dr0i could you have a look