### PR TITLE
Add missing Javadoc comments to types/classes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ put_map("<mapName>",
 
 ##### `put_rdfmap`
 
-Defines an external RDF map for lookup from a file or an HTTP(S) resource.
+Defines an external RDF map for [lookup](#lookup) from a file or an HTTP(S) resource.
 As the RDF map is reducing RDF triples to a key/value map it is mandatory to set the target.
 The targeted RDF property can optionally be bound by an RDF language tag.
 
@@ -1253,7 +1253,7 @@ end
 
 ##### `all_contain`
 
-Executes the functions if/unless the field contains the value. If it is an array or a hash all field values must contain the string.
+Executes the functions if/unless the field contains the value. If it is an array or a hash, all field values must contain the string.
 
 [Example in Playground](https://metafacture.org/playground/?example=all_contain)
 
@@ -1261,7 +1261,7 @@ Executes the functions if/unless the field contains the value. If it is an array
 
 ##### `any_contain`
 
-Executes the functions if/unless the field contains the value. If it is an array or a hash one or more field values must contain the string.
+Executes the functions if/unless the field contains the value. If it is an array or a hash, one or more field values must contain the string.
 
 [Example in Playground](https://metafacture.org/playground/?example=any_contain)
 
@@ -1269,7 +1269,7 @@ Executes the functions if/unless the field contains the value. If it is an array
 
 ##### `none_contain`
 
-Executes the functions if/unless the field does not contain the value. If it is an array or a hash none of the field values may contain the string.
+Executes the functions if/unless the field does not contain the value. If it is an array or a hash, none of the field values may contain the string.
 
 [Example in Playground](https://metafacture.org/playground/?example=none_contain)
 
@@ -1287,7 +1287,7 @@ Executes the functions if/unless the first string contains the second string.
 
 ##### `all_equal`
 
-Executes the functions if/unless the field value equals the string. If it is an array or a hash all field values must equal the string.
+Executes the functions if/unless the field value equals the string. If it is an array or a hash, all field values must equal the string.
 
 [Example in Playground](https://metafacture.org/playground/?example=all_equal)
 
@@ -1295,7 +1295,7 @@ Executes the functions if/unless the field value equals the string. If it is an 
 
 ##### `any_equal`
 
-Executes the functions if/unless the field value equals the string. If it is an array or a hash one or more field values must equal the string.
+Executes the functions if/unless the field value equals the string. If it is an array or a hash, one or more field values must equal the string.
 
 [Example in Playground](https://metafacture.org/playground/?example=any_equal)
 
@@ -1303,7 +1303,7 @@ Executes the functions if/unless the field value equals the string. If it is an 
 
 ##### `none_equal`
 
-Executes the functions if/unless the field value does not equal the string. If it is an array or a hash none of the field values may equal the string.
+Executes the functions if/unless the field value does not equal the string. If it is an array or a hash, none of the field values may equal the string.
 
 [Example in Playground](https://metafacture.org/playground/?example=none_equal)
 
@@ -1429,7 +1429,7 @@ Executes the functions if/unless the field value is less than the given value.
 
 ##### `all_match`
 
-Executes the functions if/unless the field value matches the regular expression pattern. If it is an array or a hash all field values must match the regular expression pattern.
+Executes the functions if/unless the field value matches the regular expression pattern. If it is an array or a hash, all field values must match the regular expression pattern.
 
 [Example in Playground](https://metafacture.org/playground/?example=all_match)
 
@@ -1437,7 +1437,7 @@ Executes the functions if/unless the field value matches the regular expression 
 
 ##### `any_match`
 
-Executes the functions if/unless the field value matches the regular expression pattern. If it is an array or a hash one or more field values must match the regular expression pattern.
+Executes the functions if/unless the field value matches the regular expression pattern. If it is an array or a hash, one or more field values must match the regular expression pattern.
 
 [Example in Playground](https://metafacture.org/playground/?example=any_match)
 
@@ -1445,7 +1445,7 @@ Executes the functions if/unless the field value matches the regular expression 
 
 ##### `none_match`
 
-Executes the functions if/unless the field value does not match the regular expression pattern. If it is an array or a hash none of the field values may match the regular expression pattern.
+Executes the functions if/unless the field value does not match the regular expression pattern. If it is an array or a hash, none of the field values may match the regular expression pattern.
 
 [Example in Playground](https://metafacture.org/playground/?example=none_match)
 

--- a/build.gradle
+++ b/build.gradle
@@ -176,6 +176,7 @@ subprojects {
 
     options {
       addBooleanOption 'Xwerror', true
+      addBooleanOption 'Xdoclint:all,-missing', true
     }
   }
 

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -11,7 +11,7 @@
     <property name="files" value="xtext-gen"/>
   </module>
   <module name="SuppressionSingleFilter">
-    <property name="checks" value="ExecutableStatementCount|MagicNumber|MissingJavadocMethod|MultipleStringLiterals"/>
+    <property name="checks" value="ExecutableStatementCount|MagicNumber|MissingJavadocMethod|MissingJavadocType|MultipleStringLiterals"/>
     <property name="files" value="test"/>
   </module>
   <module name="TreeWalker">
@@ -92,6 +92,7 @@
     <module name="MissingCtor"/>
     <module name="MissingDeprecated"/>
     <module name="MissingJavadocMethod"/>
+    <module name="MissingJavadocType"/>
     <module name="MissingOverride"/>
     <module name="MissingSwitchDefault"/>
     <module name="ModifiedControlVariable"/>

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/iso2709/RecordFormat.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/iso2709/RecordFormat.java
@@ -186,6 +186,9 @@ public final class RecordFormat {
                 "implDefinedPartLength=" + implDefinedPartLength + ")";
     }
 
+    /**
+     * Builder for {@link RecordFormat}.
+     */
     public static class Builder {
 
         private static final int RADIX = 10;

--- a/metafacture-biblio/src/main/java/org/metafacture/biblio/marc21/Marc21Encoder.java
+++ b/metafacture-biblio/src/main/java/org/metafacture/biblio/marc21/Marc21Encoder.java
@@ -113,7 +113,6 @@ public final class Marc21Encoder extends
      * Controls whether the leader should be validated.
      * <p>
      * The default value of {@code validateLeader} is true.
-     * <p>
      *
      * @param validateLeader if false the leader is not validated
      */

--- a/metafacture-framework/src/main/java/org/metafacture/framework/MetafactureLogger.java
+++ b/metafacture-framework/src/main/java/org/metafacture/framework/MetafactureLogger.java
@@ -32,6 +32,9 @@ public class MetafactureLogger {
     private final Logger externalLogger;
     private final Logger internalLogger;
 
+    /**
+     * Wrapper for the supported log levels and their associated actions.
+     */
     public enum Level {
 
         ERROR((l, f, a) -> l.error(f, a)),

--- a/metafacture-io/src/main/java/org/metafacture/io/CloseFailed.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/CloseFailed.java
@@ -1,5 +1,8 @@
 package org.metafacture.io;
 
+/**
+ * Error while closing output stream.
+ */
 public class CloseFailed extends IoFailed {
 
     /**

--- a/metafacture-io/src/main/java/org/metafacture/io/HttpOpener.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/HttpOpener.java
@@ -89,6 +89,9 @@ public final class HttpOpener extends DefaultObjectPipe<String, ObjectReceiver<R
     private boolean inputUsed;
     private boolean successful;
 
+    /**
+     * HTTP methods.
+     */
     public enum Method {
 
         DELETE(false, true),

--- a/metafacture-io/src/main/java/org/metafacture/io/IoFailed.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/IoFailed.java
@@ -2,6 +2,9 @@ package org.metafacture.io;
 
 import org.metafacture.framework.MetafactureException;
 
+/**
+ * Base class for IO exceptions.
+ */
 public class IoFailed extends MetafactureException {
 
     /**

--- a/metafacture-io/src/main/java/org/metafacture/io/OpenFailed.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/OpenFailed.java
@@ -1,5 +1,8 @@
 package org.metafacture.io;
 
+/**
+ * Error while opening output stream.
+ */
 public class OpenFailed extends IoFailed {
 
     /**

--- a/metafacture-io/src/main/java/org/metafacture/io/WriteFailed.java
+++ b/metafacture-io/src/main/java/org/metafacture/io/WriteFailed.java
@@ -1,5 +1,8 @@
 package org.metafacture.io;
 
+/**
+ * Error while writing to output stream.
+ */
 public class WriteFailed extends IoFailed {
 
     /**

--- a/metafix/src/jmh/java/org/metafacture/metafix/AbstractBenchmark.java
+++ b/metafix/src/jmh/java/org/metafacture/metafix/AbstractBenchmark.java
@@ -34,6 +34,9 @@ import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Base class for benchmarks.
+ */
 @Fork(2)
 @Warmup(iterations = 2)
 @Measurement(iterations = 4) // checkstyle-disable-line MagicNumber

--- a/metafix/src/jmh/java/org/metafacture/metafix/AbstractMetafixBenchmark.java
+++ b/metafix/src/jmh/java/org/metafacture/metafix/AbstractMetafixBenchmark.java
@@ -26,6 +26,9 @@ import org.metafacture.json.JsonEncoder;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
+/**
+ * Base class for Metafix benchmarks.
+ */
 public abstract class AbstractMetafixBenchmark extends FixParseBenchmark { // checkstyle-disable-line ClassDataAbstractionCoupling
 
     // TODO: Need to inject system properties into JMHTask's JavaExec process.

--- a/metafix/src/jmh/java/org/metafacture/metafix/BaselineBenchmark.java
+++ b/metafix/src/jmh/java/org/metafacture/metafix/BaselineBenchmark.java
@@ -20,6 +20,9 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Baseline benchmark.
+ */
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 public class BaselineBenchmark extends AbstractBenchmark {
 

--- a/metafix/src/jmh/java/org/metafacture/metafix/FixParseBenchmark.java
+++ b/metafix/src/jmh/java/org/metafacture/metafix/FixParseBenchmark.java
@@ -19,6 +19,9 @@ package org.metafacture.metafix;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Setup;
 
+/**
+ * Fix parsing benchmark.
+ */
 public class FixParseBenchmark extends AbstractBenchmark {
 
     protected static final String BASE = "src/jmh/resources/org/metafacture/metafix";

--- a/metafix/src/jmh/java/org/metafacture/metafix/MetafixBenchmark.java
+++ b/metafix/src/jmh/java/org/metafacture/metafix/MetafixBenchmark.java
@@ -18,6 +18,9 @@ package org.metafacture.metafix;
 
 import org.openjdk.jmh.annotations.Param;
 
+/**
+ * Metafix benchmark.
+ */
 public class MetafixBenchmark extends AbstractMetafixBenchmark {
 
     @Param({ // checkstyle-disable-line AnnotationUseStyle

--- a/metafix/src/main/java/org/metafacture/metafix/FixCommand.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixCommand.java
@@ -22,6 +22,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Annotation to register Fix commands with the given name.
+ */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/metafix/src/main/java/org/metafacture/metafix/FixParseException.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixParseException.java
@@ -18,6 +18,9 @@ package org.metafacture.metafix;
 
 import org.metafacture.framework.MetafactureException;
 
+/**
+ * Error while parsing Fix resource.
+ */
 public class FixParseException extends MetafactureException {
 
     /**

--- a/metafix/src/main/java/org/metafacture/metafix/JsonValue.java
+++ b/metafix/src/main/java/org/metafacture/metafix/JsonValue.java
@@ -29,6 +29,9 @@ import java.io.UncheckedIOException;
 
 // TODO: Utilize JsonDecoder/JsonEncoder instead?
 
+/**
+ * Serializer for JSON values.
+ */
 @FunctionalInterface
 public interface JsonValue {
 
@@ -76,6 +79,9 @@ public interface JsonValue {
         return writer.toString();
     }
 
+    /**
+     * Parser for JSON values.
+     */
     class Parser {
 
         private static final ObjectMapper MAPPER = new ObjectMapper();

--- a/metafix/src/main/java/org/metafacture/metafix/Metafix.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Metafix.java
@@ -683,6 +683,9 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps {
         return clazz;
     }
 
+    /**
+     * Strictness levels.
+     */
     public enum Strictness {
 
         /**

--- a/metafix/src/main/java/org/metafacture/metafix/Value.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Value.java
@@ -463,6 +463,9 @@ public class Value implements JsonValue { // checkstyle-disable-line ClassDataAb
         String
     }
 
+    /**
+     * Matcher for value types.
+     */
     public static class TypeMatcher {
 
         private final Set<Type> expected = EnumSet.noneOf(Type.class);

--- a/metafix/src/main/java/org/metafacture/metafix/api/FixContext.java
+++ b/metafix/src/main/java/org/metafacture/metafix/api/FixContext.java
@@ -23,6 +23,9 @@ import org.metafacture.metafix.RecordTransformer;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Fix context to execute.
+ */
 @FunctionalInterface
 public interface FixContext {
 

--- a/metafix/src/main/java/org/metafacture/metafix/api/FixFunction.java
+++ b/metafix/src/main/java/org/metafacture/metafix/api/FixFunction.java
@@ -33,6 +33,9 @@ import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 
+/**
+ * Fix function to apply.
+ */
 @FunctionalInterface
 public interface FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/api/FixPredicate.java
+++ b/metafix/src/main/java/org/metafacture/metafix/api/FixPredicate.java
@@ -27,6 +27,9 @@ import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
+/**
+ * Fix predicate to test.
+ */
 @FunctionalInterface
 public interface FixPredicate {
 

--- a/metafix/src/main/java/org/metafacture/metafix/api/FixRegistry.java
+++ b/metafix/src/main/java/org/metafacture/metafix/api/FixRegistry.java
@@ -39,6 +39,9 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.stream.Stream;
 
+/**
+ * Registry for Fix commands.
+ */
 public class FixRegistry {
 
     private static final String FILE_SEPARATOR = "/";

--- a/metafix/src/main/java/org/metafacture/metafix/bind/List.java
+++ b/metafix/src/main/java/org/metafacture/metafix/bind/List.java
@@ -25,6 +25,10 @@ import org.metafacture.metafix.api.FixContext;
 
 import java.util.Map;
 
+/**
+ * Iterates over each element of an array. In contrast to Catmandu, it can
+ * also iterate over a single object or string.
+ */
 @FixCommand("list")
 public class List implements FixContext {
 

--- a/metafix/src/main/java/org/metafacture/metafix/bind/ListAs.java
+++ b/metafix/src/main/java/org/metafacture/metafix/bind/ListAs.java
@@ -27,6 +27,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Iterates over each <i>named</i> element of an array (like
+ * {@link org.metafacture.metafix.bind.List} with a variable name). If
+ * multiple arrays are given, iterates over the <i>corresponding</i>
+ * elements from each array (i.e., all elements with the same array
+ * index, skipping elements whose arrays have already been exhausted).
+ */
 @FixCommand("list_as")
 public class ListAs implements FixContext {
 

--- a/metafix/src/main/java/org/metafacture/metafix/bind/Once.java
+++ b/metafix/src/main/java/org/metafacture/metafix/bind/Once.java
@@ -28,6 +28,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * Executes the statements only once (when the bind is first encountered),
+ * not repeatedly for each record.
+ */
 @FixCommand("once")
 public class Once implements FixContext {
 

--- a/metafix/src/main/java/org/metafacture/metafix/bind/PutMacro.java
+++ b/metafix/src/main/java/org/metafacture/metafix/bind/PutMacro.java
@@ -25,6 +25,10 @@ import org.metafacture.metafix.api.FixContext;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Defines a named macro, i.e. a list of statements that can be executed later
+ * with the {@link org.metafacture.metafix.method.record.CallMacro} function.
+ */
 @FixCommand("put_macro")
 public class PutMacro implements FixContext {
 

--- a/metafix/src/main/java/org/metafacture/metafix/conditional/AllContain.java
+++ b/metafix/src/main/java/org/metafacture/metafix/conditional/AllContain.java
@@ -24,6 +24,10 @@ import org.metafacture.metafix.api.FixPredicate;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Executes the functions if/unless the field contains the value. If it is an
+ * array or a hash, all field values must contain the string.
+ */
 @FixCommand("all_contain")
 public class AllContain implements FixPredicate {
 

--- a/metafix/src/main/java/org/metafacture/metafix/conditional/AllEqual.java
+++ b/metafix/src/main/java/org/metafacture/metafix/conditional/AllEqual.java
@@ -24,6 +24,10 @@ import org.metafacture.metafix.api.FixPredicate;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Executes the functions if/unless the field value equals the string. If it
+ * is an array or a hash, all field values must equal the string.
+ */
 @FixCommand("all_equal")
 public class AllEqual implements FixPredicate {
 

--- a/metafix/src/main/java/org/metafacture/metafix/conditional/AllMatch.java
+++ b/metafix/src/main/java/org/metafacture/metafix/conditional/AllMatch.java
@@ -24,6 +24,11 @@ import org.metafacture.metafix.api.FixPredicate;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Executes the functions if/unless the field value matches the regular
+ * expression pattern. If it is an array or a hash, all field values
+ * must match the regular expression pattern.
+ */
 @FixCommand("all_match")
 public class AllMatch implements FixPredicate {
 

--- a/metafix/src/main/java/org/metafacture/metafix/conditional/AnyContain.java
+++ b/metafix/src/main/java/org/metafacture/metafix/conditional/AnyContain.java
@@ -24,6 +24,10 @@ import org.metafacture.metafix.api.FixPredicate;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Executes the functions if/unless the field contains the value. If it is an
+ * array or a hash, one or more field values must contain the string.
+ */
 @FixCommand("any_contain")
 public class AnyContain implements FixPredicate {
 

--- a/metafix/src/main/java/org/metafacture/metafix/conditional/AnyEqual.java
+++ b/metafix/src/main/java/org/metafacture/metafix/conditional/AnyEqual.java
@@ -24,6 +24,10 @@ import org.metafacture.metafix.api.FixPredicate;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Executes the functions if/unless the field value equals the string. If it is
+ * an array or a hash, one or more field values must equal the string.
+ */
 @FixCommand("any_equal")
 public class AnyEqual implements FixPredicate {
 

--- a/metafix/src/main/java/org/metafacture/metafix/conditional/AnyMatch.java
+++ b/metafix/src/main/java/org/metafacture/metafix/conditional/AnyMatch.java
@@ -24,6 +24,11 @@ import org.metafacture.metafix.api.FixPredicate;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Executes the functions if/unless the field value matches the regular
+ * expression pattern. If it is an array or a hash, one or more field
+ * values must match the regular expression pattern.
+ */
 @FixCommand("any_match")
 public class AnyMatch implements FixPredicate {
 

--- a/metafix/src/main/java/org/metafacture/metafix/conditional/Exists.java
+++ b/metafix/src/main/java/org/metafacture/metafix/conditional/Exists.java
@@ -24,6 +24,9 @@ import org.metafacture.metafix.api.FixPredicate;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Executes the functions if/unless the field exists.
+ */
 @FixCommand("exists")
 public class Exists implements FixPredicate {
 

--- a/metafix/src/main/java/org/metafacture/metafix/conditional/GreaterThan.java
+++ b/metafix/src/main/java/org/metafacture/metafix/conditional/GreaterThan.java
@@ -24,6 +24,10 @@ import org.metafacture.metafix.api.FixPredicate;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Executes the functions if/unless the field value is greater than the given
+ * value.
+ */
 @FixCommand("greater_than")
 public class GreaterThan implements FixPredicate {
 

--- a/metafix/src/main/java/org/metafacture/metafix/conditional/In.java
+++ b/metafix/src/main/java/org/metafacture/metafix/conditional/In.java
@@ -25,6 +25,11 @@ import org.metafacture.metafix.api.FixPredicate;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Executes the functions if/unless the field value
+ * <a href="https://perldoc.perl.org/perlop#Smartmatch-Operator">is contained in</a>
+ * the value of the other field.
+ */
 @FixCommand("in")
 public class In implements FixPredicate {
 

--- a/metafix/src/main/java/org/metafacture/metafix/conditional/IsArray.java
+++ b/metafix/src/main/java/org/metafacture/metafix/conditional/IsArray.java
@@ -25,6 +25,9 @@ import org.metafacture.metafix.api.FixPredicate;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Executes the functions if/unless the field value is an array.
+ */
 @FixCommand("is_array")
 public class IsArray implements FixPredicate {
 

--- a/metafix/src/main/java/org/metafacture/metafix/conditional/IsContainedIn.java
+++ b/metafix/src/main/java/org/metafacture/metafix/conditional/IsContainedIn.java
@@ -24,6 +24,9 @@ import org.metafacture.metafix.api.FixPredicate;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * <i>Alias for {@link In}.</i>
+ */
 @FixCommand("is_contained_in")
 public class IsContainedIn implements FixPredicate {
 

--- a/metafix/src/main/java/org/metafacture/metafix/conditional/IsEmpty.java
+++ b/metafix/src/main/java/org/metafacture/metafix/conditional/IsEmpty.java
@@ -24,6 +24,9 @@ import org.metafacture.metafix.api.FixPredicate;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Executes the functions if/unless the field value is empty.
+ */
 @FixCommand("is_empty")
 public class IsEmpty implements FixPredicate {
 

--- a/metafix/src/main/java/org/metafacture/metafix/conditional/IsFalse.java
+++ b/metafix/src/main/java/org/metafacture/metafix/conditional/IsFalse.java
@@ -24,6 +24,10 @@ import org.metafacture.metafix.api.FixPredicate;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Executes the functions if/unless the field value equals {@code false}
+ * or {@code 0}.
+ */
 @FixCommand("is_false")
 public class IsFalse implements FixPredicate {
 

--- a/metafix/src/main/java/org/metafacture/metafix/conditional/IsHash.java
+++ b/metafix/src/main/java/org/metafacture/metafix/conditional/IsHash.java
@@ -24,6 +24,9 @@ import org.metafacture.metafix.api.FixPredicate;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * <i>Alias for {@link IsObject}.</i>
+ */
 @FixCommand("is_hash")
 public class IsHash implements FixPredicate {
 

--- a/metafix/src/main/java/org/metafacture/metafix/conditional/IsNumber.java
+++ b/metafix/src/main/java/org/metafacture/metafix/conditional/IsNumber.java
@@ -24,6 +24,9 @@ import org.metafacture.metafix.api.FixPredicate;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Executes the functions if/unless the field value is a number.
+ */
 @FixCommand("is_number")
 public class IsNumber implements FixPredicate {
 

--- a/metafix/src/main/java/org/metafacture/metafix/conditional/IsObject.java
+++ b/metafix/src/main/java/org/metafacture/metafix/conditional/IsObject.java
@@ -25,6 +25,9 @@ import org.metafacture.metafix.api.FixPredicate;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Executes the functions if/unless the field value is a hash (object).
+ */
 @FixCommand("is_object")
 public class IsObject implements FixPredicate {
 

--- a/metafix/src/main/java/org/metafacture/metafix/conditional/IsString.java
+++ b/metafix/src/main/java/org/metafacture/metafix/conditional/IsString.java
@@ -25,6 +25,10 @@ import org.metafacture.metafix.api.FixPredicate;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Executes the functions if/unless the field value is a string (and not
+ * a number).
+ */
 @FixCommand("is_string")
 public class IsString implements FixPredicate {
 

--- a/metafix/src/main/java/org/metafacture/metafix/conditional/IsTrue.java
+++ b/metafix/src/main/java/org/metafacture/metafix/conditional/IsTrue.java
@@ -24,6 +24,10 @@ import org.metafacture.metafix.api.FixPredicate;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Executes the functions if/unless the field value equals {@code true}
+ * or {@code 1}.
+ */
 @FixCommand("is_true")
 public class IsTrue implements FixPredicate {
 

--- a/metafix/src/main/java/org/metafacture/metafix/conditional/LessThan.java
+++ b/metafix/src/main/java/org/metafacture/metafix/conditional/LessThan.java
@@ -24,6 +24,10 @@ import org.metafacture.metafix.api.FixPredicate;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Executes the functions if/unless the field value is less than the
+ * given value.
+ */
 @FixCommand("less_than")
 public class LessThan implements FixPredicate {
 

--- a/metafix/src/main/java/org/metafacture/metafix/conditional/NoneContain.java
+++ b/metafix/src/main/java/org/metafacture/metafix/conditional/NoneContain.java
@@ -24,6 +24,10 @@ import org.metafacture.metafix.api.FixPredicate;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Executes the functions if/unless the field does not contain the value. If
+ * it is an array or a hash, none of the field values may contain the string.
+ */
 @FixCommand("none_contain")
 public class NoneContain implements FixPredicate {
 

--- a/metafix/src/main/java/org/metafacture/metafix/conditional/NoneEqual.java
+++ b/metafix/src/main/java/org/metafacture/metafix/conditional/NoneEqual.java
@@ -24,6 +24,10 @@ import org.metafacture.metafix.api.FixPredicate;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Executes the functions if/unless the field value does not equal the string.
+ * If it is an array or a hash, none of the field values may equal the string.
+ */
 @FixCommand("none_equal")
 public class NoneEqual implements FixPredicate {
 

--- a/metafix/src/main/java/org/metafacture/metafix/conditional/NoneMatch.java
+++ b/metafix/src/main/java/org/metafacture/metafix/conditional/NoneMatch.java
@@ -24,6 +24,11 @@ import org.metafacture.metafix.api.FixPredicate;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Executes the functions if/unless the field value does not match the regular
+ * expression pattern. If it is an array or a hash, none of the field values
+ * may match the regular expression pattern.
+ */
 @FixCommand("none_match")
 public class NoneMatch implements FixPredicate {
 

--- a/metafix/src/main/java/org/metafacture/metafix/conditional/StrContain.java
+++ b/metafix/src/main/java/org/metafacture/metafix/conditional/StrContain.java
@@ -24,6 +24,9 @@ import org.metafacture.metafix.api.FixPredicate;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Executes the functions if/unless the first string contains the second string.
+ */
 @FixCommand("str_contain")
 public class StrContain implements FixPredicate {
 

--- a/metafix/src/main/java/org/metafacture/metafix/conditional/StrEqual.java
+++ b/metafix/src/main/java/org/metafacture/metafix/conditional/StrEqual.java
@@ -24,6 +24,9 @@ import org.metafacture.metafix.api.FixPredicate;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Executes the functions if/unless the first string equals the second string.
+ */
 @FixCommand("str_equal")
 public class StrEqual implements FixPredicate {
 

--- a/metafix/src/main/java/org/metafacture/metafix/conditional/StrMatch.java
+++ b/metafix/src/main/java/org/metafacture/metafix/conditional/StrMatch.java
@@ -24,6 +24,10 @@ import org.metafacture.metafix.api.FixPredicate;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Executes the functions if/unless the string matches the regular
+ * expression pattern.
+ */
 @FixCommand("str_match")
 public class StrMatch implements FixPredicate {
 

--- a/metafix/src/main/java/org/metafacture/metafix/interpreter/FixInterpreter.java
+++ b/metafix/src/main/java/org/metafacture/metafix/interpreter/FixInterpreter.java
@@ -15,6 +15,9 @@ import org.eclipse.xtext.xbase.interpreter.impl.XbaseInterpreter;
 
 import java.util.List;
 
+/**
+ * Interpreter for Fix programs.
+ */
 public class FixInterpreter extends XbaseInterpreter {
 
     private static final MetafactureLogger LOG = new MetafactureLogger(FixInterpreter.class);

--- a/metafix/src/main/java/org/metafacture/metafix/method/field/Append.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/field/Append.java
@@ -24,6 +24,9 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Adds a string at the end of a field value.
+ */
 @FixCommand("append")
 public class Append implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/field/Capitalize.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/field/Capitalize.java
@@ -24,6 +24,9 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Upcases the first character in a field value.
+ */
 @FixCommand("capitalize")
 public class Capitalize implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/field/Count.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/field/Count.java
@@ -25,6 +25,10 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Counts the number of elements in an array or a hash and replaces the
+ * field value with this number.
+ */
 @FixCommand("count")
 public class Count implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/field/Downcase.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/field/Downcase.java
@@ -24,6 +24,9 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Downcases all characters in a field value.
+ */
 @FixCommand("downcase")
 public class Downcase implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/field/Filter.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/field/Filter.java
@@ -27,6 +27,10 @@ import java.util.Map;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
+/**
+ * Only keeps field values that match the regular expression pattern. Works
+ * only with array of strings/repeated fields.
+ */
 @FixCommand("filter")
 public class Filter implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/field/Flatten.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/field/Flatten.java
@@ -24,6 +24,9 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Flattens a nested array field.
+ */
 @FixCommand("flatten")
 public class Flatten implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/field/FromJson.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/field/FromJson.java
@@ -27,6 +27,9 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Replaces the string with its JSON deserialization.
+ */
 @FixCommand("from_json")
 public class FromJson implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/field/HtmlToText.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/field/HtmlToText.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Turn HTML text to plain text.
+ * Turns HTML text to plain text.
  *
  * @author Tobias Bülte (tobiasNx)
  *

--- a/metafix/src/main/java/org/metafacture/metafix/method/field/Index.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/field/Index.java
@@ -24,6 +24,10 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Returns the index position of a substring in a field and replaces the
+ * field value with this number.
+ */
 @FixCommand("index")
 public class Index implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/field/Isbn.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/field/Isbn.java
@@ -25,6 +25,10 @@ import org.metafacture.metamorph.functions.ISBN;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Extracts an ISBN and replaces the field value with the normalized ISBN;
+ * optionally converts and/or validates the ISBN.
+ */
 @FixCommand("isbn")
 public class Isbn implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/field/JoinField.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/field/JoinField.java
@@ -26,6 +26,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+/**
+ * Joins an array of strings into a single string.
+ */
 @FixCommand("join_field")
 public class JoinField implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/field/Lookup.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/field/Lookup.java
@@ -31,6 +31,12 @@ import java.util.Map;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Consumer;
 
+/**
+ * Looks up matching values in a map and replaces the field value with this match.
+ * {@link org.metafacture.metafix.method.script.PutFileMap External files},
+ * {@link org.metafacture.metafix.method.script.PutMap internal maps} as well as
+ * {@link org.metafacture.metafix.method.script.PutRdfMap RDF resources} can be used.
+ */
 @FixCommand("lookup")
 public class Lookup implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/field/Prepend.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/field/Prepend.java
@@ -24,6 +24,9 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Adds a string at the beginning of a field value.
+ */
 @FixCommand("prepend")
 public class Prepend implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/field/ReplaceAll.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/field/ReplaceAll.java
@@ -24,6 +24,11 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Replaces a regular expression pattern in field values with a replacement
+ * string. Regexp capturing is possible; refer to capturing groups by number
+ * ({@code $<number>}) or name ({@code ${<name>}}).
+ */
 @FixCommand("replace_all")
 public class ReplaceAll implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/field/Reverse.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/field/Reverse.java
@@ -27,6 +27,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+/**
+ * Reverses the character order of a string or the element order of an array.
+ */
 @FixCommand("reverse")
 public class Reverse implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/field/SortField.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/field/SortField.java
@@ -28,6 +28,10 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+/**
+ * Sorts strings in an array. Alphabetically and A-Z by default. Optional
+ * numerical and reverse sorting.
+ */
 @FixCommand("sort_field")
 public class SortField implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/field/SplitField.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/field/SplitField.java
@@ -28,6 +28,9 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
+/**
+ * Splits a string into an array and replaces the field value with this array.
+ */
 @FixCommand("split_field")
 public class SplitField implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/field/Substring.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/field/Substring.java
@@ -24,6 +24,10 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Replaces a string with its substring as defined by the start position
+ * (offset) and length.
+ */
 @FixCommand("substring")
 public class Substring implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/field/Sum.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/field/Sum.java
@@ -25,6 +25,9 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Sums numbers in an array and replaces the field value with this number.
+ */
 @FixCommand("sum")
 public class Sum implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/field/ToBase64.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/field/ToBase64.java
@@ -25,6 +25,9 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Replaces the value with its Base64 encoding.
+ */
 @FixCommand("to_base64")
 public class ToBase64 implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/field/ToJson.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/field/ToJson.java
@@ -26,6 +26,9 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Replaces the value with its JSON serialization.
+ */
 @FixCommand("to_json")
 public class ToJson implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/field/Trim.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/field/Trim.java
@@ -24,6 +24,9 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Deletes whitespace at the beginning and the end of a field value.
+ */
 @FixCommand("trim")
 public class Trim implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/field/Uniq.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/field/Uniq.java
@@ -24,6 +24,9 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Deletes duplicate values in an array.
+ */
 @FixCommand("uniq")
 public class Uniq implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/field/Upcase.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/field/Upcase.java
@@ -24,6 +24,9 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Upcases all characters in a field value.
+ */
 @FixCommand("upcase")
 public class Upcase implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/field/UriEncode.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/field/UriEncode.java
@@ -25,6 +25,9 @@ import org.metafacture.metamorph.functions.URLEncode;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Encodes a field value as URI. Aka percent-encoding.
+ */
 @FixCommand("uri_encode")
 public class UriEncode implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/record/AddArray.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/record/AddArray.java
@@ -25,6 +25,9 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Creates a new array (with optional values).
+ */
 @FixCommand("add_array")
 public class AddArray implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/record/AddField.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/record/AddField.java
@@ -25,6 +25,9 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Creates a field with a defined value.
+ */
 @FixCommand("add_field")
 public class AddField implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/record/AddHash.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/record/AddHash.java
@@ -25,6 +25,9 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Creates a new hash (with optional values).
+ */
 @FixCommand("add_hash")
 public class AddHash implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/record/Array.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/record/Array.java
@@ -25,6 +25,9 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Converts a hash/object into an array.
+ */
 @FixCommand("array")
 public class Array implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/record/CallMacro.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/record/CallMacro.java
@@ -25,6 +25,10 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Calls a named macro, i.e. a list of statements that have been previously
+ * defined with the {@link org.metafacture.metafix.bind.PutMacro} bind.
+ */
 @FixCommand("call_macro")
 public class CallMacro implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/record/CopyField.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/record/CopyField.java
@@ -25,6 +25,9 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Copies a field from an existing field.
+ */
 @FixCommand("copy_field")
 public class CopyField implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/record/Format.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/record/Format.java
@@ -26,6 +26,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Replaces the value with a formatted ({@code sprintf}-like) version as in
+ * {@link java.util.Formatter}.
+ */
 @FixCommand("format")
 public class Format implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/record/Hash.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/record/Hash.java
@@ -25,6 +25,9 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Converts an array into a hash/object.
+ */
 @FixCommand("hash")
 public class Hash implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/record/MoveField.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/record/MoveField.java
@@ -24,6 +24,9 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Moves a field from an existing field. Can be used to rename a field.
+ */
 @FixCommand("move_field")
 public class MoveField implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/record/ParseText.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/record/ParseText.java
@@ -27,6 +27,10 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * Parses a text into an array or hash of values using regular expressions
+ * and grouping.
+ */
 @FixCommand("parse_text")
 public class ParseText implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/record/Paste.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/record/Paste.java
@@ -26,6 +26,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+/**
+ * Joins multiple field values into a new field. Can be combined with
+ * additional literal strings.
+ */
 @FixCommand("paste")
 public class Paste implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/record/PrintRecord.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/record/PrintRecord.java
@@ -27,6 +27,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.LongAdder;
 
+/**
+ * Prints the current record as JSON either to standard output or to a file.
+ */
 @FixCommand("print_record")
 public class PrintRecord implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/record/Random.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/record/Random.java
@@ -25,6 +25,10 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Creates (or replaces) a field with a random number (less than the
+ * specified maximum).
+ */
 @FixCommand("random")
 public class Random implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/record/Reject.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/record/Reject.java
@@ -24,6 +24,9 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Ignores records that match a condition.
+ */
 @FixCommand("reject")
 public class Reject implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/record/RemoveField.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/record/RemoveField.java
@@ -24,6 +24,9 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Removes a field.
+ */
 @FixCommand("remove_field")
 public class RemoveField implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/record/Rename.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/record/Rename.java
@@ -26,6 +26,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.UnaryOperator;
 
+/**
+ * Replaces a regular expression pattern in subfield names of a field. Does
+ * not change the name of the source field itself.
+ */
 @FixCommand("rename")
 public class Rename implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/record/Retain.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/record/Retain.java
@@ -24,6 +24,9 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Deletes all fields except the ones listed (incl. subfields).
+ */
 @FixCommand("retain")
 public class Retain implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/record/SetArray.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/record/SetArray.java
@@ -24,6 +24,11 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Creates a new array (with optional values), provided that the intermediate
+ * structures (i.e. parent fields) exist. To create any missing intermediate
+ * structures, use {@link AddArray} instead.
+ */
 @FixCommand("set_array")
 public class SetArray implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/record/SetField.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/record/SetField.java
@@ -24,6 +24,11 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Creates a field with a defined value, provided that the intermediate
+ * structures (i.e. parent fields) exist. To create any missing intermediate
+ * structures, use {@link AddField} instead.
+ */
 @FixCommand("set_field")
 public class SetField implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/record/SetHash.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/record/SetHash.java
@@ -24,6 +24,11 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Creates a new hash (with optional values), provided that the intermediate
+ * structures (i.e. parent fields) exist. To create any missing intermediate
+ * structures, use {@link AddHash} instead.
+ */
 @FixCommand("set_hash")
 public class SetHash implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/record/Timestamp.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/record/Timestamp.java
@@ -25,6 +25,9 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Creates (or replaces) a field with the current timestamp.
+ */
 @FixCommand("timestamp")
 public class Timestamp implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/record/Vacuum.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/record/Vacuum.java
@@ -24,6 +24,9 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Deletes empty fields, arrays and objects.
+ */
 @FixCommand("vacuum")
 public class Vacuum implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/script/Include.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/script/Include.java
@@ -24,6 +24,10 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Includes a Fix file and executes it as if its statements were written in
+ * place of the function call.
+ */
 @FixCommand("include")
 public class Include implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/script/Log.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/script/Log.java
@@ -25,6 +25,9 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Sends a message to the logs.
+ */
 @FixCommand("log")
 public class Log implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/script/Nothing.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/script/Nothing.java
@@ -24,6 +24,9 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Does nothing. It is used for benchmarking in Catmandu.
+ */
 @FixCommand("nothing")
 public class Nothing implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/script/PutFileMap.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/script/PutFileMap.java
@@ -25,6 +25,11 @@ import org.metafacture.metamorph.maps.FileMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Defines an external map for {@link org.metafacture.metafix.method.field.Lookup}
+ * from a file or a URL. Maps with more than 2 columns are supported but are
+ * reduced to a defined key and a value column.
+ */
 @FixCommand("put_filemap")
 public class PutFileMap implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/script/PutMap.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/script/PutMap.java
@@ -24,6 +24,10 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Defines an internal map for {@link org.metafacture.metafix.method.field.Lookup}
+ * from key/value pairs.
+ */
 @FixCommand("put_map")
 public class PutMap implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/script/PutRdfMap.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/script/PutRdfMap.java
@@ -26,6 +26,10 @@ import org.metafacture.metamorph.api.Maps;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Defines an external RDF map for {@link org.metafacture.metafix.method.field.Lookup}
+ * from a file or an HTTP(S) resource.
+ */
 @FixCommand("put_rdfmap")
 public class PutRdfMap implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/script/PutVar.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/script/PutVar.java
@@ -24,6 +24,10 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Defines a single global variable that can be referenced with
+ * {@code $[<variableName>]}.
+ */
 @FixCommand("put_var")
 public class PutVar implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/script/PutVars.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/script/PutVars.java
@@ -24,6 +24,10 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Defines multiple global variables that can be referenced with
+ * {@code $[<variableName>]}.
+ */
 @FixCommand("put_vars")
 public class PutVars implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/method/script/ToVar.java
+++ b/metafix/src/main/java/org/metafacture/metafix/method/script/ToVar.java
@@ -25,6 +25,11 @@ import org.metafacture.metafix.api.FixFunction;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Defines a single global variable that can be referenced with
+ * {@code $[<variableName>]} and assigns the value of the
+ * {@code <sourceField>}.
+ */
 @FixCommand("to_var")
 public class ToVar implements FixFunction {
 

--- a/metafix/src/main/java/org/metafacture/metafix/validation/XtextValidator.java
+++ b/metafix/src/main/java/org/metafacture/metafix/validation/XtextValidator.java
@@ -16,6 +16,9 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
+/**
+ * Validator for Xtext resources.
+ */
 public class XtextValidator {
 
     private static final MetafactureLogger LOG = new MetafactureLogger(XtextValidator.class);


### PR DESCRIPTION
Serves in preparation for raising the minimum Java version to 21 (#765).

JDK 15 and later introduce additional checks in the `-Xdoclint` option (which appears to be enabled by default in Gradle's `javadoc` task), requiring Javadoc for public and protected (and even some private!?) types and members. In order to avoid this hassle (for the time being), we disable DocLint's `missing` check and instead rely on Checkstyle's `MissingJavadocType` check (as well as `MissingJavadocMethod`, introduced in #396). This only applies to _public_ scope, though.

An alternative approach would be to individually [suppress the warnings](https://docs.oracle.com/en/java/javase/21/docs/specs/man/javadoc.html#suppressing-messages) right where they're originating from. This would still be quite a pain, but it would make it explicit where documentation is missing (according to DocLint).

The documentation added here is intentionally curt. If you feel strongly about expanding some of it, please add concrete `suggestion`s. Otherwise, we can deal with it later (maybe even transfer the Fix command documentation from the README to the individual classes and generate the Markdown from those).

Future steps:

- "warning: no main description" ([JDK-8272374](https://bugs.openjdk.org/browse/JDK-8272374): doclint should report missing "body" comments)
- "warning: use of default constructor, which does not provide a comment" ([JDK-8249634](https://bugs.openjdk.org/browse/JDK-8249634): doclint should report implicit constructor as missing javadoc comments)
- [More Javadoc checks](https://checkstyle.org/checks/javadoc/index.html)