### PR TITLE
Optionally escape Unicode in MarcXmlEncoder.

### DIFF
--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/marc21/MarcXmlEncoder.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/marc21/MarcXmlEncoder.java
@@ -185,6 +185,15 @@ public final class MarcXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Strin
         encoder.setFormatted(formatted);
     }
 
+    /**
+     * Flags whether to escape Unicode.
+     *
+     * @param escapeUnicode true if Unicode should be escaped
+     */
+    public void setEscapeUnicode(final boolean escapeUnicode) {
+        encoder.setEscapeUnicode(escapeUnicode);
+    }
+
     @Override
     public void startRecord(final String identifier) {
         pipe.startRecord(identifier);
@@ -242,6 +251,7 @@ public final class MarcXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Strin
         private Object[] namespacePrefix = new Object[]{NAMESPACE_PREFIX};
 
         private int indentationLevel;
+        private boolean escapeUnicode;
         private boolean formatted = PRETTY_PRINTED;
         private int recordAttributeOffset;
         private int recordLeaderOffset;
@@ -268,6 +278,10 @@ public final class MarcXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Strin
 
         public void setFormatted(final boolean formatted) {
             this.formatted = formatted;
+        }
+
+        public void setEscapeUnicode(final boolean escapeUnicode) {
+            this.escapeUnicode = escapeUnicode;
         }
 
         @Override
@@ -434,7 +448,7 @@ public final class MarcXmlEncoder extends DefaultStreamPipe<ObjectReceiver<Strin
          * @param str the unescaped sequence to be written
          */
         private void writeEscaped(final String str) {
-            builder.append(XmlUtil.escape(str, false));
+            builder.append(XmlUtil.escape(str, escapeUnicode));
         }
 
         private void writeLeader() {

--- a/metafacture-biblio/src/test/java/org/metafacture/biblio/marc21/MarcXmlEncoderTest.java
+++ b/metafacture-biblio/src/test/java/org/metafacture/biblio/marc21/MarcXmlEncoderTest.java
@@ -46,6 +46,9 @@ public class MarcXmlEncoderTest {
     private static final String XML_MARC_COLLECTION_END_TAG = "</marc:collection>";
     private static final String RECORD_ID = "92005291";
 
+    private static final int UNICODE_CODE_POINT = 1048576;
+    private static final String UNICODE_STRING = Character.toString(UNICODE_CODE_POINT);
+
     private StringBuilder resultCollector;
     private int resultCollectorsResetStreamCount;
     private MarcXmlEncoder encoder;
@@ -166,6 +169,33 @@ public class MarcXmlEncoderTest {
         encoder.onResetStream();
         final String expected = XML_DECLARATION + XML_ROOT_OPEN + "<marc:record>" +
                 "<marc:controlfield tag=\"001\">&amp;&lt;&gt;&quot;</marc:controlfield>" + "</marc:record>" +
+                XML_MARC_COLLECTION_END_TAG;
+        final String actual = resultCollector.toString();
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void createARecordWithoutEscapedUnicode() {
+        encoder.startRecord(RECORD_ID);
+        encoder.literal("001", UNICODE_STRING);
+        encoder.endRecord();
+        encoder.onResetStream();
+        final String expected = XML_DECLARATION + XML_ROOT_OPEN + "<marc:record>" +
+                "<marc:controlfield tag=\"001\">\000</marc:controlfield>" + "</marc:record>" +
+                XML_MARC_COLLECTION_END_TAG;
+        final String actual = resultCollector.toString();
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void createARecordWithEscapedUnicode() {
+        encoder.setEscapeUnicode(true);
+        encoder.startRecord(RECORD_ID);
+        encoder.literal("001", UNICODE_STRING);
+        encoder.endRecord();
+        encoder.onResetStream();
+        final String expected = XML_DECLARATION + XML_ROOT_OPEN + "<marc:record>" +
+                "<marc:controlfield tag=\"001\">&#" + UNICODE_CODE_POINT + ";</marc:controlfield>" + "</marc:record>" +
                 XML_MARC_COLLECTION_END_TAG;
         final String actual = resultCollector.toString();
         Assert.assertEquals(expected, actual);


### PR DESCRIPTION
When presented with a Unicode code point (above `0x7f`), `MarcXmlEncoder` may produce invalid XML via `XmlUtil.escape()` by downcasting the `int` to a `char`, which can result in a `null` byte (e.g. `(char) 1048576 = '\000'`). Adding an option to escape Unicode code points as well gives the user more control over the generated output.