### PR TITLE
Upgrade Jena dependency to version 6.2.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ subprojects {
       'jackson':          '2.21.5',
       'jdk':              '21',
       'jdom':             '2.0.6.1',
-      'jena':             '4.10.0',
+      'jena':             '6.2.0',
       'jndi':             '0.11.4.1',
       'jsonpath':         '2.10.0',
       'jsoup':            '1.23.1',

--- a/metafix/src/main/java/org/metafacture/metafix/maps/RdfMap.java
+++ b/metafix/src/main/java/org/metafacture/metafix/maps/RdfMap.java
@@ -21,9 +21,9 @@ import org.metafacture.metafix.FixExecutionException;
 import org.metafacture.metamorph.api.Maps;
 import org.metafacture.metamorph.api.helpers.AbstractReadOnlyMap;
 
+import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Property;
-import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.ResIterator;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
@@ -240,31 +240,25 @@ public final class RdfMap extends AbstractReadOnlyMap<String, String> implements
 
     private String getSubjectUsingPropertyAndLiteral(final String resourceName, final Property targetProperty) {
         final ResIterator iter = model.listSubjectsWithProperty(targetProperty);
-        String result = map.get(Maps.DEFAULT_MAP_KEY);
 
         while (iter.hasNext()) {
             final Resource resource = iter.nextResource();
             final StmtIterator stmtIterator = resource.listProperties(targetProperty);
 
             while (stmtIterator.hasNext()) {
-                final RDFNode node = stmtIterator.next().getObject();
+                final Literal literal = stmtIterator.next().getObject().asLiteral();
 
-                if (!targetLanguage.isEmpty()) {
-                    if (node.asLiteral().toString().equals(resourceName + "@" + targetLanguage)) {
-                        result = resource.getURI();
-                        break;
+                if (literal.getString().equals(resourceName)) {
+                    if (!targetLanguage.isEmpty() && !literal.getLanguage().equals(targetLanguage)) {
+                        continue;
                     }
-                }
-                else {
-                    if (node.asLiteral().getString().equals(resourceName)) {
-                        result = resource.getURI();
-                        break;
-                    }
+
+                    return resource.getURI();
                 }
             }
         }
 
-        return result;
+        return map.get(Maps.DEFAULT_MAP_KEY);
     }
 
     /**

--- a/metafix/src/main/java/org/metafacture/metafix/maps/RdfMap.java
+++ b/metafix/src/main/java/org/metafacture/metafix/maps/RdfMap.java
@@ -278,7 +278,7 @@ public final class RdfMap extends AbstractReadOnlyMap<String, String> implements
      * @param targetLanguage the language of the target Property to be queried
      */
     public void setTargetLanguage(final String targetLanguage) {
-        this.targetLanguage = targetLanguage;
+        this.targetLanguage = targetLanguage.toLowerCase();
     }
 
     /**

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixLookupTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixLookupTest.java
@@ -1285,6 +1285,44 @@ public class MetafixLookupTest {
         );
     }
 
+    @Test
+    public void shouldLookupInExternalRdfMapGetSubjectWithTargetedPredicateIfMissingLanguage() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "put_rdfmap('" + RDF_MAP + "', 'rdfmap', target: 'skos:prefLabel')",
+                "lookup('id', 'rdfmap')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("id", "No Language");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("id", "https://w3id.org/kim/hochschulfaechersystematik/n4");
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void shouldNotLookupInExternalRdfMapGetSubjectWithTargetedPredicateOfSpecificLanguageIfMissingLanguage() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "put_rdfmap('" + RDF_MAP + "', 'rdfmap', target: 'skos:prefLabel', select_language: 'xx')",
+                "lookup('id', 'rdfmap')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("id", "No Language");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("id", "No Language");
+                o.get().endRecord();
+            }
+        );
+    }
+
     @Test // Scenario lookupRdfPropertyToProperty
     public void shouldLookupInExternalRdfMapGetPropertyOfSpecificLanguageWithTargetedPredicate() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixLookupTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixLookupTest.java
@@ -1264,11 +1264,10 @@ public class MetafixLookupTest {
         );
     }
 
-    @Test // Scenario 2
-    public void shouldLookupInExternalRdfMapGetSubjectWithTargetedPredicateOfSpecificLanguage() {
+    private void shouldLookupInExternalRdfMapGetSubjectWithTargetedPredicateOfSpecificLanguage(final String language) {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "set_array('id', 'Mathematics, Natural Sciences')",
-                "put_rdfmap('" + RDF_MAP + "', 'rdfmap', target: 'skos:prefLabel', select_language: 'en')",
+                "put_rdfmap('" + RDF_MAP + "', 'rdfmap', target: 'skos:prefLabel', select_language: '" + language + "')",
                 "lookup('id.*', 'rdfmap')"
             ),
             i -> {
@@ -1283,6 +1282,16 @@ public class MetafixLookupTest {
                 o.get().endRecord();
             }
         );
+    }
+
+    @Test // Scenario 2
+    public void shouldLookupInExternalRdfMapGetSubjectWithTargetedPredicateOfSpecificLanguage() {
+        shouldLookupInExternalRdfMapGetSubjectWithTargetedPredicateOfSpecificLanguage("en");
+    }
+
+    @Test
+    public void shouldLookupInExternalRdfMapGetSubjectWithTargetedPredicateOfSpecificLanguageCaseInsensitive() {
+        shouldLookupInExternalRdfMapGetSubjectWithTargetedPredicateOfSpecificLanguage("EN");
     }
 
     @Test

--- a/metafix/src/test/resources/org/metafacture/metafix/maps/test.ttl
+++ b/metafix/src/test/resources/org/metafacture/metafix/maps/test.ttl
@@ -5,7 +5,7 @@
 @prefix vann: <http://purl.org/vocab/vann/> .
 
 <n4> a skos:Concept ;
-    skos:prefLabel "Mathematik, Naturwissenschaften"@de, "Mathematics, Natural Sciences"@en ;
+    skos:prefLabel "Mathematik, Naturwissenschaften"@de, "Mathematics, Natural Sciences"@en, "No Language" ;
     skos:narrower   <n36>, <n37>, <n39>, <n40>, <n41>, <n42>, <n43>, <n44> ;
     skos:notation "4" ;
     skos:topConceptOf <scheme> .

--- a/metafix/src/test/resources/org/metafacture/metafix/maps/test.ttl
+++ b/metafix/src/test/resources/org/metafacture/metafix/maps/test.ttl
@@ -5,7 +5,7 @@
 @prefix vann: <http://purl.org/vocab/vann/> .
 
 <n4> a skos:Concept ;
-    skos:prefLabel "Mathematik, Naturwissenschaften"@de, "Mathematics, Natural Sciences"@en, "No Language" ;
+    skos:prefLabel "Mathematik, Naturwissenschaften"@de, "Mathematics, Natural Sciences"@EN, "No Language" ;
     skos:narrower   <n36>, <n37>, <n39>, <n40>, <n41>, <n42>, <n43>, <n44> ;
     skos:notation "4" ;
     skos:topConceptOf <scheme> .


### PR DESCRIPTION
While trying to upgrade Jena in the context of #426, I've hit a blocker in that our tests suddenly fail without any obvious (to me) indication why. This already happens with Jena 5.0 which says in its [release notes](https://github.com/apache/jena/blob/beaae2c56c847f4ee22ed973a26aaed520fa07a7/CHANGES.txt#L588):

> There has been a clearing out of deprecated functions, methods and classes. This includes the deprecations in Jena 4.10.0 added to show code that is being removed in Jena5.

However, I'm unable to find any deprecation notices with our current version 4.10.0. Also, there aren't any exceptions thrown or anything; the lookups just don't yield any results anymore.

So can you please try to find out what we have to do in order to upgrade Jena past version 4?