### PR TITLE
Raise the minimum Java version to 21.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v1
       with:
-        java-version: 17
+        java-version: 21
     - name: Build with Gradle
       run: ./gradlew check
       env:

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ subprojects {
       'everit':           '1.14.6',
       'guava':            '32.0.1-jre',
       'jackson':          '2.21.4',
-      'jdk':              '11',
+      'jdk':              '21',
       'jdom':             '2.0.6.1',
       'jena':             '4.10.0',
       'jndi':             '0.11.4.1',
@@ -195,6 +195,9 @@ subprojects {
       showStandardStreams = true
       exceptionFormat = 'full'
     }
+
+    // Required for ByteBuddy agent, used by EqualsVerifier and Mockito
+    jvmArgs += ['-XX:+EnableDynamicAgentLoading']
   }
 
   repositories {

--- a/metafacture-html/src/main/java/org/metafacture/html/HtmlDecoder.java
+++ b/metafacture-html/src/main/java/org/metafacture/html/HtmlDecoder.java
@@ -129,7 +129,7 @@ public class HtmlDecoder extends DefaultObjectPipe<Reader, StreamReceiver> {
      *
      * @param mapString the attributes to be added as subfields
      */
-    public void setAttrValsAsSubfields(final String mapString) {
+    public final void setAttrValsAsSubfields(final String mapString) {
         this.attrValsAsSubfields = new HashMap<>();
         final String input = mapString.startsWith("&") ? DEFAULT_ATTR_VALS_AS_SUBFIELDS + mapString : mapString;
         for (final String nameValuePair : input.split("&")) {

--- a/metafacture-triples/src/main/java/org/metafacture/triples/AbstractTripleSort.java
+++ b/metafacture-triples/src/main/java/org/metafacture/triples/AbstractTripleSort.java
@@ -82,6 +82,7 @@ public abstract class AbstractTripleSort extends DefaultObjectPipe<Triple, Objec
     /**
      * Constructs an AbstractTripleSort. Calls {@link MemoryWarningSystem}.
      */
+    @SuppressWarnings("this-escape")
     protected AbstractTripleSort() {
         MemoryWarningSystem.addListener(this);
     }

--- a/metafacture-triples/src/test/java/org/metafacture/triples/AbstractTripleSortTest.java
+++ b/metafacture-triples/src/test/java/org/metafacture/triples/AbstractTripleSortTest.java
@@ -77,7 +77,7 @@ public final class AbstractTripleSortTest { // checkstyle-disable-line AbstractC
         // Wait a tiny bit since GC Thread is not immediately done in Java 8
         Thread.sleep(10);
 
-        Assert.assertTrue(weakRef.isEnqueued());
+        Assert.assertTrue(weakRef.refersTo(null));
     }
 
 }

--- a/metafix/build.gradle
+++ b/metafix/build.gradle
@@ -92,6 +92,14 @@ test {
   maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
 }
 
+tasks.withType(JavaCompile) {
+  // JDK 21:
+  // metafix/src/main/xtext-gen/org/metafacture/metafix/parser/antlr/internal/InternalFixParser.java:139:
+  // warning: [this-escape] possible 'this' escape before subclass is fully initialized
+  // => TODO: Drop after removal of Xtext (see issue #579)
+  options.compilerArgs << '-Xlint:-this-escape'
+}
+
 task integrationTest(type: Exec, group: 'Verification') {
   def installDist = ':metafacture-runner:installDist'
   dependsOn installDist

--- a/metafix/src/main/java/org/metafacture/metafix/ListFixPaths.java
+++ b/metafix/src/main/java/org/metafacture/metafix/ListFixPaths.java
@@ -40,6 +40,7 @@ public class ListFixPaths extends MetafixStreamAnalyzer {
     /**
      * Creates an instance of {@link ListFixPaths}.
      */
+    @SuppressWarnings("this-escape")
     public ListFixPaths() {
         super("nothing()", Compare.PREDICATE);
         setIndex(false);

--- a/metafix/src/main/java/org/metafacture/metafix/Metafix.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Metafix.java
@@ -132,6 +132,7 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps {
      * @param function an optional function that accepts the Metafix instance
      *                 and returns the Fix variables as a Map, or {@code null}
      */
+    @SuppressWarnings("this-escape")
     public Metafix(final Function<Metafix, Map<String, String>> function) {
         init(function);
         recordTransformer = null;
@@ -169,6 +170,7 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps {
      *
      * @throws IOException if an I/O error occurs
      */
+    @SuppressWarnings("this-escape")
     public Metafix(final String fixDef, final Function<Metafix, Map<String, String>> function) throws IOException {
         init(function);
 
@@ -209,6 +211,7 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps {
      * @param function an optional function that accepts the Metafix instance
      *                 and returns the Fix variables as a Map, or {@code null}
      */
+    @SuppressWarnings("this-escape")
     public Metafix(final Reader fixDef, final Function<Metafix, Map<String, String>> function) {
         init(function);
         recordTransformer = getRecordTransformer(fixDef);

--- a/metafix/src/main/java/org/metafacture/metafix/api/FixRegistry.java
+++ b/metafix/src/main/java/org/metafacture/metafix/api/FixRegistry.java
@@ -65,6 +65,7 @@ public class FixRegistry {
      * Creates an instance of {@link FixRegistry}. {@link #registerProperties(String) Registers}
      * all Fix commands found in any {@value PROPERTIES_LOCATION} files.
      */
+    @SuppressWarnings("this-escape")
     public FixRegistry() {
         registerProperties(PROPERTIES_LOCATION);
     }


### PR DESCRIPTION
Resolves #765.

- ByteBuddy agent (used by EqualsVerifier and Mockito) requires dynamic agent loading to be enabled (see also Mockito documentation: [Explicitly setting up instrumentation for inline mocking (Java 21+)](https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3)).
- Suppress "this-escape" warnings (should eventually be solved by either refactoring or `final`izing methods/classes; see also [JDK-8299995](https://bugs.openjdk.org/browse/JDK-8299995), introduced in JDK 21).
- Replace deprecated Weak Reference check with designated replacement (deprecated in JDK 16; see also [deprecation notice](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/ref/Reference.html#isEnqueued())).

**Depends on both #779 and #780.**