### PR TITLE
Provide Jackson 2.16/2.17 forward compatibility.

### DIFF
--- a/metafacture-json/src/main/java/org/metafacture/json/JsonDecoder.java
+++ b/metafacture-json/src/main/java/org/metafacture/json/JsonDecoder.java
@@ -302,14 +302,14 @@ public final class JsonDecoder extends DefaultObjectPipe<String, StreamReceiver>
                     .append("Unexpected token '")
                     .append(jsonParser.currentToken())
                     .append("' at ")
-                    .append(jsonParser.getCurrentLocation())
+                    .append(jsonParser.currentLocation())
                     .toString());
         }
     }
 
     private void decodeObject() throws IOException {
         while (jsonParser.nextToken() == JsonToken.FIELD_NAME) {
-            decodeValue(jsonParser.getCurrentName(), jsonParser.nextToken());
+            decodeValue(jsonParser.currentName(), jsonParser.nextToken());
         }
     }
 

--- a/metafacture-json/src/main/java/org/metafacture/json/JsonEncoder.java
+++ b/metafacture-json/src/main/java/org/metafacture/json/JsonEncoder.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonStreamContext;
+import com.fasterxml.jackson.core.PrettyPrinter;
 import com.fasterxml.jackson.core.SerializableString;
 import com.fasterxml.jackson.core.io.CharacterEscapes;
 import com.fasterxml.jackson.core.io.SerializedString;
@@ -51,6 +52,13 @@ import java.io.StringWriter;
 @Out(String.class)
 @FluxCommand("encode-json")
 public final class JsonEncoder extends DefaultStreamPipe<ObjectReceiver<String>> {
+
+    public static final PrettyPrinter DEFAULT_PRETTY_PRINTER = new DefaultPrettyPrinter() {
+        @Override
+        public void writeRootValueSeparator(final JsonGenerator gen) {
+            // do nothing
+        }
+    };
 
     public static final String ARRAY_MARKER = "[]";
     public static final String BOOLEAN_MARKER = null;
@@ -140,7 +148,7 @@ public final class JsonEncoder extends DefaultStreamPipe<ObjectReceiver<String>>
      * @param prettyPrinting true if pretty printing should be used
      */
     public void setPrettyPrinting(final boolean prettyPrinting) {
-        jsonGenerator.setPrettyPrinter(prettyPrinting ? new DefaultPrettyPrinter((SerializableString) null) : null);
+        jsonGenerator.setPrettyPrinter(prettyPrinting ? DEFAULT_PRETTY_PRINTER : null);
     }
 
     /**

--- a/metafacture-yaml/src/main/java/org/metafacture/yaml/YamlDecoder.java
+++ b/metafacture-yaml/src/main/java/org/metafacture/yaml/YamlDecoder.java
@@ -215,14 +215,14 @@ public final class YamlDecoder extends DefaultObjectPipe<String, StreamReceiver>
                     .append("Unexpected token '")
                     .append(yamlParser.currentToken())
                     .append("' at ")
-                    .append(yamlParser.getCurrentLocation())
+                    .append(yamlParser.currentLocation())
                     .toString());
         }
     }
 
     private void decodeObject() throws IOException {
         while (yamlParser.nextToken() == JsonToken.FIELD_NAME) {
-            decodeValue(yamlParser.getCurrentName(), yamlParser.nextToken());
+            decodeValue(yamlParser.currentName(), yamlParser.nextToken());
         }
     }
 

--- a/metafix/build.gradle
+++ b/metafix/build.gradle
@@ -36,6 +36,7 @@ dependencies {
   implementation project(':metafacture-framework')
   implementation project(':metafacture-io')
   implementation project(':metafacture-javaintegration')
+  implementation project(':metafacture-json')
   implementation project(':metafacture-mangling')
   implementation project(':metafacture-triples')
   implementation project(':metamorph')

--- a/metafix/src/main/java/org/metafacture/metafix/JsonValue.java
+++ b/metafix/src/main/java/org/metafacture/metafix/JsonValue.java
@@ -16,10 +16,10 @@
 
 package org.metafacture.metafix;
 
+import org.metafacture.json.JsonEncoder;
+
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.SerializableString;
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -62,7 +62,7 @@ public interface JsonValue {
     default String toJson(final boolean prettyPrinting) throws IOException {
         final StringWriter writer = new StringWriter();
         final JsonGenerator jsonGenerator = new JsonFactory().createGenerator(writer);
-        jsonGenerator.setPrettyPrinter(prettyPrinting ? new DefaultPrettyPrinter((SerializableString) null) : null);
+        jsonGenerator.setPrettyPrinter(prettyPrinting ? JsonEncoder.DEFAULT_PRETTY_PRINTER : null);
 
         try {
             toJson(jsonGenerator);


### PR DESCRIPTION
While implementing support for Elasticsearch 9.x in Limetrans, the Metafacture pretty-printing feature broke. This was due to an automatic upgrade of the (transitive) dependency on Jackson from 2.15.1 (requested by Metafacture) to 2.18.3 (requested by Elasticsearch 9.x). Inbetween these versions, Jackson had introduced various deprecations (see below).

This pull request provides forward compatibility with Jackson 2.16 and 2.17 by switching to the intended replacement APIs. One review(er) should be sufficient, but I'm not sure who would be the better fit. So, whoever gets around to it first, I guess ;)

<details><summary>Jackson deprecations</summary>
<p>

```
metafacture-json/src/main/java/org/metafacture/json/JsonEncoder.java:143: warning: [deprecation] DefaultPrettyPrinter(SerializableString) in DefaultPrettyPrinter has been deprecated
        jsonGenerator.setPrettyPrinter(prettyPrinting ? new DefaultPrettyPrinter((SerializableString) null) : null);
=> "Deprecated in 2.16. Use the Separators API instead."

metafacture-json/src/main/java/org/metafacture/json/JsonDecoder.java:305: warning: [deprecation] getCurrentLocation() in JsonParser has been deprecated
                    .append(jsonParser.getCurrentLocation())
=> "Since 2.17 use currentLocation() instead."

metafacture-json/src/main/java/org/metafacture/json/JsonDecoder.java:312: warning: [deprecation] getCurrentName() in JsonParser has been deprecated
            decodeValue(jsonParser.getCurrentName(), jsonParser.nextToken());
=> "Since 2.17 use currentName() instead."
```
</p>
</details>