### PR TITLE
Delete heapspace limitiation #690

### DIFF
--- a/metafacture-runner/src/main/dist/config/java-options.conf
+++ b/metafacture-runner/src/main/dist/config/java-options.conf
@@ -4,8 +4,6 @@
 # to the folder containing the flux start-up script.
 # Undefined variables remain in the configuration.
 
--Xmx512m
-
 -Dflux.pluginsdir="$METAFACTURE_HOME/plugins"
 -Dflux.provideddir="$METAFACTURE_HOME/provided-libs"
 


### PR DESCRIPTION
The limitation is to small. Java default is better. Resolves #690.