### PR TITLE
Skip empty strings when using capitalize #751

### DIFF
--- a/metafix/src/main/java/org/metafacture/metafix/method/field/Capitalize.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/field/Capitalize.java
@@ -35,9 +35,7 @@ public class Capitalize implements FixFunction {
 
     @Override
     public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
-        if (!params.isEmpty()) {
-            record.transform(params.get(0), s -> s.substring(0, 1).toUpperCase() + s.substring(1));
-        }
+        record.transform(params.get(0), s -> s.isEmpty() ? s : s.substring(0, 1).toUpperCase() + s.substring(1));
     }
 
 }

--- a/metafix/src/main/java/org/metafacture/metafix/method/field/Capitalize.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/field/Capitalize.java
@@ -35,7 +35,9 @@ public class Capitalize implements FixFunction {
 
     @Override
     public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
-        record.transform(params.get(0), s -> s.substring(0, 1).toUpperCase() + s.substring(1));
+        if (!params.isEmpty()) {
+            record.transform(params.get(0), s -> s.substring(0, 1).toUpperCase() + s.substring(1));
+        }
     }
 
 }

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -170,6 +170,24 @@ public class MetafixMethodTest {
     }
 
     @Test
+    public void shouldSkipEmptyStringWhenCapitalize() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "capitalize('title')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("title", "");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("title", "");
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
     public void shouldCapitalizeStringsInArray() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "capitalize('title.*')"


### PR DESCRIPTION
Skip empty strings when using capitalize  #751

Quick solution.