### PR TITLE
Add setter for log prefix in `ObjectLogger` and `StreamLogger`.

### DIFF
--- a/metafacture-monitoring/build.gradle
+++ b/metafacture-monitoring/build.gradle
@@ -22,5 +22,5 @@ dependencies {
   implementation project(':metafacture-commons')
   testImplementation "junit:junit:${versions.junit}"
   testImplementation "org.mockito:mockito-core:${versions.mockito}"
-  testRuntimeOnly slf4j_provider
+  testImplementation "org.simplify4u:slf4j2-mock:${versions.slf4j_mock}"
 }

--- a/metafacture-monitoring/src/main/java/org/metafacture/monitoring/ObjectLogger.java
+++ b/metafacture-monitoring/src/main/java/org/metafacture/monitoring/ObjectLogger.java
@@ -41,23 +41,34 @@ public final class ObjectLogger<T>
 
     private static final MetafactureLogger LOG = new MetafactureLogger(ObjectLogger.class);
 
-    private final String logPrefix;
+    private String logPrefix = "";
 
     /**
      * Creates an instance of {@link ObjectLogger}.
      */
     public ObjectLogger() {
-        this("");
     }
 
     /**
      * Creates an instance of {@link ObjectLogger} by a given prefix of the log
      * messages.
      *
+     * @deprecated Use {@link #setPrefix} instead.
+     *
      * @param logPrefix the prefix of the log messages
      */
+    @Deprecated/*(since="9.0", forRemoval=true)*/
     public ObjectLogger(final String logPrefix) {
         this.logPrefix = logPrefix;
+    }
+
+    /**
+     * Sets the prefix used when logging messages.
+     *
+     * @param prefix the prefix of the log messages
+     */
+    public void setPrefix(final String prefix) {
+        this.logPrefix = prefix;
     }
 
     @Override

--- a/metafacture-monitoring/src/main/java/org/metafacture/monitoring/StreamLogger.java
+++ b/metafacture-monitoring/src/main/java/org/metafacture/monitoring/StreamLogger.java
@@ -41,23 +41,34 @@ public final class StreamLogger
 
     private static final MetafactureLogger LOG = new MetafactureLogger(StreamLogger.class);
 
-    private final String logPrefix;
+    private String logPrefix = "";
 
     /**
      * Creates an instance of {@link StreamLogger}.
      */
     public StreamLogger() {
-        this("");
     }
 
     /**
      * Creates an instance of {@link StreamLogger} by a given prefix used when log
      * messages.
      *
+     * @deprecated Use {@link #setPrefix} instead.
+     *
      * @param logPrefix the prefix of the log messages
      */
+    @Deprecated/*(since="9.0", forRemoval=true)*/
     public StreamLogger(final String logPrefix) {
-        this.logPrefix = logPrefix;
+        setPrefix(logPrefix);
+    }
+
+    /**
+     * Sets the prefix used when logging messages.
+     *
+     * @param prefix the prefix of the log messages
+     */
+    public void setPrefix(final String prefix) {
+        this.logPrefix = prefix;
     }
 
     @Override

--- a/metafacture-monitoring/src/test/java/org/metafacture/monitoring/ObjectLoggerTest.java
+++ b/metafacture-monitoring/src/test/java/org/metafacture/monitoring/ObjectLoggerTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 hbz NRW
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.metafacture.monitoring;
+
+import org.metafacture.framework.ObjectReceiver;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.Logger;
+
+/**
+ * Tests for class {@link ObjectLogger}.
+ *
+ * @author Jens Wille
+ *
+ */
+@RunWith(MockitoJUnitRunner.class)
+public final class ObjectLoggerTest extends TestHelpers {
+
+    @Mock(name = "external.org.metafacture.monitoring.ObjectLogger")
+    private Logger logLogger;
+
+    @Mock
+    private ObjectReceiver<String> receiver;
+
+    private ObjectLogger<String> logger;
+
+    public ObjectLoggerTest() {
+    }
+
+    @Before
+    public void setup() {
+        logger = new ObjectLogger<>();
+        logger.setReceiver(receiver);
+    }
+
+    @Test
+    public void shouldForwardAllProcessedObjects() {
+        logger.process("object");
+        logger.resetStream();
+        logger.closeStream();
+
+        final InOrder ordered = Mockito.inOrder(receiver);
+        ordered.verify(receiver).process("object");
+        ordered.verify(receiver).resetStream();
+        ordered.verify(receiver).closeStream();
+        ordered.verifyNoMoreInteractions();
+        Mockito.verifyNoMoreInteractions(receiver);
+
+        assertLog(logLogger, "DEBUG", c -> {
+            assertLog(c, "{}{}", "", "object");
+            assertLog(c, "{}resetStream", "");
+            assertLog(c, "{}closeStream", "");
+        });
+    }
+
+    @Test
+    public void shouldActAsSinkIfNoReceiverIsSet() {
+        logger.setReceiver(null);
+
+        logger.process("object");
+        logger.resetStream();
+        logger.closeStream();
+
+        Mockito.verifyNoMoreInteractions(receiver);
+
+        assertLog(logLogger, "DEBUG", c -> {
+            assertLog(c, "{}{}", "", "object");
+            assertLog(c, "{}resetStream", "");
+            assertLog(c, "{}closeStream", "");
+        });
+    }
+
+    @Test
+    public void shouldLogWithPrefix() {
+        final String prefix = "prefix:";
+        logger = new ObjectLogger<>(prefix);
+
+        logger.process("object");
+        logger.resetStream();
+        logger.closeStream();
+
+        assertLog(logLogger, "DEBUG", c -> {
+            assertLog(c, "{}{}", prefix, "object");
+            assertLog(c, "{}resetStream", prefix);
+            assertLog(c, "{}closeStream", prefix);
+        });
+    }
+
+}

--- a/metafacture-monitoring/src/test/java/org/metafacture/monitoring/ObjectLoggerTest.java
+++ b/metafacture-monitoring/src/test/java/org/metafacture/monitoring/ObjectLoggerTest.java
@@ -93,7 +93,7 @@ public final class ObjectLoggerTest extends TestHelpers {
     @Test
     public void shouldLogWithPrefix() {
         final String prefix = "prefix:";
-        logger = new ObjectLogger<>(prefix);
+        logger.setPrefix(prefix);
 
         logger.process("object");
         logger.resetStream();

--- a/metafacture-monitoring/src/test/java/org/metafacture/monitoring/ObjectTimerTest.java
+++ b/metafacture-monitoring/src/test/java/org/metafacture/monitoring/ObjectTimerTest.java
@@ -20,6 +20,10 @@ import org.metafacture.framework.helpers.DefaultObjectReceiver;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.Logger;
 
 /**
  * Tests for class {@link ObjectTimer}.
@@ -27,7 +31,11 @@ import org.junit.Test;
  * @author Christoph Böhme
  *
  */
-public final class ObjectTimerTest {
+@RunWith(MockitoJUnitRunner.class)
+public final class ObjectTimerTest extends TestHelpers {
+
+    @Mock(name = "external.org.metafacture.monitoring.TimerBase")
+    private Logger logger;
 
     private ObjectTimer<String> objectTimer;
     private BenchmarkedModule benchmarkedModule;
@@ -44,18 +52,34 @@ public final class ObjectTimerTest {
 
     @Test
     public void testShouldMeasureExecutionTime() {
-
         objectTimer.process("");
         objectTimer.process("");
         objectTimer.process("");
         objectTimer.process("");
         objectTimer.closeStream();
+
+        assertLog(logger, "", 4);
     }
 
     @Test
     public void testShouldHandleImmediateCloseStreamWithNoProcessing() {
-
         objectTimer.closeStream();
+        assertLog(logger, "", 0);
+    }
+
+    @Test
+    public void shouldLogWithPrefix() {
+        final String prefix = "prefix:";
+        objectTimer = new ObjectTimer<>(prefix);
+        objectTimer.setReceiver(benchmarkedModule);
+
+        objectTimer.process("");
+        objectTimer.process("");
+        objectTimer.process("");
+        objectTimer.process("");
+        objectTimer.closeStream();
+
+        assertLog(logger, prefix, 4);
     }
 
     /**

--- a/metafacture-monitoring/src/test/java/org/metafacture/monitoring/StreamLoggerTest.java
+++ b/metafacture-monitoring/src/test/java/org/metafacture/monitoring/StreamLoggerTest.java
@@ -114,7 +114,7 @@ public final class StreamLoggerTest extends TestHelpers {
     @Test
     public void shouldLogWithPrefix() {
         final String prefix = "prefix:";
-        logger = new StreamLogger(prefix);
+        logger.setPrefix(prefix);
 
         logger.startRecord("1");
         logger.startEntity("entity");

--- a/metafacture-monitoring/src/test/java/org/metafacture/monitoring/StreamLoggerTest.java
+++ b/metafacture-monitoring/src/test/java/org/metafacture/monitoring/StreamLoggerTest.java
@@ -20,10 +20,12 @@ import org.metafacture.framework.StreamReceiver;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.Logger;
 
 /**
  * Tests for class {@link StreamLogger}.
@@ -32,7 +34,11 @@ import org.mockito.MockitoAnnotations;
  * @author Christoph Böhme (refactored to Mockito)
  *
  */
-public final class StreamLoggerTest {
+@RunWith(MockitoJUnitRunner.class)
+public final class StreamLoggerTest extends TestHelpers {
+
+    @Mock(name = "external.org.metafacture.monitoring.StreamLogger")
+    private Logger logLogger;
 
     @Mock
     private StreamReceiver receiver;
@@ -44,7 +50,6 @@ public final class StreamLoggerTest {
 
     @Before
     public void setup() {
-        MockitoAnnotations.initMocks(this);
         logger = new StreamLogger();
         logger.setReceiver(receiver);
     }
@@ -67,6 +72,18 @@ public final class StreamLoggerTest {
         ordered.verify(receiver).endRecord();
         ordered.verify(receiver).resetStream();
         ordered.verify(receiver).closeStream();
+        ordered.verifyNoMoreInteractions();
+        Mockito.verifyNoMoreInteractions(receiver);
+
+        assertLog(logLogger, "DEBUG", c -> {
+            assertLog(c, "{}start record {}", "", "1");
+            assertLog(c, "{}start entity {}", "", "entity");
+            assertLog(c, "{}literal {}={}", "", "literal", "value");
+            assertLog(c, "{}end entity", "");
+            assertLog(c, "{}end record", "");
+            assertLog(c, "{}resetStream", "");
+            assertLog(c, "{}closeStream", "");
+        });
     }
 
     @Test
@@ -81,7 +98,41 @@ public final class StreamLoggerTest {
         logger.resetStream();
         logger.closeStream();
 
-        // No exceptions expected
+        Mockito.verifyNoMoreInteractions(receiver);
+
+        assertLog(logLogger, "DEBUG", c -> {
+            assertLog(c, "{}start record {}", "", "1");
+            assertLog(c, "{}start entity {}", "", "entity");
+            assertLog(c, "{}literal {}={}", "", "literal", "value");
+            assertLog(c, "{}end entity", "");
+            assertLog(c, "{}end record", "");
+            assertLog(c, "{}resetStream", "");
+            assertLog(c, "{}closeStream", "");
+        });
+    }
+
+    @Test
+    public void shouldLogWithPrefix() {
+        final String prefix = "prefix:";
+        logger = new StreamLogger(prefix);
+
+        logger.startRecord("1");
+        logger.startEntity("entity");
+        logger.literal("literal", "value");
+        logger.endEntity();
+        logger.endRecord();
+        logger.resetStream();
+        logger.closeStream();
+
+        assertLog(logLogger, "DEBUG", c -> {
+            assertLog(c, "{}start record {}", prefix, "1");
+            assertLog(c, "{}start entity {}", prefix, "entity");
+            assertLog(c, "{}literal {}={}", prefix, "literal", "value");
+            assertLog(c, "{}end entity", prefix);
+            assertLog(c, "{}end record", prefix);
+            assertLog(c, "{}resetStream", prefix);
+            assertLog(c, "{}closeStream", prefix);
+        });
     }
 
 }

--- a/metafacture-monitoring/src/test/java/org/metafacture/monitoring/StreamTimerTest.java
+++ b/metafacture-monitoring/src/test/java/org/metafacture/monitoring/StreamTimerTest.java
@@ -20,6 +20,10 @@ import org.metafacture.framework.helpers.DefaultStreamReceiver;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.Logger;
 
 /**
  * Tests for class {@link ObjectTimer}.
@@ -27,7 +31,11 @@ import org.junit.Test;
  * @author Christoph Böhme
  *
  */
-public final class StreamTimerTest {
+@RunWith(MockitoJUnitRunner.class)
+public final class StreamTimerTest extends TestHelpers {
+
+    @Mock(name = "external.org.metafacture.monitoring.TimerBase")
+    private Logger logger;
 
     private StreamTimer streamTimer;
     private BenchmarkedModule benchmarkedModule;
@@ -44,7 +52,6 @@ public final class StreamTimerTest {
 
     @Test
     public void testShouldMeasureExecutionTime() {
-
         streamTimer.startRecord("");
         streamTimer.endRecord();
         streamTimer.startRecord("");
@@ -55,12 +62,34 @@ public final class StreamTimerTest {
         streamTimer.endRecord();
 
         streamTimer.closeStream();
+
+        assertLog(logger, "", 4);
     }
 
     @Test
     public void testShouldHandleImmediateCloseStreamWithNoProcessing() {
+        streamTimer.closeStream();
+        assertLog(logger, "", 0);
+    }
+
+    @Test
+    public void shouldLogWithPrefix() {
+        final String prefix = "prefix:";
+        streamTimer = new StreamTimer(prefix);
+        streamTimer.setReceiver(benchmarkedModule);
+
+        streamTimer.startRecord("");
+        streamTimer.endRecord();
+        streamTimer.startRecord("");
+        streamTimer.endRecord();
+        streamTimer.startRecord("");
+        streamTimer.endRecord();
+        streamTimer.startRecord("");
+        streamTimer.endRecord();
 
         streamTimer.closeStream();
+
+        assertLog(logger, prefix, 4);
     }
 
     /**

--- a/metafacture-monitoring/src/test/java/org/metafacture/monitoring/TestHelpers.java
+++ b/metafacture-monitoring/src/test/java/org/metafacture/monitoring/TestHelpers.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 hbz NRW
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.metafacture.monitoring;
+
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+
+public class TestHelpers { // checkstyle-disable-line HideUtilityClassConstructor
+
+    private static final Object[] NO_ARGS = new Object[]{};
+
+    /*package-private*/ TestHelpers() {
+    }
+
+    public static void assertLog(final Logger logger, final String level, final Consumer<BiConsumer<String, Object[]>> consumer) {
+        final InOrder ordered = Mockito.inOrder(logger);
+
+        switch (level) {
+            case "DEBUG":
+                consumer.accept((f, a) -> ordered.verify(logger).debug(f, a));
+                break;
+            case "ERROR":
+                consumer.accept((f, a) -> ordered.verify(logger).error(f, a));
+                break;
+            case "INFO":
+                consumer.accept((f, a) -> ordered.verify(logger).info(f, a));
+                break;
+            case "WARN":
+                consumer.accept((f, a) -> ordered.verify(logger).warn(f, a));
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported log level: " + level);
+        }
+
+        ordered.verifyNoMoreInteractions();
+        Mockito.verifyNoMoreInteractions(logger);
+    }
+
+    public static void assertLog(final BiConsumer<String, Object[]> consumer, final String format, final Object... arguments) {
+        consumer.accept(format, arguments);
+    }
+
+    public static void assertLog(final Logger logger, final String prefix, final int executions) {
+        final InOrder ordered = Mockito.inOrder(logger);
+
+        IntStream.range(0, executions).forEach(i -> ordered.verify(logger).info(Mockito.matches(prefix + "Execution " + (i + 1) + ": \\d+.+s"), NO_ARGS));
+        ordered.verify(logger).info(Mockito.matches(prefix + "Executions: " + executions + "; Cumulative duration: \\d+.*s; Average duration: \\d+.*s"), NO_ARGS);
+        ordered.verify(logger).info(Mockito.matches(prefix + "Time to close stream:  \\d+.+s"), NO_ARGS);
+
+        ordered.verifyNoMoreInteractions();
+        Mockito.verifyNoMoreInteractions(logger);
+    }
+
+}

--- a/metafacture-runner/src/main/dist/examples/misc/logging/inputFile.json
+++ b/metafacture-runner/src/main/dist/examples/misc/logging/inputFile.json
@@ -1,0 +1,2 @@
+{  "hello" : "World"  }
+{  "goodBye" : "World"  }

--- a/metafacture-runner/src/main/dist/examples/misc/logging/log.flux
+++ b/metafacture-runner/src/main/dist/examples/misc/logging/log.flux
@@ -1,0 +1,12 @@
+FLUX_DIR + "inputFile.json"
+| open-file
+| as-records
+| log-object(prefix="Before Transformation Object Log: ")
+| decode-json
+| log-stream(prefix="Before Transformation Stream Log: ")
+| fix("add_field('test','field')")
+| log-stream(prefix="After Transformation Stream Log: ")
+| encode-json
+| log-object(prefix="Output Object Log: ")
+| print
+;


### PR DESCRIPTION
Resolves #164.

Deprecates constructor with prefix argument.