### PR TITLE
Add setter for log level in object and stream (batch) loggers.

### DIFF
--- a/metafacture-framework/src/main/java/org/metafacture/framework/MetafactureLogger.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/MetafactureLogger.java
@@ -32,6 +32,26 @@ public class MetafactureLogger {
     private final Logger externalLogger;
     private final Logger internalLogger;
 
+    public enum Level {
+
+        ERROR((l, f, a) -> l.error(f, a)),
+        WARN((l, f, a) -> l.warn(f, a)),
+        INFO((l, f, a) -> l.info(f, a)),
+        DEBUG((l, f, a) -> l.debug(f, a)),
+        TRACE((l, f, a) -> l.trace(f, a));
+
+        private final LoggingConsumer consumer;
+
+        Level(final LoggingConsumer consumer) {
+            this.consumer = consumer;
+        }
+
+        private void log(final Logger logger, final String format, final Object... arguments) {
+            consumer.accept(logger, format, arguments);
+        }
+
+    }
+
     /**
      * Creates an instance of {@link MetafactureLogger} with the given class.
      *
@@ -67,6 +87,97 @@ public class MetafactureLogger {
      */
     public Logger getExternalLogger() {
         return externalLogger;
+    }
+
+    private void log(final Level level, final Logger logger, final String format, final Object... arguments) {
+        level.log(logger, format, arguments);
+    }
+
+    private void log(final String level, final Logger logger, final String format, final Object... arguments) {
+        final Level levelValue;
+
+        try {
+            levelValue = Level.valueOf(level);
+        }
+        catch (final IllegalArgumentException e) {
+            throw new IllegalArgumentException("Unsupported log level: " + level, e);
+        }
+
+        log(levelValue, logger, format, arguments);
+    }
+
+    /**
+     * Logs an <i>internal</i> message at the specified {@link Level level}
+     * according to the specified format and arguments.
+     *
+     * @param level the log level
+     * @param format the format string
+     * @param arguments a list of arguments
+     */
+    public void log(final Level level, final String format, final Object... arguments) {
+        log(level, internalLogger, format, arguments);
+    }
+
+    /**
+     * Logs an <i>internal</i> message at the specified {@link Level level}
+     * according to the specified format and arguments.
+     *
+     * @param level the log level
+     * @param format the format string
+     * @param arguments a list of arguments
+     */
+    public void log(final String level, final String format, final Object... arguments) {
+        log(level, internalLogger, format, arguments);
+    }
+
+    /**
+     * Logs an <i>external</i> message at the specified {@link Level level}
+     * according to the specified format and arguments.
+     *
+     * @param level the log level
+     * @param format the format string
+     * @param arguments a list of arguments
+     */
+    public void externalLog(final Level level, final String format, final Object... arguments) {
+        log(level, externalLogger, format, arguments);
+    }
+
+    /**
+     * Logs an <i>external</i> message at the specified {@link Level level}
+     * according to the specified format and arguments.
+     *
+     * @param level the log level
+     * @param format the format string
+     * @param arguments a list of arguments
+     */
+    public void externalLog(final String level, final String format, final Object... arguments) {
+        log(level, externalLogger, format, arguments);
+    }
+
+    /**
+     * Logs an <i>internal and external</i> message at the specified {@link Level level}
+     * according to the specified format and arguments.
+     *
+     * @param level the log level
+     * @param format the format string
+     * @param arguments a list of arguments
+     */
+    public void combinedLog(final Level level, final String format, final Object... arguments) {
+        log(level, format, arguments);
+        externalLog(level, format, arguments);
+    }
+
+    /**
+     * Logs an <i>internal and external</i> message at the specified {@link Level level}
+     * according to the specified format and arguments.
+     *
+     * @param level the log level
+     * @param format the format string
+     * @param arguments a list of arguments
+     */
+    public void combinedLog(final String level, final String format, final Object... arguments) {
+        log(level, format, arguments);
+        externalLog(level, format, arguments);
     }
 
     /**
@@ -237,6 +348,11 @@ public class MetafactureLogger {
     public void combinedTrace(final String format, final Object... arguments) {
         trace(format, arguments);
         externalTrace(format, arguments);
+    }
+
+    @FunctionalInterface
+    private interface LoggingConsumer {
+        void accept(Logger logger, String format, Object... arguments);
     }
 
 }

--- a/metafacture-monitoring/src/main/java/org/metafacture/monitoring/ObjectBatchLogger.java
+++ b/metafacture-monitoring/src/main/java/org/metafacture/monitoring/ObjectBatchLogger.java
@@ -49,12 +49,14 @@ public final class ObjectBatchLogger<T> extends DefaultObjectPipe<T, ObjectRecei
     public static final String BATCH_COUNT_VAR = "batches";
     public static final String BATCH_SIZE_VAR = "batchSize";
     public static final String DEFAULT_FORMAT = "records processed: ${totalRecords}";
+    public static final String DEFAULT_LEVEL = "INFO";
 
     private static final MetafactureLogger LOG = new MetafactureLogger(ObjectBatchLogger.class);
 
     private final Map<String, String> vars = new HashMap<String, String>();
     private final String format;
 
+    private String level = DEFAULT_LEVEL;
     private long batchSize = DEFAULT_BATCH_SIZE;
     private long recordCount;
     private long batchCount;
@@ -96,12 +98,21 @@ public final class ObjectBatchLogger<T> extends DefaultObjectPipe<T, ObjectRecei
         this.batchSize = batchSize;
     }
 
+    /**
+     * Sets the {@link MetafactureLogger.Level log level}.
+     *
+     * @param level the log level
+     */
+    public void setLevel(final String level) {
+        this.level = level;
+    }
+
     private void writeLog() {
         vars.put(RECORD_COUNT_VAR, Long.toString(recordCount));
         vars.put(BATCH_COUNT_VAR, Long.toString(batchCount));
         vars.put(BATCH_SIZE_VAR, Long.toString(batchSize));
         vars.put(TOTAL_RECORD_COUNT_VAR, Long.toString((batchSize * batchCount) + recordCount));
-        LOG.externalInfo(StringUtil.format(format, vars));
+        LOG.externalLog(level, StringUtil.format(format, vars));
     }
 
     @Override

--- a/metafacture-monitoring/src/main/java/org/metafacture/monitoring/ObjectLogger.java
+++ b/metafacture-monitoring/src/main/java/org/metafacture/monitoring/ObjectLogger.java
@@ -24,6 +24,10 @@ import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * Logs the string representation of every object.
  *
@@ -73,7 +77,7 @@ public final class ObjectLogger<T>
 
     @Override
     public void process(final T obj) {
-        LOG.externalDebug("{}{}", logPrefix, obj);
+        writeLog("{}", obj);
         if (getReceiver() != null) {
             getReceiver().process(obj);
         }
@@ -81,12 +85,21 @@ public final class ObjectLogger<T>
 
     @Override
     protected void onResetStream() {
-        LOG.externalDebug("{}resetStream", logPrefix);
+        writeLog("resetStream");
     }
 
     @Override
     protected void onCloseStream() {
-        LOG.externalDebug("{}closeStream", logPrefix);
+        writeLog("closeStream");
+    }
+
+    private void writeLog(final String message, final Object... arguments) {
+        final List<Object> argumentList = new ArrayList<>(arguments.length + 1);
+
+        argumentList.add(logPrefix);
+        Arrays.stream(arguments).forEach(argumentList::add);
+
+        LOG.externalDebug("{}" + message, argumentList.toArray());
     }
 
 }

--- a/metafacture-monitoring/src/main/java/org/metafacture/monitoring/ObjectLogger.java
+++ b/metafacture-monitoring/src/main/java/org/metafacture/monitoring/ObjectLogger.java
@@ -43,8 +43,11 @@ import java.util.List;
 public final class ObjectLogger<T>
         extends DefaultObjectPipe<T, ObjectReceiver<T>> {
 
+    public static final String DEFAULT_LEVEL = "DEBUG";
+
     private static final MetafactureLogger LOG = new MetafactureLogger(ObjectLogger.class);
 
+    private String level = DEFAULT_LEVEL;
     private String logPrefix = "";
 
     /**
@@ -75,6 +78,15 @@ public final class ObjectLogger<T>
         this.logPrefix = prefix;
     }
 
+    /**
+     * Sets the {@link MetafactureLogger.Level log level}.
+     *
+     * @param level the log level
+     */
+    public void setLevel(final String level) {
+        this.level = level;
+    }
+
     @Override
     public void process(final T obj) {
         writeLog("{}", obj);
@@ -99,7 +111,7 @@ public final class ObjectLogger<T>
         argumentList.add(logPrefix);
         Arrays.stream(arguments).forEach(argumentList::add);
 
-        LOG.externalDebug("{}" + message, argumentList.toArray());
+        LOG.externalLog(level, "{}" + message, argumentList.toArray());
     }
 
 }

--- a/metafacture-monitoring/src/main/java/org/metafacture/monitoring/ObjectLogger.java
+++ b/metafacture-monitoring/src/main/java/org/metafacture/monitoring/ObjectLogger.java
@@ -43,7 +43,7 @@ import java.util.List;
 public final class ObjectLogger<T>
         extends DefaultObjectPipe<T, ObjectReceiver<T>> {
 
-    public static final String DEFAULT_LEVEL = "DEBUG";
+    public static final String DEFAULT_LEVEL = "INFO";
 
     private static final MetafactureLogger LOG = new MetafactureLogger(ObjectLogger.class);
 

--- a/metafacture-monitoring/src/main/java/org/metafacture/monitoring/StreamBatchLogger.java
+++ b/metafacture-monitoring/src/main/java/org/metafacture/monitoring/StreamBatchLogger.java
@@ -34,7 +34,7 @@ import java.util.Map;
  * @author Markus Michael Geipel
  * @author Christoph Böhme
  */
-@Description("Writes log info every BATCHSIZE records. ")
+@Description("Writes log info every BATCHSIZE records.")
 @In(StreamReceiver.class)
 @Out(StreamReceiver.class)
 @FluxCommand("batch-log")
@@ -45,6 +45,7 @@ public final class StreamBatchLogger extends ForwardingStreamPipe {
     public static final String BATCH_SIZE_VAR = "batchSize";
     public static final String TOTAL_RECORD_COUNT_VAR = "totalRecords";
     public static final String DEFAULT_FORMAT = "records processed: ${totalRecords}";
+    public static final String DEFAULT_LEVEL = "INFO";
 
     public static final long DEFAULT_BATCH_SIZE = 1000;
 
@@ -53,6 +54,7 @@ public final class StreamBatchLogger extends ForwardingStreamPipe {
     private final Map<String, String> vars = new HashMap<>();
     private final String format;
 
+    private String level = DEFAULT_LEVEL;
     private long batchSize = DEFAULT_BATCH_SIZE;
     private long recordCount;
     private long batchCount;
@@ -92,6 +94,15 @@ public final class StreamBatchLogger extends ForwardingStreamPipe {
      */
     public void setBatchSize(final int batchSize) {
         this.batchSize = batchSize;
+    }
+
+    /**
+     * Sets the {@link MetafactureLogger.Level log level}.
+     *
+     * @param level the log level
+     */
+    public void setLevel(final String level) {
+        this.level = level;
     }
 
     /**
@@ -149,7 +160,7 @@ public final class StreamBatchLogger extends ForwardingStreamPipe {
         vars.put(BATCH_SIZE_VAR, Long.toString(batchSize));
         vars.put(TOTAL_RECORD_COUNT_VAR,
                 Long.toString(batchSize * batchCount + recordCount));
-        LOG.externalInfo(StringUtil.format(format, vars));
+        LOG.externalLog(level, StringUtil.format(format, vars));
     }
 
 }

--- a/metafacture-monitoring/src/main/java/org/metafacture/monitoring/StreamLogger.java
+++ b/metafacture-monitoring/src/main/java/org/metafacture/monitoring/StreamLogger.java
@@ -43,8 +43,11 @@ import java.util.List;
 public final class StreamLogger
         extends DefaultStreamPipe<StreamReceiver> {
 
+    public static final String DEFAULT_LEVEL = "DEBUG";
+
     private static final MetafactureLogger LOG = new MetafactureLogger(StreamLogger.class);
 
+    private String level = DEFAULT_LEVEL;
     private String logPrefix = "";
 
     /**
@@ -73,6 +76,15 @@ public final class StreamLogger
      */
     public void setPrefix(final String prefix) {
         this.logPrefix = prefix;
+    }
+
+    /**
+     * Sets the {@link MetafactureLogger.Level log level}.
+     *
+     * @param level the log level
+     */
+    public void setLevel(final String level) {
+        this.level = level;
     }
 
     @Override
@@ -137,7 +149,7 @@ public final class StreamLogger
         argumentList.add(logPrefix);
         Arrays.stream(arguments).forEach(argumentList::add);
 
-        LOG.externalDebug("{}" + message, argumentList.toArray());
+        LOG.externalLog(level, "{}" + message, argumentList.toArray());
     }
 
 }

--- a/metafacture-monitoring/src/main/java/org/metafacture/monitoring/StreamLogger.java
+++ b/metafacture-monitoring/src/main/java/org/metafacture/monitoring/StreamLogger.java
@@ -29,7 +29,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Leaves the event stream untouched but logs it to the debug log.
+ * Leaves the event stream untouched but logs it to the info log.
  * The {@link StreamReceiver} may be {@code null}.
  * In this case {@link StreamLogger} behaves as a sink, just logging.
  *
@@ -43,7 +43,7 @@ import java.util.List;
 public final class StreamLogger
         extends DefaultStreamPipe<StreamReceiver> {
 
-    public static final String DEFAULT_LEVEL = "DEBUG";
+    public static final String DEFAULT_LEVEL = "INFO";
 
     private static final MetafactureLogger LOG = new MetafactureLogger(StreamLogger.class);
 

--- a/metafacture-monitoring/src/main/java/org/metafacture/monitoring/StreamLogger.java
+++ b/metafacture-monitoring/src/main/java/org/metafacture/monitoring/StreamLogger.java
@@ -24,6 +24,10 @@ import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultStreamPipe;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * Leaves the event stream untouched but logs it to the debug log.
  * The {@link StreamReceiver} may be {@code null}.
@@ -74,7 +78,7 @@ public final class StreamLogger
     @Override
     public void startRecord(final String identifier) {
         assert !isClosed();
-        LOG.externalDebug("{}start record {}", logPrefix, identifier);
+        writeLog("start record {}", identifier);
         if (null != getReceiver()) {
             getReceiver().startRecord(identifier);
         }
@@ -83,7 +87,7 @@ public final class StreamLogger
     @Override
     public void endRecord() {
         assert !isClosed();
-        LOG.externalDebug("{}end record", logPrefix);
+        writeLog("end record");
         if (null != getReceiver()) {
             getReceiver().endRecord();
         }
@@ -92,7 +96,7 @@ public final class StreamLogger
     @Override
     public void startEntity(final String name) {
         assert !isClosed();
-        LOG.externalDebug("{}start entity {}", logPrefix, name);
+        writeLog("start entity {}", name);
         if (null != getReceiver()) {
             getReceiver().startEntity(name);
         }
@@ -101,7 +105,7 @@ public final class StreamLogger
     @Override
     public void endEntity() {
         assert !isClosed();
-        LOG.externalDebug("{}end entity", logPrefix);
+        writeLog("end entity");
         if (null != getReceiver()) {
             getReceiver().endEntity();
         }
@@ -111,7 +115,7 @@ public final class StreamLogger
     @Override
     public void literal(final String name, final String value) {
         assert !isClosed();
-        LOG.externalDebug("{}literal {}={}", logPrefix, name, value);
+        writeLog("literal {}={}", name, value);
         if (null != getReceiver()) {
             getReceiver().literal(name, value);
         }
@@ -119,12 +123,21 @@ public final class StreamLogger
 
     @Override
     protected void onResetStream() {
-        LOG.externalDebug("{}resetStream", logPrefix);
+        writeLog("resetStream");
     }
 
     @Override
     protected void onCloseStream() {
-        LOG.externalDebug("{}closeStream", logPrefix);
+        writeLog("closeStream");
+    }
+
+    private void writeLog(final String message, final Object... arguments) {
+        final List<Object> argumentList = new ArrayList<>(arguments.length + 1);
+
+        argumentList.add(logPrefix);
+        Arrays.stream(arguments).forEach(argumentList::add);
+
+        LOG.externalDebug("{}" + message, argumentList.toArray());
     }
 
 }

--- a/metafacture-monitoring/src/test/java/org/metafacture/monitoring/ObjectBatchLoggerTest.java
+++ b/metafacture-monitoring/src/test/java/org/metafacture/monitoring/ObjectBatchLoggerTest.java
@@ -108,4 +108,16 @@ public final class ObjectBatchLoggerTest extends TestHelpers {
         });
     }
 
+    @Test
+    public void shouldLogAtCustomLevel() {
+        objectBatchLogger.setLevel("WARN");
+
+        objectBatchLogger.process("object");
+        objectBatchLogger.closeStream();
+
+        assertLog(logger, "WARN", c -> {
+            assertLog(c, "records processed: 1");
+        });
+    }
+
 }

--- a/metafacture-monitoring/src/test/java/org/metafacture/monitoring/ObjectBatchLoggerTest.java
+++ b/metafacture-monitoring/src/test/java/org/metafacture/monitoring/ObjectBatchLoggerTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 hbz NRW
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.metafacture.monitoring;
+
+import org.metafacture.framework.ObjectReceiver;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.Logger;
+
+/**
+ * Tests for class {@link ObjectBatchLogger}.
+ *
+ * @author Jens Wille
+ *
+ */
+@RunWith(MockitoJUnitRunner.class)
+public final class ObjectBatchLoggerTest extends TestHelpers {
+
+    @Mock(name = "external.org.metafacture.monitoring.ObjectBatchLogger")
+    private Logger logger;
+
+    @Mock
+    private ObjectReceiver<String> receiver;
+
+    private ObjectBatchLogger<String> objectBatchLogger;
+
+    public ObjectBatchLoggerTest() {
+    }
+
+    @Before
+    public void setup() {
+        objectBatchLogger = new ObjectBatchLogger<>();
+        objectBatchLogger.setReceiver(receiver);
+        objectBatchLogger.setBatchSize(2);
+    }
+
+    @Test
+    public void shouldForwardAllProcessedObjects() {
+        objectBatchLogger.process("object1");
+        objectBatchLogger.process("object2");
+        objectBatchLogger.process("object3");
+        objectBatchLogger.process("object4");
+        objectBatchLogger.process("object5");
+        objectBatchLogger.closeStream();
+
+        final InOrder ordered = Mockito.inOrder(receiver);
+        ordered.verify(receiver).process("object1");
+        ordered.verify(receiver).process("object2");
+        ordered.verify(receiver).process("object3");
+        ordered.verify(receiver).process("object4");
+        ordered.verify(receiver).process("object5");
+        ordered.verify(receiver).closeStream();
+        ordered.verifyNoMoreInteractions();
+        Mockito.verifyNoMoreInteractions(receiver);
+
+        assertLog(logger, "INFO", c -> {
+            assertLog(c, "records processed: 2");
+            assertLog(c, "records processed: 4");
+            assertLog(c, "records processed: 5");
+        });
+    }
+
+    @Test
+    public void shouldActAsSinkIfNoReceiverIsSet() {
+        objectBatchLogger.setReceiver(null);
+
+        objectBatchLogger.process("object");
+        objectBatchLogger.closeStream();
+
+        Mockito.verifyNoMoreInteractions(receiver);
+
+        assertLog(logger, "INFO", c -> {
+            assertLog(c, "records processed: 1");
+        });
+    }
+
+    @Test
+    public void shouldLogWithCustomFormat() {
+        objectBatchLogger = new ObjectBatchLogger<>("records=${records}, totalRecords=${totalRecords}, batches=${batches}, batchSize=${batchSize}");
+
+        objectBatchLogger.process("object");
+        objectBatchLogger.closeStream();
+
+        Mockito.verifyNoMoreInteractions(receiver);
+
+        assertLog(logger, "INFO", c -> {
+            assertLog(c, "records=1, totalRecords=1, batches=0, batchSize=1000");
+        });
+    }
+
+}

--- a/metafacture-monitoring/src/test/java/org/metafacture/monitoring/ObjectLoggerTest.java
+++ b/metafacture-monitoring/src/test/java/org/metafacture/monitoring/ObjectLoggerTest.java
@@ -66,7 +66,7 @@ public final class ObjectLoggerTest extends TestHelpers {
         ordered.verifyNoMoreInteractions();
         Mockito.verifyNoMoreInteractions(receiver);
 
-        assertLog(logLogger, "DEBUG", c -> {
+        assertLog(logLogger, "INFO", c -> {
             assertLog(c, "{}{}", "", "object");
             assertLog(c, "{}resetStream", "");
             assertLog(c, "{}closeStream", "");
@@ -83,7 +83,7 @@ public final class ObjectLoggerTest extends TestHelpers {
 
         Mockito.verifyNoMoreInteractions(receiver);
 
-        assertLog(logLogger, "DEBUG", c -> {
+        assertLog(logLogger, "INFO", c -> {
             assertLog(c, "{}{}", "", "object");
             assertLog(c, "{}resetStream", "");
             assertLog(c, "{}closeStream", "");
@@ -99,7 +99,7 @@ public final class ObjectLoggerTest extends TestHelpers {
         logger.resetStream();
         logger.closeStream();
 
-        assertLog(logLogger, "DEBUG", c -> {
+        assertLog(logLogger, "INFO", c -> {
             assertLog(c, "{}{}", prefix, "object");
             assertLog(c, "{}resetStream", prefix);
             assertLog(c, "{}closeStream", prefix);

--- a/metafacture-monitoring/src/test/java/org/metafacture/monitoring/ObjectLoggerTest.java
+++ b/metafacture-monitoring/src/test/java/org/metafacture/monitoring/ObjectLoggerTest.java
@@ -106,4 +106,19 @@ public final class ObjectLoggerTest extends TestHelpers {
         });
     }
 
+    @Test
+    public void shouldLogAtCustomLevel() {
+        logger.setLevel("WARN");
+
+        logger.process("object");
+        logger.resetStream();
+        logger.closeStream();
+
+        assertLog(logLogger, "WARN", c -> {
+            assertLog(c, "{}{}", "", "object");
+            assertLog(c, "{}resetStream", "");
+            assertLog(c, "{}closeStream", "");
+        });
+    }
+
 }

--- a/metafacture-monitoring/src/test/java/org/metafacture/monitoring/StreamBatchLoggerTest.java
+++ b/metafacture-monitoring/src/test/java/org/metafacture/monitoring/StreamBatchLoggerTest.java
@@ -129,4 +129,17 @@ public final class StreamBatchLoggerTest extends TestHelpers {
         });
     }
 
+    @Test
+    public void shouldLogAtCustomLevel() {
+        streamBatchLogger.setLevel("WARN");
+
+        streamBatchLogger.startRecord("1");
+        streamBatchLogger.endRecord();
+        streamBatchLogger.closeStream();
+
+        assertLog(logger, "WARN", c -> {
+            assertLog(c, "records processed: 1");
+        });
+    }
+
 }

--- a/metafacture-monitoring/src/test/java/org/metafacture/monitoring/StreamBatchLoggerTest.java
+++ b/metafacture-monitoring/src/test/java/org/metafacture/monitoring/StreamBatchLoggerTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 hbz NRW
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.metafacture.monitoring;
+
+import org.metafacture.framework.StreamReceiver;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.Logger;
+
+/**
+ * Tests for class {@link StreamBatchLogger}.
+ *
+ * @author Jens Wille
+ *
+ */
+@RunWith(MockitoJUnitRunner.class)
+public final class StreamBatchLoggerTest extends TestHelpers {
+
+    @Mock(name = "external.org.metafacture.monitoring.StreamBatchLogger")
+    private Logger logger;
+
+    @Mock
+    private StreamReceiver receiver;
+
+    private StreamBatchLogger streamBatchLogger;
+
+    public StreamBatchLoggerTest() {
+    }
+
+    @Before
+    public void setup() {
+        streamBatchLogger = new StreamBatchLogger();
+        streamBatchLogger.setReceiver(receiver);
+        streamBatchLogger.setBatchSize(2);
+    }
+
+    @Test
+    public void shouldForwardAllReceivedEvents() {
+        streamBatchLogger.startRecord("1");
+        streamBatchLogger.startEntity("entity");
+        streamBatchLogger.literal("literal", "value");
+        streamBatchLogger.endEntity();
+        streamBatchLogger.endRecord();
+        streamBatchLogger.startRecord("2");
+        streamBatchLogger.endRecord();
+        streamBatchLogger.startRecord("3");
+        streamBatchLogger.endRecord();
+        streamBatchLogger.startRecord("4");
+        streamBatchLogger.endRecord();
+        streamBatchLogger.startRecord("5");
+        streamBatchLogger.endRecord();
+        streamBatchLogger.closeStream();
+
+        final InOrder ordered = Mockito.inOrder(receiver);
+        ordered.verify(receiver).startRecord("1");
+        ordered.verify(receiver).startEntity("entity");
+        ordered.verify(receiver).literal("literal", "value");
+        ordered.verify(receiver).endEntity();
+        ordered.verify(receiver).endRecord();
+        ordered.verify(receiver).startRecord("2");
+        ordered.verify(receiver).endRecord();
+        ordered.verify(receiver).startRecord("3");
+        ordered.verify(receiver).endRecord();
+        ordered.verify(receiver).startRecord("4");
+        ordered.verify(receiver).endRecord();
+        ordered.verify(receiver).startRecord("5");
+        ordered.verify(receiver).endRecord();
+        ordered.verify(receiver).closeStream();
+        ordered.verifyNoMoreInteractions();
+        Mockito.verifyNoMoreInteractions(receiver);
+
+        assertLog(logger, "INFO", c -> {
+            assertLog(c, "records processed: 2");
+            assertLog(c, "records processed: 4");
+            assertLog(c, "records processed: 5");
+        });
+    }
+
+    @Test
+    public void shouldNotActAsSinkIfNoReceiverIsSet() {
+        streamBatchLogger.setReceiver(null);
+
+        Assert.assertThrows(NullPointerException.class, () -> streamBatchLogger.startRecord("1"));
+        Assert.assertThrows(NullPointerException.class, streamBatchLogger::endRecord);
+        streamBatchLogger.closeStream();
+
+        Mockito.verifyNoMoreInteractions(receiver);
+
+        assertLog(logger, "INFO", c -> {
+            assertLog(c, "records processed: 0");
+        });
+    }
+
+    @Test
+    public void shouldLogWithCustomFormat() {
+        streamBatchLogger = new StreamBatchLogger("records=${records}, totalRecords=${totalRecords}, batches=${batches}, batchSize=${batchSize}");
+        streamBatchLogger.setReceiver(receiver);
+
+        streamBatchLogger.startRecord("1");
+        streamBatchLogger.startEntity("entity");
+        streamBatchLogger.literal("literal", "value");
+        streamBatchLogger.endEntity();
+        streamBatchLogger.endRecord();
+        streamBatchLogger.closeStream();
+
+        assertLog(logger, "INFO", c -> {
+            assertLog(c, "records=1, totalRecords=1, batches=0, batchSize=1000");
+        });
+    }
+
+}

--- a/metafacture-monitoring/src/test/java/org/metafacture/monitoring/StreamLoggerTest.java
+++ b/metafacture-monitoring/src/test/java/org/metafacture/monitoring/StreamLoggerTest.java
@@ -75,7 +75,7 @@ public final class StreamLoggerTest extends TestHelpers {
         ordered.verifyNoMoreInteractions();
         Mockito.verifyNoMoreInteractions(receiver);
 
-        assertLog(logLogger, "DEBUG", c -> {
+        assertLog(logLogger, "INFO", c -> {
             assertLog(c, "{}start record {}", "", "1");
             assertLog(c, "{}start entity {}", "", "entity");
             assertLog(c, "{}literal {}={}", "", "literal", "value");
@@ -100,7 +100,7 @@ public final class StreamLoggerTest extends TestHelpers {
 
         Mockito.verifyNoMoreInteractions(receiver);
 
-        assertLog(logLogger, "DEBUG", c -> {
+        assertLog(logLogger, "INFO", c -> {
             assertLog(c, "{}start record {}", "", "1");
             assertLog(c, "{}start entity {}", "", "entity");
             assertLog(c, "{}literal {}={}", "", "literal", "value");
@@ -124,7 +124,7 @@ public final class StreamLoggerTest extends TestHelpers {
         logger.resetStream();
         logger.closeStream();
 
-        assertLog(logLogger, "DEBUG", c -> {
+        assertLog(logLogger, "INFO", c -> {
             assertLog(c, "{}start record {}", prefix, "1");
             assertLog(c, "{}start entity {}", prefix, "entity");
             assertLog(c, "{}literal {}={}", prefix, "literal", "value");

--- a/metafacture-monitoring/src/test/java/org/metafacture/monitoring/StreamLoggerTest.java
+++ b/metafacture-monitoring/src/test/java/org/metafacture/monitoring/StreamLoggerTest.java
@@ -135,4 +135,27 @@ public final class StreamLoggerTest extends TestHelpers {
         });
     }
 
+    @Test
+    public void shouldLogAtCustomLevel() {
+        logger.setLevel("WARN");
+
+        logger.startRecord("1");
+        logger.startEntity("entity");
+        logger.literal("literal", "value");
+        logger.endEntity();
+        logger.endRecord();
+        logger.resetStream();
+        logger.closeStream();
+
+        assertLog(logLogger, "WARN", c -> {
+            assertLog(c, "{}start record {}", "", "1");
+            assertLog(c, "{}start entity {}", "", "entity");
+            assertLog(c, "{}literal {}={}", "", "literal", "value");
+            assertLog(c, "{}end entity", "");
+            assertLog(c, "{}end record", "");
+            assertLog(c, "{}resetStream", "");
+            assertLog(c, "{}closeStream", "");
+        });
+    }
+
 }

--- a/metafix/src/main/java/org/metafacture/metafix/method/script/Log.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/script/Log.java
@@ -24,7 +24,6 @@ import org.metafacture.metafix.api.FixFunction;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
 
 @FixCommand("log")
 public class Log implements FixFunction {
@@ -39,29 +38,8 @@ public class Log implements FixFunction {
 
     @Override
     public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
-        // does not support Catmandu log level option FATAL
-
-        final String level = options.getOrDefault("level", "INFO");
-        final Consumer<String> consumer;
-
-        switch (level) {
-            case "DEBUG":
-                consumer = LOG::externalDebug;
-                break;
-            case "ERROR":
-                consumer = LOG::externalError;
-                break;
-            case "INFO":
-                consumer = LOG::externalInfo;
-                break;
-            case "WARN":
-                consumer = LOG::externalWarn;
-                break;
-            default:
-                throw new IllegalArgumentException("Unsupported log level: " + level);
-        }
-
-        consumer.accept(params.get(0));
+        // does not support Catmandu log level option FATAL, but does (incidentally) support TRACE
+        LOG.externalLog(options.getOrDefault("level", "INFO"), params.get(0));
     }
 
 }


### PR DESCRIPTION
Resolves #214.

Also switches the default log level for `ObjectLogger` and `StreamLogger` to INFO (aligning them with `ObjectBatchLogger` and `StreamBatchLogger`).

_Base branch will be changed automatically once #771 is merged._