### PR TITLE
Provide Java 21 forward compatibility.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ subprojects {
       'commons_io':       '2.21.0',
       'dbcp':             '1.4',
       'dspace':           '1.0.0',
-      'equalsverifier':   '3.8.2',
+      'equalsverifier':   '3.19.4',
       'everit':           '1.14.6',
       'guava':            '32.0.1-jre',
       'jackson':          '2.21.4',

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ subprojects {
       'junit_jupiter':    '5.8.2',
       'junit_platform':   '1.4.2',
       'mockito':          '2.27.0',
+      'nashorn':          '15.7',
       'opencsv':          '5.12.0',
       'slf4j':            '2.0.17',
       'slf4j_log4j':      '2.25.4',

--- a/metafacture-commons/src/main/java/org/metafacture/commons/ResourceUtil.java
+++ b/metafacture-commons/src/main/java/org/metafacture/commons/ResourceUtil.java
@@ -25,6 +25,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
@@ -70,7 +72,7 @@ public final class ResourceUtil { // checkstyle-disable-line ClassDataAbstractio
                 .getResourceAsStream(name);
         if (stream == null) {
             try {
-                stream = new URL(name).openStream();
+                stream = toURL(name).openStream();
             }
             catch (final IOException e) {
                 throwFileNotFoundException(name, e);
@@ -177,7 +179,7 @@ public final class ResourceUtil { // checkstyle-disable-line ClassDataAbstractio
 
         final URL resourceUrl =
                 Thread.currentThread().getContextClassLoader().getResource(name);
-        return resourceUrl != null ? resourceUrl : new URL(name);
+        return resourceUrl != null ? resourceUrl : toURL(name);
     }
 
     /**
@@ -189,6 +191,52 @@ public final class ResourceUtil { // checkstyle-disable-line ClassDataAbstractio
      */
     public static URL getUrl(final File file) throws MalformedURLException {
         return file.toURI().toURL();
+    }
+
+    /**
+     * Creates a URL by parsing the given spec within a specified context.
+     *
+     * @param context the context in which to parse the specification
+     * @param spec the String to parse as a URL
+     *
+     * @return the resolved URL
+     *
+     * @throws MalformedURLException if the spec is invalid
+     */
+    public static URL toURL(final URL context, final String spec) throws MalformedURLException {
+        try {
+            return context.toURI().resolve(toURI(spec)).toURL();
+        }
+        catch (final URISyntaxException e) {
+            throw new MalformedURLException(e.toString());
+        }
+    }
+
+    /**
+     * Creates a URL object from the String representation.
+     *
+     * @param spec the String to parse as a URL
+     *
+     * @return the URL
+     *
+     * @throws MalformedURLException if the spec is invalid
+     */
+    public static URL toURL(final String spec) throws MalformedURLException {
+        try {
+            return toURI(spec).toURL();
+        }
+        catch (final IllegalArgumentException e) {
+            throw new MalformedURLException(e.toString());
+        }
+    }
+
+    private static URI toURI(final String spec) throws MalformedURLException {
+        try {
+            return new URI(spec);
+        }
+        catch (final URISyntaxException e) {
+            throw new MalformedURLException(e.toString());
+        }
     }
 
     /**

--- a/metafacture-io/src/main/java/org/metafacture/io/HttpOpener.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/HttpOpener.java
@@ -16,6 +16,7 @@
 
 package org.metafacture.io;
 
+import org.metafacture.commons.ResourceUtil;
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.MetafactureException;
 import org.metafacture.framework.ObjectReceiver;
@@ -301,7 +302,7 @@ public final class HttpOpener extends DefaultObjectPipe<String, ObjectReceiver<R
             final String requestBody = getInput(input,
                 body == null && method.getRequestHasBody() ? INPUT_DESIGNATOR : body);
 
-            final URL urlToOpen = new URL(requestUrl);
+            final URL urlToOpen = ResourceUtil.toURL(requestUrl);
             final HttpURLConnection connection = requestBody != null ?
                 doOutput(urlToOpen, requestBody) : doRedirects(urlToOpen);
 
@@ -368,7 +369,7 @@ public final class HttpOpener extends DefaultObjectPipe<String, ObjectReceiver<R
                 case HttpURLConnection.HTTP_MOVED_PERM:
                 case HttpURLConnection.HTTP_MOVED_TEMP:
                     final String location = URLDecoder.decode(connection.getHeaderField("Location"), "UTF-8");
-                    urlToFollow = new URL(urlToFollow, location); // Deal with relative URLs
+                    urlToFollow = ResourceUtil.toURL(urlToFollow, location); // Deal with relative URLs
                     break;
                 default:
                     return connection;

--- a/metafacture-json/build.gradle
+++ b/metafacture-json/build.gradle
@@ -19,6 +19,7 @@ description = 'Modules for processing JSON data in Metafacture'
 
 dependencies {
   api project(':metafacture-framework')
+  implementation project(':metafacture-commons')
   implementation "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
   implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"
   implementation "com.jayway.jsonpath:json-path:${versions.jsonpath}"

--- a/metafacture-json/src/main/java/org/metafacture/json/JsonValidator.java
+++ b/metafacture-json/src/main/java/org/metafacture/json/JsonValidator.java
@@ -16,6 +16,7 @@
 
 package org.metafacture.json;
 
+import org.metafacture.commons.ResourceUtil;
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.MetafactureException;
 import org.metafacture.framework.MetafactureLogger;
@@ -125,7 +126,7 @@ public final class JsonValidator extends DefaultObjectPipe<String, ObjectReceive
         }
         SchemaLoaderBuilder schemaLoader = SchemaLoader.builder();
         try {
-            final URL url = new URL(schemaUrl);
+            final URL url = ResourceUtil.toURL(schemaUrl);
             schemaLoader = schemaLoader.schemaJson(jsonFrom(url.openStream()))
                     .resolutionScope(baseFor(url.toString()));
         }

--- a/metafacture-json/src/test/java/org/metafacture/json/JsonValidatorTest.java
+++ b/metafacture-json/src/test/java/org/metafacture/json/JsonValidatorTest.java
@@ -16,6 +16,7 @@
 
 package org.metafacture.json;
 
+import org.metafacture.commons.ResourceUtil;
 import org.metafacture.framework.MetafactureException;
 import org.metafacture.framework.ObjectReceiver;
 
@@ -113,7 +114,7 @@ public final class JsonValidatorTest {
 
     @Test
     public void callWireMockSchema() throws MalformedURLException, IOException {
-        final String schemaContent = readToString(new URL(wireMockRule.baseUrl() + MAIN_SCHEMA));
+        final String schemaContent = readToString(ResourceUtil.toURL(wireMockRule.baseUrl() + MAIN_SCHEMA));
         MatcherAssert.assertThat(schemaContent, CoreMatchers.both(CoreMatchers.containsString("$schema")).and(CoreMatchers.containsString("$ref")));
     }
 

--- a/metafacture-triples/src/main/java/org/metafacture/triples/TripleObjectRetriever.java
+++ b/metafacture-triples/src/main/java/org/metafacture/triples/TripleObjectRetriever.java
@@ -100,7 +100,7 @@ public final class TripleObjectRetriever extends DefaultObjectPipe<Triple, Objec
 
     private String retrieveObjectValue(final String urlString) {
         try {
-            final URL url = new URL(urlString);
+            final URL url = ResourceUtil.toURL(urlString);
             final URLConnection connection = url.openConnection();
             connection.connect();
             final String encodingName = connection.getContentEncoding();

--- a/metafix/src/main/java/org/metafacture/metafix/Metafix.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Metafix.java
@@ -18,6 +18,7 @@
 
 package org.metafacture.metafix;
 
+import org.metafacture.commons.ResourceUtil;
 import org.metafacture.framework.FluxCommand;
 import org.metafacture.framework.MetafactureException;
 import org.metafacture.framework.MetafactureLogger;
@@ -39,7 +40,6 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
-import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -290,7 +290,7 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps {
 
     private boolean isValidUrl(final String url) {
         try {
-            new URL(url);
+            ResourceUtil.toURL(url);
             return true;
         }
         catch (final MalformedURLException e) {

--- a/metafix/src/main/java/org/metafacture/metafix/maps/RdfMap.java
+++ b/metafix/src/main/java/org/metafacture/metafix/maps/RdfMap.java
@@ -16,6 +16,7 @@
 
 package org.metafacture.metafix.maps;
 
+import org.metafacture.commons.ResourceUtil;
 import org.metafacture.metafix.FixExecutionException;
 import org.metafacture.metamorph.api.Maps;
 import org.metafacture.metamorph.api.helpers.AbstractReadOnlyMap;
@@ -34,7 +35,6 @@ import org.apache.jena.shared.PropertyNotFoundException;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.net.URL;
 import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -365,7 +365,7 @@ public final class RdfMap extends AbstractReadOnlyMap<String, String> implements
         URLConnection conn;
 
         while (true) {
-            final URLConnection conn2 = new URL(connectionURL).openConnection();
+            final URLConnection conn2 = ResourceUtil.toURL(connectionURL).openConnection();
             if (!(conn2 instanceof HttpURLConnection)) {
                 conn = conn2;
                 break;

--- a/metafix/src/test/java/org/metafacture/metafix/HashValueTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/HashValueTest.java
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class HashValueTest {
 
@@ -37,6 +39,8 @@ public class HashValueTest {
     private static final Value VALUE = new Value("value");
     private static final Value OTHER_VALUE = new Value("other value");
 
+    private static final Pattern PATTERN = Pattern.compile("");
+
     public HashValueTest() {
     }
 
@@ -44,6 +48,7 @@ public class HashValueTest {
     public void shouldSatisfyEqualsContract() {
         EqualsVerifier.forClass(Value.Hash.class)
             .withPrefabValues(Value.class, Value.newArray(), Value.newHash())
+            .withPrefabValues(Matcher.class, PATTERN.matcher("a"), PATTERN.matcher("b"))
             .withPrefabValues(SimpleRegexTrie.class, new SimpleRegexTrie<String>(), new SimpleRegexTrie<String>())
             .withIgnoredFields("patternMatcher", "prefixCache", "trie", "trieCache")
             .verify();

--- a/metamorph/build.gradle
+++ b/metamorph/build.gradle
@@ -26,6 +26,7 @@ dependencies {
   implementation project(':metafacture-mangling')
   implementation project(':metafacture-javaintegration')
   implementation "com.google.guava:guava:${versions.guava}"
+  implementation "org.openjdk.nashorn:nashorn-core:${versions.nashorn}"
   testRuntimeOnly slf4j_provider
   testImplementation "junit:junit:${versions.junit}"
   testImplementation "org.mockito:mockito-core:${versions.mockito}"

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/Case.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/Case.java
@@ -75,7 +75,7 @@ public final class Case extends AbstractSimpleStatelessFunction {
         if (!LANGUAGES.contains(language)) {
             throw new MorphBuildException("Language " + language + " not supported.");
         }
-        this.locale = new Locale(language);
+        this.locale = Locale.forLanguageTag(language);
     }
 
 }

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/DateFormat.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/DateFormat.java
@@ -212,6 +212,6 @@ public class DateFormat extends AbstractSimpleStatelessFunction {
         if (!SUPPORTED_LANGUAGES.contains(language)) {
             throw new MorphBuildException("Language '" + language + "' not supported.");
         }
-        this.outputLocale = new Locale(language);
+        this.outputLocale = Locale.forLanguageTag(language);
     }
 }

--- a/metamorph/src/main/java/org/metafacture/metamorph/functions/Timestamp.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/functions/Timestamp.java
@@ -111,7 +111,7 @@ public final class Timestamp extends AbstractSimpleStatelessFunction {
         if (!SUPPORTED_LANGUAGES.contains(language)) {
             throw new MorphBuildException("Language '" + language + "' not supported.");
         }
-        this.locale = new Locale(language);
+        this.locale = Locale.forLanguageTag(language);
     }
 
 }

--- a/metamorph/src/main/java/org/metafacture/metamorph/maps/FileMap.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/maps/FileMap.java
@@ -16,6 +16,7 @@
 
 package org.metafacture.metamorph.maps;
 
+import org.metafacture.commons.ResourceUtil;
 import org.metafacture.io.FileOpener;
 import org.metafacture.metamorph.api.MorphExecutionException;
 import org.metafacture.metamorph.api.helpers.AbstractReadOnlyMap;
@@ -229,7 +230,7 @@ public final class FileMap extends AbstractReadOnlyMap<String, String> implement
     private Optional<InputStream> openAsUrl(final String file) {
         final URL url;
         try {
-            url = new URL(file);
+            url = ResourceUtil.toURL(file);
         }
         catch (final MalformedURLException e) {
             return Optional.empty();

--- a/metamorph/src/main/java/org/metafacture/metamorph/maps/RestMap.java
+++ b/metamorph/src/main/java/org/metafacture/metamorph/maps/RestMap.java
@@ -16,15 +16,14 @@
 
 package org.metafacture.metamorph.maps;
 
+import org.metafacture.commons.ResourceUtil;
 import org.metafacture.metamorph.api.helpers.AbstractReadOnlyMap;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -73,7 +72,7 @@ public final class RestMap extends AbstractReadOnlyMap<String, String> {
     }
 
     private String readFromUrl(final String targetUrl) throws IOException, URISyntaxException {
-        final InputStream inputStream = new URL(new URI(targetUrl.replace(" ", "%20")).toASCIIString()).openConnection()
+        final InputStream inputStream = ResourceUtil.toURL(targetUrl.replace(" ", "%20")).openConnection()
                 .getInputStream();
         try {
             final BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, Charset.forName(charsetName)));


### PR DESCRIPTION
Serves in preparation for raising the minimum Java version to 21 (#765).

- Upgrade EqualsVerifier dependency to version 3.19.4 (latest pre-4 release) and add prefab values for type `java.util.regex.Matcher`.
- Include Nashorn Javascript engine as standalone library (removed as built-in in JDK 15; see [JEP 372](https://openjdk.org/jeps/372) and [documentation](https://github.com/szegedi/nashorn/wiki/Using-Nashorn-with-different-Java-versions)).
- Replace deprecated `Locale` constructor (deprecated in JDK 19).
- Replace deprecated `URL` constructor (deprecated in JDK 20).