### PR TITLE
Decode multiline CSV.

### DIFF
--- a/metafacture-csv/src/main/java/org/metafacture/csv/CsvDecoder.java
+++ b/metafacture-csv/src/main/java/org/metafacture/csv/CsvDecoder.java
@@ -17,6 +17,7 @@
 package org.metafacture.csv;
 
 import org.metafacture.framework.FluxCommand;
+import org.metafacture.framework.MetafactureException;
 import org.metafacture.framework.StreamReceiver;
 import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
@@ -31,7 +32,6 @@ import com.opencsv.exceptions.CsvException;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.util.List;
 
 /**
  * Decodes lines of CSV files. First line may be interpreted as header.
@@ -91,50 +91,51 @@ public final class CsvDecoder extends DefaultObjectPipe<String, StreamReceiver> 
     @Override
     public void process(final String string) {
         assert !isClosed();
-        final String[] parts = parseCsv(string);
-        if (hasHeader) {
-            if (header.length == 0) {
-                header = parts;
-            }
-            else if (parts.length == header.length) {
-                getReceiver().startRecord(String.valueOf(++count));
-                for (int i = 0; i < parts.length; ++i) {
-                    getReceiver().literal(header[i], parts[i]);
+        try (
+            StringReader sr = new StringReader(string);
+            CSVReader reader = new CSVReaderBuilder(sr).withCSVParser(parser).build()
+        ) {
+            String[] parts;
+            while ((parts = parseCsv(reader)) != null) {
+                if (hasHeader) {
+                    if (header.length == 0) {
+                        header = parts;
+                    }
+                    else if (parts.length == header.length) {
+                        getReceiver().startRecord(String.valueOf(++count));
+                        for (int i = 0; i < parts.length; ++i) {
+                            getReceiver().literal(header[i], parts[i]);
+                        }
+                        getReceiver().endRecord();
+                    }
+                    else {
+                        throw new IllegalArgumentException(
+                                String.format(
+                                    "wrong number of columns (expected %s, was %s) in input line: %s",
+                                    header.length, parts.length, string));
+                    }
                 }
-                getReceiver().endRecord();
-            }
-            else {
-                throw new IllegalArgumentException(
-                        String.format(
-                                "wrong number of columns (expected %s, was %s) in input line: %s",
-                                header.length, parts.length, string));
+                else {
+                    getReceiver().startRecord(String.valueOf(++count));
+                    for (int i = 0; i < parts.length; ++i) {
+                        getReceiver().literal(String.valueOf(i), parts[i]);
+                    }
+                    getReceiver().endRecord();
+                }
             }
         }
-        else {
-            getReceiver().startRecord(String.valueOf(++count));
-            for (int i = 0; i < parts.length; ++i) {
-                getReceiver().literal(String.valueOf(i), parts[i]);
-            }
-            getReceiver().endRecord();
+        catch (final IOException e) {
+            throw new MetafactureException(e);
         }
     }
 
-    private String[] parseCsv(final String csv) {
-        String[] parts = new String[0];
+    private String[] parseCsv(final CSVReader reader) {
         try {
-            final CSVReader reader = new CSVReaderBuilder(new StringReader(csv))
-                .withCSVParser(parser)
-                .build();
-            final List<String[]> lines = reader.readAll();
-            if (lines.size() > 0) {
-                parts = lines.get(0);
-            }
-            reader.close();
+            return reader.readNext();
         }
         catch (final IOException | CsvException e) {
-            e.printStackTrace();
+            throw new MetafactureException(e);
         }
-        return parts;
     }
 
     /**

--- a/metafacture-csv/src/test/java/org/metafacture/csv/CsvDecoderTest.java
+++ b/metafacture-csv/src/test/java/org/metafacture/csv/CsvDecoderTest.java
@@ -18,7 +18,10 @@ package org.metafacture.csv;
 
 import org.metafacture.framework.StreamReceiver;
 
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -79,6 +82,51 @@ public final class CsvDecoderTest {
     }
 
     @Test
+    public void testInvalidSyntax() {
+        assertException(IllegalArgumentException.class, null,
+                "wrong number of columns (expected 3, was 0)", "a,\"b1,b2,b3,c"); // missing closing "
+    }
+
+    @Test
+    public void testInvalidColumns() {
+        assertException(IllegalArgumentException.class, null,
+                "wrong number of columns (expected 3, was 2)", "a,b"); // missing third column
+    }
+
+    @Test
+    public void testMultilineSingleRow() {
+        decoder.process("a,\"b1,b2,\nb3\",c");
+        final InOrder ordered = Mockito.inOrder(receiver);
+        ordered.verify(receiver).startRecord("1");
+        ordered.verify(receiver).literal("h1", "a");
+        ordered.verify(receiver).literal("h2", "b1,b2,\nb3");
+        ordered.verify(receiver).literal("h3", "c");
+        ordered.verify(receiver).endRecord();
+        ordered.verifyNoMoreInteractions();
+        Mockito.verifyNoMoreInteractions(receiver);
+    }
+
+    @Test
+    public void testMultilineMultipleRows() {
+        decoder.process("a,\"b1,b2,\nb3\",c\na2,b4,c2");
+        final InOrder ordered = Mockito.inOrder(receiver);
+        ordered.verify(receiver).startRecord("1");
+        ordered.verify(receiver).literal("h1", "a");
+        ordered.verify(receiver).literal("h2", "b1,b2,\nb3");
+        ordered.verify(receiver).literal("h3", "c");
+        ordered.verify(receiver).endRecord();
+        /* skipped:
+        ordered.verify(receiver).startRecord("2");
+        ordered.verify(receiver).literal("h1", "a2");
+        ordered.verify(receiver).literal("h2", "b4");
+        ordered.verify(receiver).literal("h3", "c2");
+        ordered.verify(receiver).endRecord();
+        */
+        ordered.verifyNoMoreInteractions();
+        Mockito.verifyNoMoreInteractions(receiver);
+    }
+
+    @Test
     public void testTabSeparated() {
 
         decoder.setSeparator("\t");
@@ -108,6 +156,26 @@ public final class CsvDecoderTest {
         ordered.verify(receiver).literal("3", "\\");
         ordered.verify(receiver).literal("4", "\\cd\\");
         ordered.verify(receiver).endRecord();
+    }
+
+    private void assertException(final Class<? extends Throwable> exceptionClass, final Class<?> expectedClass, final String expectedMessage, final String input) {
+        final Throwable thrownException = Assert.assertThrows(exceptionClass, () -> decoder.process(input));
+        final Throwable actualException;
+
+        final String expectedSuffix;
+
+        if (expectedClass != null) {
+            actualException = thrownException.getCause();
+            Assert.assertEquals(expectedClass, actualException.getClass());
+
+            expectedSuffix = ". ";
+        }
+        else {
+            actualException = thrownException;
+            expectedSuffix = " in ";
+        }
+
+        MatcherAssert.assertThat(actualException.getMessage(), CoreMatchers.startsWith(expectedMessage + expectedSuffix));
     }
 
 }

--- a/metafacture-csv/src/test/java/org/metafacture/csv/CsvDecoderTest.java
+++ b/metafacture-csv/src/test/java/org/metafacture/csv/CsvDecoderTest.java
@@ -16,8 +16,10 @@
 
 package org.metafacture.csv;
 
+import org.metafacture.framework.MetafactureException;
 import org.metafacture.framework.StreamReceiver;
 
+import com.opencsv.exceptions.CsvMalformedLineException;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.After;
@@ -83,8 +85,8 @@ public final class CsvDecoderTest {
 
     @Test
     public void testInvalidSyntax() {
-        assertException(IllegalArgumentException.class, null,
-                "wrong number of columns (expected 3, was 0)", "a,\"b1,b2,b3,c"); // missing closing "
+        assertException(MetafactureException.class, CsvMalformedLineException.class,
+                "Unterminated quoted field at end of CSV line", "a,\"b1,b2,b3,c"); // missing closing "
     }
 
     @Test
@@ -115,13 +117,11 @@ public final class CsvDecoderTest {
         ordered.verify(receiver).literal("h2", "b1,b2,\nb3");
         ordered.verify(receiver).literal("h3", "c");
         ordered.verify(receiver).endRecord();
-        /* skipped:
         ordered.verify(receiver).startRecord("2");
         ordered.verify(receiver).literal("h1", "a2");
         ordered.verify(receiver).literal("h2", "b4");
         ordered.verify(receiver).literal("h3", "c2");
         ordered.verify(receiver).endRecord();
-        */
         ordered.verifyNoMoreInteractions();
         Mockito.verifyNoMoreInteractions(receiver);
     }


### PR DESCRIPTION
Resolves #769.

Surfacing the actual CSV syntax error, if any, instead of printing the stack trace.

(Best viewed with [whitespace changes hidden](https://github.com/metafacture/metafacture-core/pull/770/changes?w=1).)