### PR TITLE
Let `HelpPrinter` output options under their original setter name.

### DIFF
--- a/metafacture-commons/src/main/java/org/metafacture/commons/reflection/ConfigurableClass.java
+++ b/metafacture-commons/src/main/java/org/metafacture/commons/reflection/ConfigurableClass.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 /**
  * Provides method for creating and initialising classes. The
@@ -90,7 +91,7 @@ public final class ConfigurableClass<T> {
 
     private void initSettersCache() {
         settersCache = new HashMap<>();
-        originalSettersCache = new HashMap<>();
+        originalSettersCache = new TreeMap<>();
         for (final Method method : plainClass.getMethods()) {
             if (isSetter(method)) {
                 final String setterName = method.getName().substring(SETTER_PREFIX.length());

--- a/metafacture-commons/src/main/java/org/metafacture/commons/reflection/ConfigurableClass.java
+++ b/metafacture-commons/src/main/java/org/metafacture/commons/reflection/ConfigurableClass.java
@@ -45,6 +45,7 @@ public final class ConfigurableClass<T> {
     private final Class<T> plainClass;
 
     private Map<String, Method> settersCache;
+    private Map<String, Method> originalSettersCache;
 
     /**
      *
@@ -77,13 +78,24 @@ public final class ConfigurableClass<T> {
         return settersCache;
     }
 
+    /**
+     * Gets all public "set" methods of this class under their original name.
+     *
+     * @return the Map of the setter methods of this class
+     */
+    public Map<String, Method> getOriginalSetters() {
+        getSetters();
+        return originalSettersCache;
+    }
+
     private void initSettersCache() {
         settersCache = new HashMap<>();
+        originalSettersCache = new HashMap<>();
         for (final Method method : plainClass.getMethods()) {
             if (isSetter(method)) {
-                final String setterName = method.getName().substring(
-                        SETTER_PREFIX.length()).toLowerCase();
-                settersCache.put(setterName, method);
+                final String setterName = method.getName().substring(SETTER_PREFIX.length());
+                settersCache.put(setterName.toLowerCase(), method);
+                originalSettersCache.put(setterName.substring(0, 1).toLowerCase() + setterName.substring(1), method);
             }
         }
     }

--- a/metafacture-flux/src/main/java/org/metafacture/flux/HelpPrinter.java
+++ b/metafacture-flux/src/main/java/org/metafacture/flux/HelpPrinter.java
@@ -122,7 +122,7 @@ public final class HelpPrinter {
             out.println("- arguments:\t" + arguments);
         }
 
-        printAttributes(out, configurableClass, configurableClass.getSetters());
+        printAttributes(out, configurableClass, configurableClass.getOriginalSetters());
         printSignature(out, moduleClass);
 
         final String[] examplesEntry = EXAMPLES_MAP.get(name);


### PR DESCRIPTION
Resolves #716.

Keeps the original case from the setter method.

Also outputs options in lexicographically sorted order.